### PR TITLE
Add artifact schemas, provenance helpers, artifact I/O, and CLI pipeline

### DIFF
--- a/src/fluxforge/cli/app.py
+++ b/src/fluxforge/cli/app.py
@@ -7,8 +7,30 @@ import json
 from pathlib import Path
 from typing import List, Optional
 
+import numpy as np
+
+from fluxforge.analysis.segmented_detection import SegmentedDetectionConfig, detect_peaks_segmented
 from fluxforge.core.response import EnergyGroupStructure, ReactionCrossSection, build_response_matrix
-from fluxforge.physics.activation import GammaLineMeasurement, IrradiationSegment, reaction_rate_from_activity, weighted_activity
+from fluxforge.io.artifacts import (
+    read_line_activities,
+    read_peak_report,
+    read_reaction_rates,
+    read_response_bundle,
+    read_spectrum_file,
+    read_unfold_result,
+    read_validation_bundle,
+    write_line_activities,
+    write_peak_report,
+    write_reaction_rates,
+    write_report_bundle,
+    write_response_bundle,
+    write_spectrum_file,
+    write_unfold_result,
+    write_validation_bundle,
+)
+from fluxforge.io.genie import read_genie_spectrum
+from fluxforge.io.spe import GammaSpectrum, read_spe_file
+from fluxforge.physics.activation import IrradiationSegment, reaction_rate_from_activity
 from fluxforge.solvers.gls import gls_adjust
 
 
@@ -16,7 +38,138 @@ def _load_json(path: Path):
     return json.loads(path.read_text())
 
 
-def cmd_build_response(args: argparse.Namespace) -> None:
+def cmd_ingest(args: argparse.Namespace) -> None:
+    input_path = args.input
+    suffix = input_path.suffix.lower()
+
+    if suffix in {".spe"}:
+        spectrum = read_spe_file(input_path)
+    elif suffix in {".asc", ".txt"}:
+        spectrum = read_genie_spectrum(input_path)
+    else:
+        payload = read_spectrum_file(input_path)
+        spectrum = GammaSpectrum.from_dict(payload["spectrum"])
+
+    write_spectrum_file(args.output, spectrum, source_path=input_path)
+    print(f"Wrote spectrum file to {args.output}")
+
+
+def cmd_peaks(args: argparse.Namespace) -> None:
+    spectrum_payload = read_spectrum_file(args.spectrum_file)
+    spectrum = GammaSpectrum.from_dict(spectrum_payload["spectrum"])
+    energies = spectrum.energies if spectrum.energies is not None else spectrum.channels.astype(float)
+    if args.sensitivity == "sensitive":
+        config = SegmentedDetectionConfig.sensitive()
+    elif args.sensitivity == "conservative":
+        config = SegmentedDetectionConfig.conservative()
+    else:
+        config = SegmentedDetectionConfig()
+
+    peaks = detect_peaks_segmented(
+        spectrum.channels,
+        energies,
+        spectrum.counts,
+        config=config,
+        refine_centroids=True,
+        fit_window=args.fit_window,
+    )
+    peak_payload = [
+        {
+            "channel": peak.channel,
+            "energy_keV": peak.energy_keV,
+            "amplitude": peak.amplitude,
+            "raw_counts": peak.raw_counts,
+            "sigma_keV": peak.sigma_keV,
+            "area": peak.area,
+            "region": peak.region,
+            "is_report": peak.is_report,
+            "report_isotope": peak.report_isotope,
+            "report_file": peak.report_file,
+        }
+        for peak in peaks
+    ]
+
+    write_peak_report(
+        args.output,
+        spectrum_id=spectrum.spectrum_id,
+        live_time_s=spectrum.live_time,
+        peaks=peak_payload,
+        source_path=args.spectrum_file,
+    )
+    print(f"Wrote peak report to {args.output}")
+
+
+def cmd_activity(args: argparse.Namespace) -> None:
+    peak_report = read_peak_report(args.peaks_file)
+    live_time_s = peak_report.get("live_time_s") or args.live_time_s
+    if live_time_s is None:
+        raise ValueError("Live time is required to compute activities.")
+
+    lines = []
+    for idx, peak in enumerate(peak_report["peaks"]):
+        net_counts = peak.get("area") or peak.get("raw_counts") or peak.get("amplitude")
+        efficiency = args.efficiency
+        emission_probability = args.emission_probability
+        activity = net_counts / max(efficiency * emission_probability * live_time_s, 1e-12)
+        activity_unc = activity / np.sqrt(max(net_counts, 1e-12))
+        isotope = peak.get("report_isotope") or args.isotope or "unknown"
+        reaction_id = args.reaction_id or isotope or f"reaction_{idx + 1}"
+        lines.append(
+            {
+                "energy_keV": peak["energy_keV"],
+                "isotope": isotope,
+                "reaction_id": reaction_id,
+                "net_counts": net_counts,
+                "activity_Bq": activity,
+                "activity_unc_Bq": activity_unc,
+                "efficiency": efficiency,
+                "emission_probability": emission_probability,
+                "half_life_s": args.half_life_s,
+            }
+        )
+
+    write_line_activities(
+        args.output,
+        spectrum_id=peak_report.get("spectrum_id", ""),
+        lines=lines,
+        source_path=args.peaks_file,
+    )
+    print(f"Wrote line activities to {args.output}")
+
+
+def cmd_rates(args: argparse.Namespace) -> None:
+    line_payload = read_line_activities(args.lines_file)
+    segments = None
+    if args.segments_file:
+        segments = _load_json(args.segments_file)
+    if segments is None:
+        segments = [{"duration_s": args.duration_s, "relative_power": 1.0}]
+
+    segment_objs = [IrradiationSegment(**seg) for seg in segments]
+    rates = []
+    for idx, line in enumerate(line_payload["lines"]):
+        half_life_s = line.get("half_life_s", args.half_life_s)
+        rate_estimate = reaction_rate_from_activity(line["activity_Bq"], segment_objs, half_life_s)
+        reaction_id = line.get("reaction_id") or line.get("isotope") or f"reaction_{idx + 1}"
+        rates.append(
+            {
+                "reaction_id": reaction_id,
+                "rate": rate_estimate.rate,
+                "uncertainty": rate_estimate.uncertainty,
+                "half_life_s": half_life_s,
+            }
+        )
+
+    write_reaction_rates(
+        args.output,
+        rates=rates,
+        segments=segments,
+        source_path=args.lines_file,
+    )
+    print(f"Wrote reaction rates to {args.output}")
+
+
+def cmd_response(args: argparse.Namespace) -> None:
     boundaries = [float(x) for x in _load_json(args.boundaries_file)]
     groups = EnergyGroupStructure(boundaries)
     cross_sections_raw = _load_json(args.cross_section_file)
@@ -29,96 +182,173 @@ def cmd_build_response(args: argparse.Namespace) -> None:
         number_density_values.append(float(number_densities[reaction_id]))
 
     response = build_response_matrix(reactions, groups, number_density_values)
-    output_data = {
-        "matrix": response.matrix,
-        "reactions": response.reactions,
-        "boundaries": response.energy_groups.boundaries_eV,
-    }
-    Path(args.output).write_text(json.dumps(output_data, indent=2))
-    print(f"Wrote response matrix to {args.output}")
+    write_response_bundle(
+        args.output,
+        matrix=response.matrix,
+        reactions=response.reactions,
+        boundaries_eV=response.energy_groups.boundaries_eV,
+        source_path=args.cross_section_file,
+    )
+    print(f"Wrote response bundle to {args.output}")
 
 
-def cmd_infer_spectrum(args: argparse.Namespace) -> None:
-    response_data = _load_json(args.response_file)
+def cmd_unfold(args: argparse.Namespace) -> None:
+    response_data = read_response_bundle(args.response_file)
     response_matrix = response_data["matrix"]
-    boundaries = response_data["boundaries"]
+    boundaries = response_data["boundaries_eV"]
     reactions = response_data["reactions"]
     groups = EnergyGroupStructure([float(b) for b in boundaries])
 
-    measurements_data = _load_json(args.measurements_file)
-    half_life_map = {rx["reaction_id"]: float(rx["half_life_s"]) for rx in measurements_data["reactions"]}
-    segments = [IrradiationSegment(**seg) for seg in measurements_data["segments"]]
-
-    measured_rates: List[float] = []
-    rate_uncertainties: List[float] = []
-    for reaction in measurements_data["reactions"]:
-        gamma_lines = [GammaLineMeasurement(**line) for line in reaction["gamma_lines"]]
-        activity, _ = weighted_activity(gamma_lines)
-        rate_estimate = reaction_rate_from_activity(activity, segments, half_life_map[reaction["reaction_id"]])
-        measured_rates.append(rate_estimate.rate)
-        rate_uncertainties.append(rate_estimate.uncertainty)
+    rates_payload = read_reaction_rates(args.rates_file)
+    measured_rates = [float(rx["rate"]) for rx in rates_payload["rates"]]
+    rate_uncertainties = [float(rx["uncertainty"]) for rx in rates_payload["rates"]]
 
     if args.prior_flux_file:
         prior_flux = [float(v) for v in _load_json(args.prior_flux_file)]
     else:
         avg_response = sum(sum(row) for row in response_matrix) / max(len(response_matrix) * len(response_matrix[0]), 1)
         prior_flux = [sum(measured_rates) / max(avg_response, 1e-12) for _ in range(groups.group_count)]
-    prior_cov = [[(args.prior_uncertainty * val) ** 2 if i == j else 0.0 for j in range(groups.group_count)] for i, val in enumerate(prior_flux)]
-    measurement_cov = [[(rate_uncertainties[i] ** 2) if i == j else 0.0 for j in range(len(measured_rates))] for i in range(len(measured_rates))]
+    prior_cov = [
+        [(args.prior_uncertainty * val) ** 2 if i == j else 0.0 for j in range(groups.group_count)]
+        for i, val in enumerate(prior_flux)
+    ]
+    measurement_cov = [
+        [(rate_uncertainties[i] ** 2) if i == j else 0.0 for j in range(len(measured_rates))]
+        for i in range(len(measured_rates))
+    ]
 
     solution = gls_adjust(response_matrix, measured_rates, measurement_cov, prior_flux, prior_cov)
-    result = {
-        "boundaries_eV": boundaries,
-        "reactions": reactions,
-        "flux": solution.flux,
-        "covariance": solution.covariance,
-        "chi2": solution.chi2,
+    write_unfold_result(
+        args.output,
+        boundaries_eV=boundaries,
+        reactions=reactions,
+        flux=solution.flux,
+        covariance=solution.covariance,
+        chi2=solution.chi2,
+        method="gls",
+        source_path=args.rates_file,
+    )
+    print(f"Saved unfolded spectrum to {args.output}")
+
+
+def cmd_compare(args: argparse.Namespace) -> None:
+    unfold_data = read_unfold_result(args.unfold_file)
+    predicted_flux = unfold_data["flux"]
+    truth_flux = [float(v) for v in _load_json(args.truth_flux_file)]
+    residuals = [p - t for p, t in zip(predicted_flux, truth_flux)]
+    mae = sum(abs(r) for r in residuals) / max(len(residuals), 1)
+    rmse = np.sqrt(sum(r * r for r in residuals) / max(len(residuals), 1))
+    metrics = {
+        "mae": mae,
+        "rmse": float(rmse),
+        "chi2": unfold_data.get("chi2"),
     }
-    Path(args.output).write_text(json.dumps(result, indent=2))
-    print(f"Saved inferred spectrum to {args.output}")
+    write_validation_bundle(
+        args.output,
+        metrics=metrics,
+        truth_flux=truth_flux,
+        predicted_flux=predicted_flux,
+        residuals=residuals,
+        source_path=args.unfold_file,
+    )
+    print(f"Wrote validation bundle to {args.output}")
 
 
-def cmd_validate(args: argparse.Namespace) -> None:
-    response_data = _load_json(args.response_file)
-    r = response_data["matrix"]
-    phi_true = [float(v) for v in _load_json(args.truth_flux_file)]
-    y = [sum(row[i] * phi_true[i] for i in range(len(phi_true))) for row in r]
-    noise = [max(abs(val) * args.noise_fraction, 1e-12) for val in y]
-    cy = [[(noise[i] ** 2) if i == j else 0.0 for j in range(len(y))] for i in range(len(y))]
-    prior = [v * 0.8 for v in phi_true]
-    c0 = [[(args.noise_fraction * prior[i]) ** 2 if i == j else 0.0 for j in range(len(prior))] for i in range(len(prior))]
-    solution = gls_adjust(r, y, cy, prior, c0)
-    mae = sum(abs(a - b) / max(b, 1e-12) for a, b in zip(solution.flux, phi_true)) / len(phi_true)
-    print(f"Validation chi2: {solution.chi2:.2f}")
-    print(f"Mean absolute percent error: {mae * 100:.2f}%")
+def cmd_report(args: argparse.Namespace) -> None:
+    inputs = {}
+    summary = {}
+    if args.spectrum_file:
+        inputs["spectrum_file"] = str(args.spectrum_file)
+    if args.peaks_file:
+        inputs["peaks_file"] = str(args.peaks_file)
+        peak_report = read_peak_report(args.peaks_file)
+        summary["peak_count"] = len(peak_report.get("peaks", []))
+    if args.lines_file:
+        inputs["lines_file"] = str(args.lines_file)
+        line_payload = read_line_activities(args.lines_file)
+        summary["line_count"] = len(line_payload.get("lines", []))
+    if args.rates_file:
+        inputs["rates_file"] = str(args.rates_file)
+        rates_payload = read_reaction_rates(args.rates_file)
+        summary["rate_count"] = len(rates_payload.get("rates", []))
+    if args.unfold_file:
+        inputs["unfold_file"] = str(args.unfold_file)
+        unfold_payload = read_unfold_result(args.unfold_file)
+        summary["chi2"] = unfold_payload.get("chi2")
+    if args.validation_file:
+        inputs["validation_file"] = str(args.validation_file)
+        validation_payload = read_validation_bundle(args.validation_file)
+        summary["mae"] = validation_payload.get("metrics", {}).get("mae")
+
+    write_report_bundle(args.output, summary=summary, inputs=inputs or None)
+    print(f"Wrote report bundle to {args.output}")
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="UWNR Flux-Wire–Driven Neutron Spectrum Reconstruction Tool")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    build = subparsers.add_parser("build-response", help="Build response matrix from cross sections")
-    build.add_argument("--cross-section-file", type=Path, required=True)
-    build.add_argument("--number-densities-file", type=Path, required=True)
-    build.add_argument("--boundaries-file", type=Path, required=True)
-    build.add_argument("--output", type=Path, default=Path("response.json"))
-    build.set_defaults(func=cmd_build_response)
+    ingest = subparsers.add_parser("ingest", help="Ingest spectrum files into schema artifacts")
+    ingest.add_argument("--input", type=Path, required=True)
+    ingest.add_argument("--output", type=Path, default=Path("spectrum.json"))
+    ingest.set_defaults(func=cmd_ingest)
 
-    infer = subparsers.add_parser("infer-spectrum", help="Infer spectrum using GLS")
-    infer.add_argument("--measurements-file", type=Path, required=True)
-    infer.add_argument("--response-file", type=Path, required=True)
-    infer.add_argument("--prior-flux-file", type=Path)
-    infer.add_argument("--prior-uncertainty", type=float, default=0.25)
-    infer.add_argument("--output", type=Path, default=Path("spectrum.json"))
-    infer.set_defaults(func=cmd_infer_spectrum)
+    peaks = subparsers.add_parser("peaks", help="Detect peaks from a spectrum artifact")
+    peaks.add_argument("--spectrum-file", type=Path, required=True)
+    peaks.add_argument("--output", type=Path, default=Path("peaks.json"))
+    peaks.add_argument("--sensitivity", choices=["default", "sensitive", "conservative"], default="default")
+    peaks.add_argument("--fit-window", type=int, default=6)
+    peaks.set_defaults(func=cmd_peaks)
 
-    validate = subparsers.add_parser("validate", help="Run synthetic validation")
-    validate.add_argument("--response-file", type=Path, required=True)
-    validate.add_argument("--truth-flux-file", type=Path, required=True)
-    validate.add_argument("--noise-fraction", type=float, default=0.05)
-    validate.set_defaults(func=cmd_validate)
+    activity = subparsers.add_parser("activity", help="Compute line activities from peak report")
+    activity.add_argument("--peaks-file", type=Path, required=True)
+    activity.add_argument("--output", type=Path, default=Path("activities.json"))
+    activity.add_argument("--live-time-s", type=float)
+    activity.add_argument("--efficiency", type=float, default=1.0)
+    activity.add_argument("--emission-probability", type=float, default=1.0)
+    activity.add_argument("--half-life-s", type=float, default=1.0)
+    activity.add_argument("--isotope", type=str)
+    activity.add_argument("--reaction-id", type=str)
+    activity.set_defaults(func=cmd_activity)
 
-    subparsers.add_parser("report", help="Report generation placeholder")
+    rates = subparsers.add_parser("rates", help="Compute reaction rates from line activities")
+    rates.add_argument("--lines-file", type=Path, required=True)
+    rates.add_argument("--segments-file", type=Path)
+    rates.add_argument("--duration-s", type=float, default=1.0)
+    rates.add_argument("--half-life-s", type=float, default=1.0)
+    rates.add_argument("--output", type=Path, default=Path("rates.json"))
+    rates.set_defaults(func=cmd_rates)
+
+    response = subparsers.add_parser("response", help="Build response matrix from cross sections")
+    response.add_argument("--cross-section-file", type=Path, required=True)
+    response.add_argument("--number-densities-file", type=Path, required=True)
+    response.add_argument("--boundaries-file", type=Path, required=True)
+    response.add_argument("--output", type=Path, default=Path("response.json"))
+    response.set_defaults(func=cmd_response)
+
+    unfold = subparsers.add_parser("unfold", help="Infer spectrum using GLS")
+    unfold.add_argument("--rates-file", type=Path, required=True)
+    unfold.add_argument("--response-file", type=Path, required=True)
+    unfold.add_argument("--prior-flux-file", type=Path)
+    unfold.add_argument("--prior-uncertainty", type=float, default=0.25)
+    unfold.add_argument("--output", type=Path, default=Path("spectrum.json"))
+    unfold.set_defaults(func=cmd_unfold)
+
+    compare = subparsers.add_parser("compare", help="Compare unfolded spectrum with reference")
+    compare.add_argument("--unfold-file", type=Path, required=True)
+    compare.add_argument("--truth-flux-file", type=Path, required=True)
+    compare.add_argument("--output", type=Path, default=Path("validation.json"))
+    compare.set_defaults(func=cmd_compare)
+
+    report = subparsers.add_parser("report", help="Compile a report bundle from artifacts")
+    report.add_argument("--spectrum-file", type=Path)
+    report.add_argument("--peaks-file", type=Path)
+    report.add_argument("--lines-file", type=Path)
+    report.add_argument("--rates-file", type=Path)
+    report.add_argument("--unfold-file", type=Path)
+    report.add_argument("--validation-file", type=Path)
+    report.add_argument("--output", type=Path, default=Path("report.json"))
+    report.set_defaults(func=cmd_report)
     return parser
 
 
@@ -128,7 +358,7 @@ def main(argv: Optional[list[str]] = None) -> None:
     if hasattr(args, "func"):
         args.func(args)
     else:
-        print("Report generation not yet implemented. Track inputs and outputs manually for now.")
+        print("No command provided.")
 
 
 if __name__ == "__main__":

--- a/src/fluxforge/core/provenance.py
+++ b/src/fluxforge/core/provenance.py
@@ -1,0 +1,48 @@
+"""Shared provenance helpers for FluxForge artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from fluxforge import __version__
+
+
+def hash_bytes(payload: bytes) -> Dict[str, str]:
+    """Return standard hashes for a byte payload."""
+    sha256 = hashlib.sha256(payload).hexdigest()
+    md5 = hashlib.md5(payload).hexdigest()
+    return {"sha256": sha256, "md5": md5}
+
+
+def hash_file(path: Path) -> Dict[str, str]:
+    """Hash a file on disk."""
+    return hash_bytes(path.read_bytes())
+
+
+def build_provenance(
+    *,
+    units: Dict[str, str],
+    normalization: Optional[Dict[str, str]] = None,
+    source_hashes: Optional[Dict[str, Dict[str, str]]] = None,
+    extra_versions: Optional[Dict[str, str]] = None,
+    notes: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a provenance record for serialized artifacts."""
+    versions = {"fluxforge": __version__}
+    if extra_versions:
+        versions.update(extra_versions)
+    provenance: Dict[str, Any] = {
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "versions": versions,
+        "units": units,
+    }
+    if normalization:
+        provenance["normalization"] = normalization
+    if source_hashes:
+        provenance["hashes"] = source_hashes
+    if notes:
+        provenance["notes"] = notes
+    return provenance

--- a/src/fluxforge/core/schemas.py
+++ b/src/fluxforge/core/schemas.py
@@ -1,0 +1,200 @@
+"""Artifact schema definitions for FluxForge outputs."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+
+def _schema_id(name: str, version: str = "v1") -> str:
+    return f"fluxforge.{name}.{version}"
+
+
+SPECTRUM_FILE_SCHEMA: Dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "SpectrumFile",
+    "type": "object",
+    "required": ["schema", "spectrum", "provenance"],
+    "properties": {
+        "schema": {"const": _schema_id("spectrum_file")},
+        "spectrum": {
+            "type": "object",
+            "required": ["counts", "channels", "live_time", "real_time"],
+            "properties": {
+                "counts": {"type": "array", "items": {"type": "number"}},
+                "channels": {"type": "array", "items": {"type": "integer"}},
+                "energies": {"type": ["array", "null"], "items": {"type": "number"}},
+                "live_time": {"type": "number"},
+                "real_time": {"type": "number"},
+                "start_time": {"type": ["string", "null"]},
+                "spectrum_id": {"type": "string"},
+                "detector_id": {"type": "string"},
+                "calibration": {"type": "object"},
+                "metadata": {"type": "object"},
+            },
+        },
+        "provenance": {"type": "object"},
+    },
+}
+
+PEAK_REPORT_SCHEMA: Dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "PeakReport",
+    "type": "object",
+    "required": ["schema", "spectrum_id", "peaks", "provenance"],
+    "properties": {
+        "schema": {"const": _schema_id("peak_report")},
+        "spectrum_id": {"type": "string"},
+        "live_time_s": {"type": "number"},
+        "peaks": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["channel", "energy_keV", "amplitude", "raw_counts"],
+                "properties": {
+                    "channel": {"type": "integer"},
+                    "energy_keV": {"type": "number"},
+                    "amplitude": {"type": "number"},
+                    "raw_counts": {"type": "number"},
+                    "sigma_keV": {"type": "number"},
+                    "area": {"type": "number"},
+                    "region": {"type": "string"},
+                    "is_report": {"type": "boolean"},
+                    "report_isotope": {"type": "string"},
+                    "report_file": {"type": "string"},
+                },
+            },
+        },
+        "provenance": {"type": "object"},
+    },
+}
+
+LINE_ACTIVITIES_SCHEMA: Dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "LineActivities",
+    "type": "object",
+    "required": ["schema", "lines", "provenance"],
+    "properties": {
+        "schema": {"const": _schema_id("line_activities")},
+        "spectrum_id": {"type": "string"},
+        "lines": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["energy_keV", "net_counts", "activity_Bq", "activity_unc_Bq"],
+                "properties": {
+                    "energy_keV": {"type": "number"},
+                    "isotope": {"type": "string"},
+                    "reaction_id": {"type": "string"},
+                    "net_counts": {"type": "number"},
+                    "activity_Bq": {"type": "number"},
+                    "activity_unc_Bq": {"type": "number"},
+                    "efficiency": {"type": "number"},
+                    "emission_probability": {"type": "number"},
+                    "half_life_s": {"type": "number"},
+                },
+            },
+        },
+        "provenance": {"type": "object"},
+    },
+}
+
+REACTION_RATES_SCHEMA: Dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "ReactionRates",
+    "type": "object",
+    "required": ["schema", "rates", "provenance"],
+    "properties": {
+        "schema": {"const": _schema_id("reaction_rates")},
+        "segments": {"type": "array"},
+        "rates": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["reaction_id", "rate", "uncertainty"],
+                "properties": {
+                    "reaction_id": {"type": "string"},
+                    "rate": {"type": "number"},
+                    "uncertainty": {"type": "number"},
+                    "half_life_s": {"type": "number"},
+                },
+            },
+        },
+        "provenance": {"type": "object"},
+    },
+}
+
+RESPONSE_BUNDLE_SCHEMA: Dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "ResponseBundle",
+    "type": "object",
+    "required": ["schema", "matrix", "reactions", "boundaries_eV", "provenance"],
+    "properties": {
+        "schema": {"const": _schema_id("response_bundle")},
+        "matrix": {"type": "array", "items": {"type": "array", "items": {"type": "number"}}},
+        "reactions": {"type": "array", "items": {"type": "string"}},
+        "boundaries_eV": {"type": "array", "items": {"type": "number"}},
+        "provenance": {"type": "object"},
+    },
+}
+
+UNFOLD_RESULT_SCHEMA: Dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "UnfoldResult",
+    "type": "object",
+    "required": ["schema", "flux", "boundaries_eV", "provenance"],
+    "properties": {
+        "schema": {"const": _schema_id("unfold_result")},
+        "flux": {"type": "array", "items": {"type": "number"}},
+        "covariance": {"type": "array", "items": {"type": "array", "items": {"type": "number"}}},
+        "chi2": {"type": "number"},
+        "method": {"type": "string"},
+        "reactions": {"type": "array", "items": {"type": "string"}},
+        "boundaries_eV": {"type": "array", "items": {"type": "number"}},
+        "provenance": {"type": "object"},
+    },
+}
+
+VALIDATION_BUNDLE_SCHEMA: Dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "ValidationBundle",
+    "type": "object",
+    "required": ["schema", "metrics", "provenance"],
+    "properties": {
+        "schema": {"const": _schema_id("validation_bundle")},
+        "metrics": {"type": "object"},
+        "truth_flux": {"type": "array", "items": {"type": "number"}},
+        "predicted_flux": {"type": "array", "items": {"type": "number"}},
+        "residuals": {"type": "array", "items": {"type": "number"}},
+        "provenance": {"type": "object"},
+    },
+}
+
+REPORT_BUNDLE_SCHEMA: Dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "ReportBundle",
+    "type": "object",
+    "required": ["schema", "summary", "provenance"],
+    "properties": {
+        "schema": {"const": _schema_id("report_bundle")},
+        "summary": {"type": "object"},
+        "inputs": {"type": "object"},
+        "provenance": {"type": "object"},
+    },
+}
+
+SCHEMAS: Dict[str, Dict[str, Any]] = {
+    "SpectrumFile": SPECTRUM_FILE_SCHEMA,
+    "PeakReport": PEAK_REPORT_SCHEMA,
+    "LineActivities": LINE_ACTIVITIES_SCHEMA,
+    "ReactionRates": REACTION_RATES_SCHEMA,
+    "ResponseBundle": RESPONSE_BUNDLE_SCHEMA,
+    "UnfoldResult": UNFOLD_RESULT_SCHEMA,
+    "ValidationBundle": VALIDATION_BUNDLE_SCHEMA,
+    "ReportBundle": REPORT_BUNDLE_SCHEMA,
+}
+
+
+def schema_as_yaml(schema: Dict[str, Any]) -> str:
+    """Return a YAML representation (JSON is valid YAML)."""
+    return json.dumps(schema, indent=2)

--- a/src/fluxforge/io/__init__.py
+++ b/src/fluxforge/io/__init__.py
@@ -19,6 +19,26 @@ from fluxforge.io.genie import (
     discover_spectrum_pairs,
     load_spectrum_pair,
 )
+from fluxforge.io.artifacts import (
+    read_artifact,
+    write_artifact,
+    read_line_activities,
+    read_peak_report,
+    read_reaction_rates,
+    read_report_bundle,
+    read_response_bundle,
+    read_spectrum_file,
+    read_unfold_result,
+    read_validation_bundle,
+    write_line_activities,
+    write_peak_report,
+    write_reaction_rates,
+    write_report_bundle,
+    write_response_bundle,
+    write_spectrum_file,
+    write_unfold_result,
+    write_validation_bundle,
+)
 
 __all__ = [
     # SPE format
@@ -37,4 +57,23 @@ __all__ = [
     'SpectrumPair',
     'discover_spectrum_pairs',
     'load_spectrum_pair',
+    # Artifact I/O
+    'read_artifact',
+    'write_artifact',
+    'read_line_activities',
+    'read_peak_report',
+    'read_reaction_rates',
+    'read_report_bundle',
+    'read_response_bundle',
+    'read_spectrum_file',
+    'read_unfold_result',
+    'read_validation_bundle',
+    'write_line_activities',
+    'write_peak_report',
+    'write_reaction_rates',
+    'write_report_bundle',
+    'write_response_bundle',
+    'write_spectrum_file',
+    'write_unfold_result',
+    'write_validation_bundle',
 ]

--- a/src/fluxforge/io/artifacts.py
+++ b/src/fluxforge/io/artifacts.py
@@ -1,0 +1,381 @@
+"""Artifact read/write helpers for FluxForge JSON/YAML bundles."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from fluxforge.core.provenance import build_provenance, hash_file
+from fluxforge.core.schemas import _schema_id
+from fluxforge.io.spe import GammaSpectrum
+
+
+def _load_yaml_module():
+    if importlib.util.find_spec("yaml") is None:
+        return None
+    import yaml
+
+    return yaml
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _write_text(path: Path, payload: str) -> None:
+    path.write_text(payload, encoding="utf-8")
+
+
+def write_artifact(path: Path, payload: Dict[str, Any]) -> None:
+    """Write artifact data as JSON or YAML depending on extension."""
+    if path.suffix.lower() in {".yml", ".yaml"}:
+        yaml = _load_yaml_module()
+        if yaml is None:
+            raise ImportError("PyYAML is required to write YAML artifacts.")
+        _write_text(path, yaml.safe_dump(payload, sort_keys=False))
+    else:
+        _write_text(path, json.dumps(payload, indent=2))
+
+
+def read_artifact(path: Path) -> Dict[str, Any]:
+    """Read artifact data from JSON or YAML."""
+    if path.suffix.lower() in {".yml", ".yaml"}:
+        yaml = _load_yaml_module()
+        if yaml is None:
+            raise ImportError("PyYAML is required to read YAML artifacts.")
+        return yaml.safe_load(_read_text(path))
+    return json.loads(_read_text(path))
+
+
+def make_spectrum_file(
+    spectrum: GammaSpectrum,
+    *,
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    units = {
+        "counts": "counts",
+        "channels": "index",
+        "energies": "keV",
+        "live_time": "s",
+        "real_time": "s",
+    }
+    hashes = {"source": hash_file(source_path)} if source_path else None
+    provenance = build_provenance(units=units, normalization={"counts": "raw"}, source_hashes=hashes)
+    return {
+        "schema": _schema_id("spectrum_file"),
+        "spectrum": spectrum.to_dict(),
+        "provenance": provenance,
+    }
+
+
+def write_spectrum_file(
+    path: Path,
+    spectrum: GammaSpectrum,
+    *,
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    payload = make_spectrum_file(spectrum, source_path=source_path)
+    write_artifact(path, payload)
+    return payload
+
+
+def read_spectrum_file(path: Path) -> Dict[str, Any]:
+    return read_artifact(path)
+
+
+def make_peak_report(
+    *,
+    spectrum_id: str,
+    live_time_s: float,
+    peaks: Iterable[Dict[str, Any]],
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    units = {
+        "energy_keV": "keV",
+        "amplitude": "counts",
+        "raw_counts": "counts",
+        "sigma_keV": "keV",
+        "area": "counts",
+        "live_time_s": "s",
+    }
+    hashes = {"source": hash_file(source_path)} if source_path else None
+    provenance = build_provenance(units=units, normalization={"peaks": "raw"}, source_hashes=hashes)
+    return {
+        "schema": _schema_id("peak_report"),
+        "spectrum_id": spectrum_id,
+        "live_time_s": live_time_s,
+        "peaks": list(peaks),
+        "provenance": provenance,
+    }
+
+
+def write_peak_report(
+    path: Path,
+    *,
+    spectrum_id: str,
+    live_time_s: float,
+    peaks: Iterable[Dict[str, Any]],
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    payload = make_peak_report(
+        spectrum_id=spectrum_id,
+        live_time_s=live_time_s,
+        peaks=peaks,
+        source_path=source_path,
+    )
+    write_artifact(path, payload)
+    return payload
+
+
+def read_peak_report(path: Path) -> Dict[str, Any]:
+    return read_artifact(path)
+
+
+def make_line_activities(
+    *,
+    spectrum_id: str,
+    lines: Iterable[Dict[str, Any]],
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    units = {
+        "energy_keV": "keV",
+        "net_counts": "counts",
+        "activity_Bq": "Bq",
+        "activity_unc_Bq": "Bq",
+        "half_life_s": "s",
+    }
+    hashes = {"source": hash_file(source_path)} if source_path else None
+    provenance = build_provenance(units=units, normalization={"activity": "per-line"}, source_hashes=hashes)
+    return {
+        "schema": _schema_id("line_activities"),
+        "spectrum_id": spectrum_id,
+        "lines": list(lines),
+        "provenance": provenance,
+    }
+
+
+def write_line_activities(
+    path: Path,
+    *,
+    spectrum_id: str,
+    lines: Iterable[Dict[str, Any]],
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    payload = make_line_activities(spectrum_id=spectrum_id, lines=lines, source_path=source_path)
+    write_artifact(path, payload)
+    return payload
+
+
+def read_line_activities(path: Path) -> Dict[str, Any]:
+    return read_artifact(path)
+
+
+def make_reaction_rates(
+    *,
+    rates: Iterable[Dict[str, Any]],
+    segments: Optional[List[Dict[str, Any]]] = None,
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    units = {"rate": "reactions/s", "uncertainty": "reactions/s", "half_life_s": "s"}
+    hashes = {"source": hash_file(source_path)} if source_path else None
+    provenance = build_provenance(units=units, normalization={"rates": "per-reaction"}, source_hashes=hashes)
+    payload = {
+        "schema": _schema_id("reaction_rates"),
+        "rates": list(rates),
+        "provenance": provenance,
+    }
+    if segments is not None:
+        payload["segments"] = segments
+    return payload
+
+
+def write_reaction_rates(
+    path: Path,
+    *,
+    rates: Iterable[Dict[str, Any]],
+    segments: Optional[List[Dict[str, Any]]] = None,
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    payload = make_reaction_rates(rates=rates, segments=segments, source_path=source_path)
+    write_artifact(path, payload)
+    return payload
+
+
+def read_reaction_rates(path: Path) -> Dict[str, Any]:
+    return read_artifact(path)
+
+
+def make_response_bundle(
+    *,
+    matrix: List[List[float]],
+    reactions: List[str],
+    boundaries_eV: List[float],
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    units = {"matrix": "barn", "boundaries_eV": "eV"}
+    hashes = {"source": hash_file(source_path)} if source_path else None
+    provenance = build_provenance(units=units, normalization={"matrix": "number_density_applied"}, source_hashes=hashes)
+    return {
+        "schema": _schema_id("response_bundle"),
+        "matrix": matrix,
+        "reactions": reactions,
+        "boundaries_eV": boundaries_eV,
+        "provenance": provenance,
+    }
+
+
+def write_response_bundle(
+    path: Path,
+    *,
+    matrix: List[List[float]],
+    reactions: List[str],
+    boundaries_eV: List[float],
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    payload = make_response_bundle(
+        matrix=matrix,
+        reactions=reactions,
+        boundaries_eV=boundaries_eV,
+        source_path=source_path,
+    )
+    write_artifact(path, payload)
+    return payload
+
+
+def read_response_bundle(path: Path) -> Dict[str, Any]:
+    return read_artifact(path)
+
+
+def make_unfold_result(
+    *,
+    boundaries_eV: List[float],
+    reactions: List[str],
+    flux: List[float],
+    covariance: List[List[float]],
+    chi2: float,
+    method: str,
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    units = {"flux": "a.u.", "covariance": "a.u.^2", "boundaries_eV": "eV"}
+    hashes = {"source": hash_file(source_path)} if source_path else None
+    provenance = build_provenance(units=units, normalization={"flux": "per-group"}, source_hashes=hashes)
+    return {
+        "schema": _schema_id("unfold_result"),
+        "boundaries_eV": boundaries_eV,
+        "reactions": reactions,
+        "flux": flux,
+        "covariance": covariance,
+        "chi2": chi2,
+        "method": method,
+        "provenance": provenance,
+    }
+
+
+def write_unfold_result(
+    path: Path,
+    *,
+    boundaries_eV: List[float],
+    reactions: List[str],
+    flux: List[float],
+    covariance: List[List[float]],
+    chi2: float,
+    method: str,
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    payload = make_unfold_result(
+        boundaries_eV=boundaries_eV,
+        reactions=reactions,
+        flux=flux,
+        covariance=covariance,
+        chi2=chi2,
+        method=method,
+        source_path=source_path,
+    )
+    write_artifact(path, payload)
+    return payload
+
+
+def read_unfold_result(path: Path) -> Dict[str, Any]:
+    return read_artifact(path)
+
+
+def make_validation_bundle(
+    *,
+    metrics: Dict[str, Any],
+    truth_flux: List[float],
+    predicted_flux: List[float],
+    residuals: List[float],
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    units = {"truth_flux": "a.u.", "predicted_flux": "a.u.", "residuals": "a.u."}
+    hashes = {"source": hash_file(source_path)} if source_path else None
+    provenance = build_provenance(units=units, normalization={"metrics": "comparison"}, source_hashes=hashes)
+    return {
+        "schema": _schema_id("validation_bundle"),
+        "metrics": metrics,
+        "truth_flux": truth_flux,
+        "predicted_flux": predicted_flux,
+        "residuals": residuals,
+        "provenance": provenance,
+    }
+
+
+def write_validation_bundle(
+    path: Path,
+    *,
+    metrics: Dict[str, Any],
+    truth_flux: List[float],
+    predicted_flux: List[float],
+    residuals: List[float],
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    payload = make_validation_bundle(
+        metrics=metrics,
+        truth_flux=truth_flux,
+        predicted_flux=predicted_flux,
+        residuals=residuals,
+        source_path=source_path,
+    )
+    write_artifact(path, payload)
+    return payload
+
+
+def read_validation_bundle(path: Path) -> Dict[str, Any]:
+    return read_artifact(path)
+
+
+def make_report_bundle(
+    *,
+    summary: Dict[str, Any],
+    inputs: Optional[Dict[str, Any]] = None,
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    units = {"summary": "mixed"}
+    hashes = {"source": hash_file(source_path)} if source_path else None
+    provenance = build_provenance(units=units, normalization={"report": "aggregate"}, source_hashes=hashes)
+    payload = {
+        "schema": _schema_id("report_bundle"),
+        "summary": summary,
+        "provenance": provenance,
+    }
+    if inputs is not None:
+        payload["inputs"] = inputs
+    return payload
+
+
+def write_report_bundle(
+    path: Path,
+    *,
+    summary: Dict[str, Any],
+    inputs: Optional[Dict[str, Any]] = None,
+    source_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    payload = make_report_bundle(summary=summary, inputs=inputs, source_path=source_path)
+    write_artifact(path, payload)
+    return payload
+
+
+def read_report_bundle(path: Path) -> Dict[str, Any]:
+    return read_artifact(path)

--- a/tests/test_artifacts_io.py
+++ b/tests/test_artifacts_io.py
@@ -1,0 +1,158 @@
+import pytest
+
+from fluxforge.io.artifacts import (
+    read_line_activities,
+    read_peak_report,
+    read_reaction_rates,
+    read_report_bundle,
+    read_response_bundle,
+    read_spectrum_file,
+    read_unfold_result,
+    read_validation_bundle,
+    write_line_activities,
+    write_peak_report,
+    write_reaction_rates,
+    write_report_bundle,
+    write_response_bundle,
+    write_spectrum_file,
+    write_unfold_result,
+    write_validation_bundle,
+)
+
+
+def _require_numpy():
+    np = pytest.importorskip("numpy")
+    from fluxforge.io.spe import GammaSpectrum
+
+    return np, GammaSpectrum
+
+
+def test_spectrum_file_roundtrip(tmp_path):
+    np, GammaSpectrum = _require_numpy()
+    spectrum = GammaSpectrum(
+        counts=np.array([10.0, 20.0, 30.0]),
+        channels=np.array([0, 1, 2]),
+        energies=np.array([0.0, 1.0, 2.0]),
+        live_time=12.0,
+        real_time=15.0,
+        spectrum_id="demo",
+    )
+    output = tmp_path / "spectrum.json"
+    write_spectrum_file(output, spectrum)
+    payload = read_spectrum_file(output)
+    assert payload["spectrum"]["counts"] == [10.0, 20.0, 30.0]
+    assert payload["spectrum"]["live_time"] == 12.0
+    assert payload["provenance"]["units"]["energies"] == "keV"
+
+
+def test_peak_report_roundtrip(tmp_path):
+    _require_numpy()
+    peaks = [
+        {
+            "channel": 12,
+            "energy_keV": 511.0,
+            "amplitude": 200.0,
+            "raw_counts": 180.0,
+            "sigma_keV": 1.2,
+            "area": 500.0,
+            "region": "mid",
+            "is_report": False,
+            "report_isotope": "",
+            "report_file": "",
+        }
+    ]
+    output = tmp_path / "peaks.json"
+    write_peak_report(output, spectrum_id="demo", live_time_s=10.0, peaks=peaks)
+    payload = read_peak_report(output)
+    assert payload["peaks"][0]["energy_keV"] == 511.0
+    assert payload["provenance"]["units"]["live_time_s"] == "s"
+
+
+def test_line_activities_roundtrip(tmp_path):
+    _require_numpy()
+    lines = [
+        {
+            "energy_keV": 511.0,
+            "isotope": "Na-22",
+            "reaction_id": "Na-22",
+            "net_counts": 500.0,
+            "activity_Bq": 5.0,
+            "activity_unc_Bq": 0.5,
+            "efficiency": 0.2,
+            "emission_probability": 0.9,
+            "half_life_s": 10.0,
+        }
+    ]
+    output = tmp_path / "activities.json"
+    write_line_activities(output, spectrum_id="demo", lines=lines)
+    payload = read_line_activities(output)
+    assert payload["lines"][0]["activity_Bq"] == 5.0
+    assert payload["provenance"]["units"]["activity_Bq"] == "Bq"
+
+
+def test_reaction_rates_roundtrip(tmp_path):
+    _require_numpy()
+    rates = [
+        {"reaction_id": "Fe-59", "rate": 1.5, "uncertainty": 0.1, "half_life_s": 12.0}
+    ]
+    segments = [{"duration_s": 5.0, "relative_power": 1.0}]
+    output = tmp_path / "rates.json"
+    write_reaction_rates(output, rates=rates, segments=segments)
+    payload = read_reaction_rates(output)
+    assert payload["rates"][0]["rate"] == 1.5
+    assert payload["provenance"]["units"]["rate"] == "reactions/s"
+
+
+def test_response_bundle_roundtrip(tmp_path):
+    _require_numpy()
+    output = tmp_path / "response.json"
+    write_response_bundle(
+        output,
+        matrix=[[1.0, 0.5], [0.2, 0.1]],
+        reactions=["rx1", "rx2"],
+        boundaries_eV=[0.0, 1.0, 2.0],
+    )
+    payload = read_response_bundle(output)
+    assert payload["matrix"][0][0] == 1.0
+    assert payload["provenance"]["units"]["boundaries_eV"] == "eV"
+
+
+def test_unfold_result_roundtrip(tmp_path):
+    _require_numpy()
+    output = tmp_path / "unfold.json"
+    write_unfold_result(
+        output,
+        boundaries_eV=[0.0, 1.0],
+        reactions=["rx1"],
+        flux=[1.2],
+        covariance=[[0.04]],
+        chi2=1.1,
+        method="gls",
+    )
+    payload = read_unfold_result(output)
+    assert payload["flux"] == [1.2]
+    assert payload["provenance"]["units"]["flux"] == "a.u."
+
+
+def test_validation_bundle_roundtrip(tmp_path):
+    _require_numpy()
+    output = tmp_path / "validation.json"
+    write_validation_bundle(
+        output,
+        metrics={"mae": 0.1},
+        truth_flux=[1.0, 2.0],
+        predicted_flux=[1.1, 1.9],
+        residuals=[0.1, -0.1],
+    )
+    payload = read_validation_bundle(output)
+    assert payload["metrics"]["mae"] == 0.1
+    assert payload["provenance"]["units"]["residuals"] == "a.u."
+
+
+def test_report_bundle_roundtrip(tmp_path):
+    _require_numpy()
+    output = tmp_path / "report.json"
+    write_report_bundle(output, summary={"peak_count": 3}, inputs={"peaks_file": "peaks.json"})
+    payload = read_report_bundle(output)
+    assert payload["summary"]["peak_count"] == 3
+    assert payload["provenance"]["units"]["summary"] == "mixed"


### PR DESCRIPTION
### Motivation

- Provide machine-readable artifact schemas for SpectrumFile, PeakReport, LineActivities, ReactionRates, ResponseBundle, UnfoldResult, ValidationBundle, and ReportBundle to standardize outputs.
- Centralize provenance metadata (hashes, versions, units, normalization) so artifact writers share consistent provenance fields.
- Wire artifact read/write into the CLI so common workflows can emit and consume schema-backed JSON/YAML bundles for `ingest`, `peaks`, `activity`, `rates`, `response`, `unfold`, `compare`, and `report` steps.
- Add round-trip I/O tests to ensure values and declared units are preserved across serialization.

### Description

- Add `src/fluxforge/core/schemas.py` with JSON schema objects and `_schema_id` helpers and `src/fluxforge/core/provenance.py` with `hash_bytes`, `hash_file`, and `build_provenance` helpers.
- Implement `src/fluxforge/io/artifacts.py` to `make`/`read`/`write` artifact bundles (JSON/YAML), attach provenance and optional source file hashes, and export convenient `read_*`/`write_*` functions.
- Export artifact I/O functions from `src/fluxforge/io/__init__.py` and update `src/fluxforge/cli/app.py` to add commands `ingest`, `peaks`, `activity`, `rates`, `response`, `unfold`, `compare`, and `report` that produce/consume the new artifact formats.
- Add `tests/test_artifacts_io.py` containing round-trip tests for spectrum, peak report, line activities, reaction rates, response bundle, unfold result, validation bundle, and report bundle.

### Testing

- Executed `pytest -q tests/test_artifacts_io.py`, which was skipped in the current environment because `numpy` is not installed and the tests rely on `numpy` for `GammaSpectrum` objects.
- Running `PYTHONPATH=src pytest -q tests/test_artifacts_io.py` in this environment produced an error during collection due to the same missing `numpy` dependency.
- No other automated test suites were run as part of this rollout.
- The new tests exercise artifact round-trips and provenance `units` fields when `numpy` is available in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587653cf688321bba6a0d9d10539c2)