### PR TITLE
Add GRAVEL and MLEM iterative unfolding solvers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.env
+.venv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # FluxForge
+
+UWNR Flux-Wire–Driven Neutron Spectrum Reconstruction Tool. This repository
+provides a pure-Python package and CLI that converts HPGe-derived wire activities
+into reaction rates, constructs response matrices from dosimetry cross sections,
+and infers neutron flux spectra with generalized least squares and Monte Carlo
+uncertainty propagation.
+
+## Features
+- Activation and decay helpers for converting net peak areas to activities and
+  reaction rates.
+- Response matrix construction for groupwise cross sections and number densities.
+- GLS spectrum adjustment with optional non-negativity enforcement.
+- Iterative GRAVEL and MLEM unfolding options for prior-free spectrum recovery.
+- Monte Carlo uncertainty propagation to estimate percentile bands on inferred
+  spectra.
+- Argparse-based CLI with ``build-response``, ``infer-spectrum``, ``validate``,
+  and ``report`` commands.
+
+## Getting started
+The project avoids external dependencies to simplify offline execution. Install
+it in editable mode (setuptools is bundled with Python) and invoke the CLI:
+
+```bash
+pip install -e .
+python -m fluxforge.cli.app --help
+```
+
+Synthetic validation and inference routines expect JSON inputs; see
+``src/fluxforge/cli/app.py`` for the expected schemas and adjust to your UWNR
+data formats.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "fluxforge"
+version = "0.1.0"
+description = "UWNR Flux-Wire–Driven Neutron Spectrum Reconstruction Tool"
+authors = [{name = "UWNR Team"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+fluxforge = "fluxforge.cli.app:main"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,13 @@
+[metadata]
+name = fluxforge
+version = 0.1.0
+
+[options]
+package_dir =
+    = src
+packages = find:
+install_requires =
+python_requires = >=3.11
+
+[options.packages.find]
+where = src

--- a/src/fluxforge/__init__.py
+++ b/src/fluxforge/__init__.py
@@ -1,0 +1,10 @@
+"""FluxForge package entry."""
+
+from importlib.metadata import version
+
+__all__ = ["__version__"]
+
+try:
+    __version__ = version("fluxforge")
+except Exception:  # fallback for editable installs before metadata exists
+    __version__ = "0.1.0"

--- a/src/fluxforge/cli/__init__.py
+++ b/src/fluxforge/cli/__init__.py
@@ -1,0 +1,1 @@
+"""FluxForge module."""

--- a/src/fluxforge/cli/app.py
+++ b/src/fluxforge/cli/app.py
@@ -1,0 +1,135 @@
+"""Command-line interface for FluxForge using argparse."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List, Optional
+
+from fluxforge.core.response import EnergyGroupStructure, ReactionCrossSection, build_response_matrix
+from fluxforge.physics.activation import GammaLineMeasurement, IrradiationSegment, reaction_rate_from_activity, weighted_activity
+from fluxforge.solvers.gls import gls_adjust
+
+
+def _load_json(path: Path):
+    return json.loads(path.read_text())
+
+
+def cmd_build_response(args: argparse.Namespace) -> None:
+    boundaries = [float(x) for x in _load_json(args.boundaries_file)]
+    groups = EnergyGroupStructure(boundaries)
+    cross_sections_raw = _load_json(args.cross_section_file)
+    number_densities = _load_json(args.number_densities_file)
+
+    reactions = []
+    number_density_values: List[float] = []
+    for reaction_id, sigma in cross_sections_raw.items():
+        reactions.append(ReactionCrossSection(reaction_id=reaction_id, sigma_g=[float(s) for s in sigma]))
+        number_density_values.append(float(number_densities[reaction_id]))
+
+    response = build_response_matrix(reactions, groups, number_density_values)
+    output_data = {
+        "matrix": response.matrix,
+        "reactions": response.reactions,
+        "boundaries": response.energy_groups.boundaries_eV,
+    }
+    Path(args.output).write_text(json.dumps(output_data, indent=2))
+    print(f"Wrote response matrix to {args.output}")
+
+
+def cmd_infer_spectrum(args: argparse.Namespace) -> None:
+    response_data = _load_json(args.response_file)
+    response_matrix = response_data["matrix"]
+    boundaries = response_data["boundaries"]
+    reactions = response_data["reactions"]
+    groups = EnergyGroupStructure([float(b) for b in boundaries])
+
+    measurements_data = _load_json(args.measurements_file)
+    half_life_map = {rx["reaction_id"]: float(rx["half_life_s"]) for rx in measurements_data["reactions"]}
+    segments = [IrradiationSegment(**seg) for seg in measurements_data["segments"]]
+
+    measured_rates: List[float] = []
+    rate_uncertainties: List[float] = []
+    for reaction in measurements_data["reactions"]:
+        gamma_lines = [GammaLineMeasurement(**line) for line in reaction["gamma_lines"]]
+        activity, _ = weighted_activity(gamma_lines)
+        rate_estimate = reaction_rate_from_activity(activity, segments, half_life_map[reaction["reaction_id"]])
+        measured_rates.append(rate_estimate.rate)
+        rate_uncertainties.append(rate_estimate.uncertainty)
+
+    if args.prior_flux_file:
+        prior_flux = [float(v) for v in _load_json(args.prior_flux_file)]
+    else:
+        avg_response = sum(sum(row) for row in response_matrix) / max(len(response_matrix) * len(response_matrix[0]), 1)
+        prior_flux = [sum(measured_rates) / max(avg_response, 1e-12) for _ in range(groups.group_count)]
+    prior_cov = [[(args.prior_uncertainty * val) ** 2 if i == j else 0.0 for j in range(groups.group_count)] for i, val in enumerate(prior_flux)]
+    measurement_cov = [[(rate_uncertainties[i] ** 2) if i == j else 0.0 for j in range(len(measured_rates))] for i in range(len(measured_rates))]
+
+    solution = gls_adjust(response_matrix, measured_rates, measurement_cov, prior_flux, prior_cov)
+    result = {
+        "boundaries_eV": boundaries,
+        "reactions": reactions,
+        "flux": solution.flux,
+        "covariance": solution.covariance,
+        "chi2": solution.chi2,
+    }
+    Path(args.output).write_text(json.dumps(result, indent=2))
+    print(f"Saved inferred spectrum to {args.output}")
+
+
+def cmd_validate(args: argparse.Namespace) -> None:
+    response_data = _load_json(args.response_file)
+    r = response_data["matrix"]
+    phi_true = [float(v) for v in _load_json(args.truth_flux_file)]
+    y = [sum(row[i] * phi_true[i] for i in range(len(phi_true))) for row in r]
+    noise = [max(abs(val) * args.noise_fraction, 1e-12) for val in y]
+    cy = [[(noise[i] ** 2) if i == j else 0.0 for j in range(len(y))] for i in range(len(y))]
+    prior = [v * 0.8 for v in phi_true]
+    c0 = [[(args.noise_fraction * prior[i]) ** 2 if i == j else 0.0 for j in range(len(prior))] for i in range(len(prior))]
+    solution = gls_adjust(r, y, cy, prior, c0)
+    mae = sum(abs(a - b) / max(b, 1e-12) for a, b in zip(solution.flux, phi_true)) / len(phi_true)
+    print(f"Validation chi2: {solution.chi2:.2f}")
+    print(f"Mean absolute percent error: {mae * 100:.2f}%")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="UWNR Flux-Wire–Driven Neutron Spectrum Reconstruction Tool")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build-response", help="Build response matrix from cross sections")
+    build.add_argument("--cross-section-file", type=Path, required=True)
+    build.add_argument("--number-densities-file", type=Path, required=True)
+    build.add_argument("--boundaries-file", type=Path, required=True)
+    build.add_argument("--output", type=Path, default=Path("response.json"))
+    build.set_defaults(func=cmd_build_response)
+
+    infer = subparsers.add_parser("infer-spectrum", help="Infer spectrum using GLS")
+    infer.add_argument("--measurements-file", type=Path, required=True)
+    infer.add_argument("--response-file", type=Path, required=True)
+    infer.add_argument("--prior-flux-file", type=Path)
+    infer.add_argument("--prior-uncertainty", type=float, default=0.25)
+    infer.add_argument("--output", type=Path, default=Path("spectrum.json"))
+    infer.set_defaults(func=cmd_infer_spectrum)
+
+    validate = subparsers.add_parser("validate", help="Run synthetic validation")
+    validate.add_argument("--response-file", type=Path, required=True)
+    validate.add_argument("--truth-flux-file", type=Path, required=True)
+    validate.add_argument("--noise-fraction", type=float, default=0.05)
+    validate.set_defaults(func=cmd_validate)
+
+    subparsers.add_parser("report", help="Report generation placeholder")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        print("Report generation not yet implemented. Track inputs and outputs manually for now.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fluxforge/core/__init__.py
+++ b/src/fluxforge/core/__init__.py
@@ -1,0 +1,1 @@
+"""FluxForge module."""

--- a/src/fluxforge/core/linalg.py
+++ b/src/fluxforge/core/linalg.py
@@ -1,0 +1,172 @@
+"""Lightweight linear algebra helpers that avoid external dependencies."""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Iterable, List, Sequence, Tuple
+
+Vector = List[float]
+Matrix = List[List[float]]
+
+
+def to_vector(values: Iterable[float]) -> Vector:
+    return [float(v) for v in values]
+
+
+def zeros_matrix(rows: int, cols: int) -> Matrix:
+    return [[0.0 for _ in range(cols)] for _ in range(rows)]
+
+
+def identity(size: int) -> Matrix:
+    m = zeros_matrix(size, size)
+    for i in range(size):
+        m[i][i] = 1.0
+    return m
+
+
+def transpose(mat: Matrix) -> Matrix:
+    return [list(row) for row in zip(*mat)]
+
+
+def matmul(a: Matrix, b: Matrix | Vector) -> Matrix | Vector:
+    if isinstance(b[0], list):  # type: ignore[index]
+        b_mat: Matrix = b  # type: ignore[assignment]
+        result = zeros_matrix(len(a), len(b_mat[0]))
+        for i in range(len(a)):
+            for k in range(len(b_mat)):
+                for j in range(len(b_mat[0])):
+                    result[i][j] += a[i][k] * b_mat[k][j]
+        return result
+    else:
+        b_vec: Vector = b  # type: ignore[assignment]
+        result_vec: Vector = [0.0 for _ in range(len(a))]
+        for i in range(len(a)):
+            for k in range(len(b_vec)):
+                result_vec[i] += a[i][k] * b_vec[k]
+        return result_vec
+
+
+def add_vectors(a: Vector, b: Vector) -> Vector:
+    return [x + y for x, y in zip(a, b)]
+
+
+def sub_vectors(a: Vector, b: Vector) -> Vector:
+    return [x - y for x, y in zip(a, b)]
+
+
+def scalar_multiply(vec: Vector, scalar: float) -> Vector:
+    return [scalar * x for x in vec]
+
+
+def diag(values: Vector) -> Matrix:
+    m = zeros_matrix(len(values), len(values))
+    for i, v in enumerate(values):
+        m[i][i] = v
+    return m
+
+
+def cholesky(mat: Matrix) -> Matrix:
+    n = len(mat)
+    L = zeros_matrix(n, n)
+    for i in range(n):
+        for j in range(i + 1):
+            sum_val = sum(L[i][k] * L[j][k] for k in range(j))
+            if i == j:
+                diff = mat[i][i] - sum_val
+                if diff <= 0:
+                    raise ValueError("Matrix is not positive definite")
+                L[i][j] = math.sqrt(diff)
+            else:
+                L[i][j] = (mat[i][j] - sum_val) / L[j][j]
+    return L
+
+
+def invert_square_matrix(mat: Matrix) -> Matrix:
+    n = len(mat)
+    aug = [row[:] + identity_row for row, identity_row in zip(mat, identity(n))]
+    # Forward elimination
+    for col in range(n):
+        pivot_row = max(range(col, n), key=lambda r: abs(aug[r][col]))
+        if abs(aug[pivot_row][col]) < 1e-12:
+            raise ValueError("Matrix is singular")
+        aug[col], aug[pivot_row] = aug[pivot_row], aug[col]
+        pivot = aug[col][col]
+        for j in range(2 * n):
+            aug[col][j] /= pivot
+        for r in range(n):
+            if r == col:
+                continue
+            factor = aug[r][col]
+            for j in range(2 * n):
+                aug[r][j] -= factor * aug[col][j]
+    return [row[n:] for row in aug]
+
+
+def gram_matrix(mat: Matrix) -> Matrix:
+    return matmul(transpose(mat), mat)  # type: ignore[arg-type]
+
+
+def pseudo_inverse(mat: Matrix) -> Matrix:
+    # Moore-Penrose via normal equations
+    gram = gram_matrix(mat)
+    gram_inv = invert_square_matrix(gram)
+    return matmul(gram_inv, transpose(mat))  # type: ignore[arg-type]
+
+
+def vector_mean(vec: Vector) -> float:
+    return sum(vec) / len(vec)
+
+
+def vector_average(values: Vector, weights: Vector) -> float:
+    weighted_sum = sum(v * w for v, w in zip(values, weights))
+    weight_total = sum(weights)
+    if weight_total == 0:
+        raise ValueError("Weights must not sum to zero")
+    return weighted_sum / weight_total
+
+
+def vector_sum(vec: Vector) -> float:
+    return sum(vec)
+
+
+def elementwise_square(vec: Vector) -> Vector:
+    return [v * v for v in vec]
+
+
+def elementwise_clip(vec: Vector, lower: float = 0.0) -> Vector:
+    return [max(lower, v) for v in vec]
+
+
+def elementwise_maximum(vec: Vector, floor: float) -> Vector:
+    return [v if v > floor else floor for v in vec]
+
+
+def percentile(values: List[Vector], q: float) -> Vector:
+    if not values:
+        return []
+    n_rows = len(values)
+    n_cols = len(values[0])
+    result: Vector = []
+    for col in range(n_cols):
+        col_values = sorted(row[col] for row in values)
+        rank = (q / 100) * (n_rows - 1)
+        lower = int(math.floor(rank))
+        upper = int(math.ceil(rank))
+        if lower == upper:
+            result.append(col_values[lower])
+        else:
+            interp = col_values[lower] + (col_values[upper] - col_values[lower]) * (rank - lower)
+            result.append(interp)
+    return result
+
+
+def multivariate_normal_samples(mean: Vector, cov: Matrix, n: int) -> List[Vector]:
+    L = cholesky(cov)
+    dim = len(mean)
+    samples: List[Vector] = []
+    for _ in range(n):
+        z = [random.gauss(0.0, 1.0) for _ in range(dim)]
+        noise = [sum(L[i][k] * z[k] for k in range(dim)) for i in range(dim)]
+        samples.append([m + n_val for m, n_val in zip(mean, noise)])
+    return samples

--- a/src/fluxforge/core/response.py
+++ b/src/fluxforge/core/response.py
@@ -1,0 +1,60 @@
+"""Response matrix construction utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from fluxforge.core.linalg import Matrix, Vector, matmul
+
+
+@dataclass
+class EnergyGroupStructure:
+    """Defines the energy bin boundaries for groupwise calculations."""
+
+    boundaries_eV: List[float]
+
+    def __post_init__(self) -> None:
+        if any(b2 <= b1 for b1, b2 in zip(self.boundaries_eV, self.boundaries_eV[1:])):
+            raise ValueError("Energy boundaries must be strictly increasing.")
+
+    @property
+    def group_count(self) -> int:
+        return len(self.boundaries_eV) - 1
+
+
+@dataclass
+class ReactionCrossSection:
+    """Stores groupwise cross sections for a reaction."""
+
+    reaction_id: str
+    sigma_g: Vector
+
+
+@dataclass
+class ResponseMatrix:
+    """Container for the response matrix and metadata."""
+
+    matrix: Matrix
+    reactions: List[str]
+    energy_groups: EnergyGroupStructure
+
+
+def build_response_matrix(
+    reactions: Iterable[ReactionCrossSection],
+    groups: EnergyGroupStructure,
+    target_number_densities: Iterable[float],
+) -> ResponseMatrix:
+    reaction_list = list(reactions)
+    number_densities = list(target_number_densities)
+    if len(reaction_list) != len(number_densities):
+        raise ValueError("Cross section list and number densities must align.")
+
+    rows: Matrix = []
+    reaction_ids: List[str] = []
+    for rx, n_density in zip(reaction_list, number_densities):
+        if len(rx.sigma_g) != groups.group_count:
+            raise ValueError("Cross section group structure mismatch.")
+        rows.append([n_density * sigma for sigma in rx.sigma_g])
+        reaction_ids.append(rx.reaction_id)
+    return ResponseMatrix(matrix=rows, reactions=reaction_ids, energy_groups=groups)

--- a/src/fluxforge/data/__init__.py
+++ b/src/fluxforge/data/__init__.py
@@ -1,0 +1,1 @@
+"""FluxForge module."""

--- a/src/fluxforge/examples/README.md
+++ b/src/fluxforge/examples/README.md
@@ -1,0 +1,5 @@
+# UWNR example scaffold
+
+This folder is reserved for an end-to-end UWNR irradiation example. Populate it
+with your activation measurements, OpenMC/MCNP prior spectrum, and cross-section
+pack once those datasets are ready.

--- a/src/fluxforge/examples/__init__.py
+++ b/src/fluxforge/examples/__init__.py
@@ -1,0 +1,1 @@
+"""FluxForge module."""

--- a/src/fluxforge/io/__init__.py
+++ b/src/fluxforge/io/__init__.py
@@ -1,0 +1,1 @@
+"""FluxForge module."""

--- a/src/fluxforge/physics/__init__.py
+++ b/src/fluxforge/physics/__init__.py
@@ -1,0 +1,1 @@
+"""FluxForge module."""

--- a/src/fluxforge/physics/activation.py
+++ b/src/fluxforge/physics/activation.py
@@ -1,0 +1,94 @@
+"""Activation and decay relationships for flux-wire analysis."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from fluxforge.core.linalg import vector_average
+
+
+@dataclass
+class GammaLineMeasurement:
+    """Represents a single gamma-line observation used to infer activity."""
+
+    net_counts: float
+    live_time_s: float
+    efficiency: float
+    gamma_intensity: float
+    half_life_s: float
+    cooling_time_s: float = 0.0
+    dead_time_fraction: float = 0.0
+
+    def activity_at_reference(self) -> float:
+        """Return the activity at the chosen reference (usually EOI)."""
+
+        decay_const = math.log(2.0) / self.half_life_s
+        corrected_counts = self.net_counts / max(1.0 - self.dead_time_fraction, 1e-12)
+        buildup = (1.0 - math.exp(-decay_const * self.live_time_s)) / max(decay_const, 1e-12)
+        if buildup <= 0:
+            raise ValueError("Live time must be positive to compute activity.")
+        activity_at_count_start = corrected_counts / (self.efficiency * self.gamma_intensity * buildup)
+        activity_ref = activity_at_count_start * math.exp(decay_const * self.cooling_time_s)
+        return activity_ref
+
+
+@dataclass
+class IrradiationSegment:
+    """Segment of an irradiation timeline."""
+
+    duration_s: float
+    relative_power: float = 1.0
+
+
+@dataclass
+class ReactionRateEstimate:
+    """Container holding a reaction rate estimate and propagated uncertainty."""
+
+    rate: float
+    uncertainty: float
+
+
+def weighted_activity(gamma_lines: Iterable[GammaLineMeasurement]) -> tuple[float, float]:
+    """Compute a weighted mean activity and uncertainty from multiple lines."""
+
+    activities = []
+    variances = []
+    for line in gamma_lines:
+        activity = line.activity_at_reference()
+        variance = activity * activity / max(line.net_counts, 1.0)
+        activities.append(activity)
+        variances.append(variance)
+
+    if not activities:
+        raise ValueError("At least one gamma-line measurement is required.")
+
+    weights = [1.0 / v for v in variances]
+    weighted_mean = vector_average(activities, weights)
+    combined_variance = 1.0 / sum(weights)
+    return weighted_mean, math.sqrt(combined_variance)
+
+
+def irradiation_buildup_factor(segments: Sequence[IrradiationSegment], half_life_s: float) -> float:
+    decay_const = math.log(2.0) / half_life_s
+    total_duration = sum(seg.duration_s for seg in segments)
+    elapsed = 0.0
+    factor = 0.0
+    for segment in segments:
+        elapsed += segment.duration_s
+        segment_term = segment.relative_power * (1.0 - math.exp(-decay_const * segment.duration_s))
+        decay_after = math.exp(-decay_const * (total_duration - elapsed))
+        factor += segment_term * decay_after
+    return factor
+
+
+def reaction_rate_from_activity(activity_eoi: float, segments: Sequence[IrradiationSegment], half_life_s: float) -> ReactionRateEstimate:
+    if activity_eoi < 0:
+        raise ValueError("Activity must be non-negative.")
+    factor = irradiation_buildup_factor(segments, half_life_s)
+    if factor <= 0:
+        raise ValueError("Irradiation factor must be positive.")
+    rate = activity_eoi / factor
+    uncertainty = rate / math.sqrt(max(activity_eoi, 1e-12))
+    return ReactionRateEstimate(rate=rate, uncertainty=uncertainty)

--- a/src/fluxforge/plots/__init__.py
+++ b/src/fluxforge/plots/__init__.py
@@ -1,0 +1,1 @@
+"""FluxForge module."""

--- a/src/fluxforge/solvers/__init__.py
+++ b/src/fluxforge/solvers/__init__.py
@@ -1,0 +1,11 @@
+"""Solver package."""
+
+from fluxforge.solvers.gls import gls_adjust
+from fluxforge.solvers.iterative import IterativeSolution, gravel, mlem
+
+__all__ = [
+    "gls_adjust",
+    "IterativeSolution",
+    "gravel",
+    "mlem",
+]

--- a/src/fluxforge/solvers/gls.py
+++ b/src/fluxforge/solvers/gls.py
@@ -1,0 +1,66 @@
+"""Generalized least-squares spectrum adjustment without external dependencies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fluxforge.core.linalg import (
+    Matrix,
+    Vector,
+    add_vectors,
+    elementwise_clip,
+    matmul,
+    pseudo_inverse,
+    sub_vectors,
+    transpose,
+)
+
+
+@dataclass
+class GLSSolution:
+    flux: Vector
+    covariance: Matrix
+    residuals: Vector
+    chi2: float
+
+
+def _quadratic_form(vec: Vector, mat: Matrix) -> float:
+    total = 0.0
+    for i, v_i in enumerate(vec):
+        total += v_i * sum(mat[i][j] * vec[j] for j in range(len(vec)))
+    return total
+
+
+def gls_adjust(
+    response: Matrix,
+    measurements: Vector,
+    measurement_cov: Matrix,
+    prior_flux: Vector,
+    prior_cov: Matrix,
+    enforce_nonnegativity: bool = True,
+) -> GLSSolution:
+    if len(response[0]) != len(prior_flux):
+        raise ValueError("Response matrix and prior flux shape mismatch.")
+
+    rc0 = matmul(response, prior_cov)  # type: ignore[arg-type]
+    innovation_cov = matmul(rc0, transpose(response))  # type: ignore[arg-type]
+    for i in range(len(innovation_cov)):
+        for j in range(len(innovation_cov)):
+            innovation_cov[i][j] += measurement_cov[i][j]
+    innovation_cov_inv = pseudo_inverse(innovation_cov)
+
+    gain = matmul(prior_cov, matmul(transpose(response), innovation_cov_inv))  # type: ignore[arg-type]
+    model_prediction = matmul(response, prior_flux)  # type: ignore[arg-type]
+    residuals = sub_vectors(measurements, model_prediction)  # type: ignore[arg-type]
+    update = matmul(gain, residuals)  # type: ignore[arg-type]
+    phi_hat = add_vectors(prior_flux, update)
+    if enforce_nonnegativity:
+        phi_hat = elementwise_clip(phi_hat, 0.0)
+
+    posterior_cov = matmul(prior_cov, matmul(transpose(response), matmul(innovation_cov_inv, rc0)))  # type: ignore[arg-type]
+    for i in range(len(prior_cov)):
+        for j in range(len(prior_cov)):
+            posterior_cov[i][j] = prior_cov[i][j] - posterior_cov[i][j]
+
+    chi2 = _quadratic_form(residuals, innovation_cov_inv)
+    return GLSSolution(flux=phi_hat, covariance=posterior_cov, residuals=residuals, chi2=chi2)

--- a/src/fluxforge/solvers/iterative.py
+++ b/src/fluxforge/solvers/iterative.py
@@ -1,0 +1,135 @@
+"""Iterative unfolding algorithms (GRAVEL and MLEM)."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import List, Optional
+
+from fluxforge.core.linalg import Matrix, Vector, elementwise_maximum, matmul
+
+
+@dataclass
+class IterativeSolution:
+    """Container for iterative solver results."""
+
+    flux: Vector
+    history: List[Vector]
+    iterations: int
+    converged: bool
+
+
+def _default_flux(n_groups: int, scale: float = 1.0) -> Vector:
+    return [scale for _ in range(n_groups)]
+
+
+def gravel(
+    response: Matrix,
+    measurements: Vector,
+    initial_flux: Optional[Vector] = None,
+    measurement_uncertainty: Optional[Vector] = None,
+    max_iters: int = 500,
+    tolerance: float = 1e-6,
+    floor: float = 1e-20,
+) -> IterativeSolution:
+    """GRAVEL algorithm (log-space SAND-II variant) for spectrum unfolding.
+
+    Args:
+        response: Response matrix R_{i,g}.
+        measurements: Measured reaction rates y_i.
+        initial_flux: Starting flux guess. Defaults to uniform.
+        measurement_uncertainty: Optional 1-sigma uncertainties on y_i for weighting.
+        max_iters: Maximum iterations to perform.
+        tolerance: Relative max change threshold for convergence.
+        floor: Minimum flux/prediction value to avoid divide-by-zero.
+    """
+
+    n_groups = len(response[0])
+    phi = initial_flux[:] if initial_flux is not None else _default_flux(n_groups)
+    phi = elementwise_maximum(phi, floor)
+    weights = (
+        [1.0 / (u * u) if u > 0 else 0.0 for u in measurement_uncertainty]
+        if measurement_uncertainty
+        else [1.0 for _ in measurements]
+    )
+
+    history: List[Vector] = [phi[:]]
+    converged = False
+
+    for it in range(1, max_iters + 1):
+        predicted = matmul(response, phi)  # type: ignore[arg-type]
+        predicted = [max(p, floor) for p in predicted]
+        ratios = [m / p for m, p in zip(measurements, predicted)]
+        log_ratios = [math.log(r) for r in ratios]
+
+        updated: Vector = []
+        max_rel_change = 0.0
+        for g in range(n_groups):
+            num = sum(weights[i] * response[i][g] * log_ratios[i] for i in range(len(measurements)))
+            den = sum(weights[i] * response[i][g] for i in range(len(measurements)))
+            if den <= 0:
+                updated.append(phi[g])
+                continue
+            factor = math.exp(num / den)
+            new_phi = max(phi[g] * factor, floor)
+            max_rel_change = max(max_rel_change, abs(new_phi - phi[g]) / max(phi[g], floor))
+            updated.append(new_phi)
+
+        phi = updated
+        history.append(phi[:])
+        if max_rel_change < tolerance:
+            converged = True
+            return IterativeSolution(flux=phi, history=history, iterations=it, converged=converged)
+
+    return IterativeSolution(flux=phi, history=history, iterations=max_iters, converged=converged)
+
+
+def mlem(
+    response: Matrix,
+    measurements: Vector,
+    initial_flux: Optional[Vector] = None,
+    max_iters: int = 500,
+    tolerance: float = 1e-6,
+    floor: float = 1e-20,
+) -> IterativeSolution:
+    """Maximum-likelihood expectation maximization (MLEM) unfolding.
+
+    Args:
+        response: Response matrix R_{i,g}.
+        measurements: Measured reaction rates y_i.
+        initial_flux: Starting flux guess. Defaults to uniform.
+        max_iters: Maximum iterations to perform.
+        tolerance: Relative max change threshold for convergence.
+        floor: Minimum flux/prediction value to avoid divide-by-zero.
+    """
+
+    n_groups = len(response[0])
+    phi = initial_flux[:] if initial_flux is not None else _default_flux(n_groups)
+    phi = elementwise_maximum(phi, floor)
+
+    history: List[Vector] = [phi[:]]
+    converged = False
+
+    for it in range(1, max_iters + 1):
+        predicted = matmul(response, phi)  # type: ignore[arg-type]
+        predicted = [max(p, floor) for p in predicted]
+
+        updated: Vector = []
+        max_rel_change = 0.0
+        for g in range(n_groups):
+            numerator = sum(response[i][g] * measurements[i] / predicted[i] for i in range(len(measurements)))
+            denominator = sum(response[i][g] for i in range(len(measurements)))
+            if denominator <= 0:
+                updated.append(phi[g])
+                continue
+            new_phi = max(phi[g] * numerator / denominator, floor)
+            max_rel_change = max(max_rel_change, abs(new_phi - phi[g]) / max(phi[g], floor))
+            updated.append(new_phi)
+
+        phi = updated
+        history.append(phi[:])
+        if max_rel_change < tolerance:
+            converged = True
+            return IterativeSolution(flux=phi, history=history, iterations=it, converged=converged)
+
+    return IterativeSolution(flux=phi, history=history, iterations=max_iters, converged=converged)

--- a/src/fluxforge/uncertainty/__init__.py
+++ b/src/fluxforge/uncertainty/__init__.py
@@ -1,0 +1,1 @@
+"""FluxForge module."""

--- a/src/fluxforge/uncertainty/mc.py
+++ b/src/fluxforge/uncertainty/mc.py
@@ -1,0 +1,33 @@
+"""Monte Carlo uncertainty propagation for flux solutions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, List
+
+from fluxforge.core.linalg import Matrix, Vector, multivariate_normal_samples, percentile
+
+
+@dataclass
+class MonteCarloBand:
+    median: Vector
+    lower: Vector
+    upper: Vector
+
+
+def propagate_measurement_uncertainty(
+    solver: Callable[[Vector], Vector],
+    mean_measurement: Vector,
+    measurement_cov: Matrix,
+    n_samples: int = 100,
+    confidence: float = 0.68,
+) -> MonteCarloBand:
+    samples = multivariate_normal_samples(mean_measurement, measurement_cov, n_samples)
+    spectra = [solver(sample) for sample in samples]
+    lower_q = 50 * (1 - confidence)
+    upper_q = 50 * (1 + confidence)
+    return MonteCarloBand(
+        median=percentile(spectra, 50),
+        lower=percentile(spectra, lower_q),
+        upper=percentile(spectra, upper_q),
+    )

--- a/tests/test_activation.py
+++ b/tests/test_activation.py
@@ -1,0 +1,43 @@
+import math
+
+from fluxforge.physics.activation import (
+    GammaLineMeasurement,
+    IrradiationSegment,
+    irradiation_buildup_factor,
+    reaction_rate_from_activity,
+    weighted_activity,
+)
+
+
+def test_activity_from_counts_no_decay():
+    line = GammaLineMeasurement(
+        net_counts=1000,
+        live_time_s=10.0,
+        efficiency=0.1,
+        gamma_intensity=0.5,
+        half_life_s=1e9,
+        cooling_time_s=0.0,
+    )
+    activity = line.activity_at_reference()
+    expected = 1000 / (0.1 * 0.5 * 10)
+    assert math.isclose(activity, expected, rel_tol=1e-6)
+
+
+def test_weighted_activity_combines_lines():
+    lines = [
+        GammaLineMeasurement(1000, 10.0, 0.1, 0.5, 1e9),
+        GammaLineMeasurement(2000, 10.0, 0.1, 0.5, 1e9),
+    ]
+    activity, sigma = weighted_activity(lines)
+    assert activity > 0
+    assert sigma > 0
+
+
+def test_reaction_rate_single_segment():
+    activity = 5.0
+    half_life = 60.0
+    segments = [IrradiationSegment(duration_s=30.0, relative_power=1.0)]
+    factor = irradiation_buildup_factor(segments, half_life)
+    rate_estimate = reaction_rate_from_activity(activity, segments, half_life)
+    assert math.isclose(rate_estimate.rate * factor, activity, rel_tol=1e-6)
+

--- a/tests/test_gls.py
+++ b/tests/test_gls.py
@@ -1,0 +1,26 @@
+from fluxforge.solvers.gls import gls_adjust
+
+
+def test_gls_identity_case():
+    response = [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ]
+    measurements = [1.0, 2.0, 3.0]
+    cy = [
+        [0.01, 0.0, 0.0],
+        [0.0, 0.01, 0.0],
+        [0.0, 0.0, 0.01],
+    ]
+    prior = [0.0, 0.0, 0.0]
+    c0 = [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0],
+    ]
+    solution = gls_adjust(response, measurements, cy, prior, c0)
+    expected_scale = 1 / 1.01
+    for estimate, truth in zip(solution.flux, measurements):
+        assert abs(estimate - truth * expected_scale) < 1e-3
+    assert solution.chi2 > 0

--- a/tests/test_iterative.py
+++ b/tests/test_iterative.py
@@ -1,0 +1,36 @@
+from fluxforge.solvers.iterative import gravel, mlem
+
+
+def test_mlem_identity_converges_to_measurements():
+    response = [
+        [1.0, 0.0],
+        [0.0, 1.0],
+    ]
+    measurements = [1.5, 3.0]
+    solution = mlem(response, measurements, initial_flux=[0.5, 0.5], max_iters=25, tolerance=1e-9)
+    assert solution.converged
+    for est, truth in zip(solution.flux, measurements):
+        assert abs(est - truth) < 1e-6
+
+
+def test_gravel_recovers_scale_with_weights():
+    response = [
+        [1.0, 0.5],
+        [0.2, 1.0],
+    ]
+    true_flux = [2.0, 1.0]
+    measurements = [response[0][0] * true_flux[0] + response[0][1] * true_flux[1],
+                    response[1][0] * true_flux[0] + response[1][1] * true_flux[1]]
+    measurement_uncertainty = [0.05 * m for m in measurements]
+
+    solution = gravel(
+        response,
+        measurements,
+        initial_flux=[1.0, 1.0],
+        measurement_uncertainty=measurement_uncertainty,
+        max_iters=200,
+        tolerance=1e-8,
+    )
+    assert solution.converged
+    for est, truth in zip(solution.flux, true_flux):
+        assert abs(est - truth) / truth < 1e-3


### PR DESCRIPTION
## Summary
- add GRAVEL and MLEM iterative unfolding routines with convergence tracking
- expose new solvers from the package interface and document the available algorithms
- add regression tests covering identity and weighted recovery scenarios

## Testing
- PYTHONPATH=src python -m pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69436874d8388321857d3908db6dae18)