### PR TITLE
Add CSV/HPGe readers and QC flags; extend Genie ASCII parser

### DIFF
--- a/src/fluxforge/io/__init__.py
+++ b/src/fluxforge/io/__init__.py
@@ -19,6 +19,13 @@ from fluxforge.io.genie import (
     discover_spectrum_pairs,
     load_spectrum_pair,
 )
+from fluxforge.io.hpge import HPGeReport, read_hpge_report
+from fluxforge.io.csv_readers import (
+    EfficiencyExport,
+    FluxWireTiming,
+    read_efficiency_export,
+    read_flux_wire_timing_csv,
+)
 from fluxforge.io.artifacts import (
     read_artifact,
     write_artifact,
@@ -57,6 +64,13 @@ __all__ = [
     'SpectrumPair',
     'discover_spectrum_pairs',
     'load_spectrum_pair',
+    # CSV/HPGe exports
+    'EfficiencyExport',
+    'FluxWireTiming',
+    'read_efficiency_export',
+    'read_flux_wire_timing_csv',
+    'HPGeReport',
+    'read_hpge_report',
     # Artifact I/O
     'read_artifact',
     'write_artifact',

--- a/src/fluxforge/io/csv_readers.py
+++ b/src/fluxforge/io/csv_readers.py
@@ -1,0 +1,180 @@
+"""CSV readers for FluxForge example exports."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+import numpy as np
+
+
+def _parse_datetime(value: str) -> Optional[datetime]:
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+@dataclass
+class EfficiencyExport:
+    """LabSOCS-style efficiency CSV export."""
+
+    header: Dict[str, str] = field(default_factory=dict)
+    coefficients: Dict[str, float] = field(default_factory=dict)
+    table: Dict[str, np.ndarray] = field(default_factory=dict)
+    qc_flags: List[str] = field(default_factory=list)
+
+
+def read_efficiency_export(path: Union[str, Path]) -> EfficiencyExport:
+    """Read LabSOCS efficiency CSV export with header row and energy table."""
+    path = Path(path)
+    qc_flags: List[str] = []
+    header: Dict[str, str] = {}
+    coefficients: Dict[str, float] = {}
+    table: Dict[str, np.ndarray] = {}
+
+    with path.open("r", encoding="utf-8", errors="ignore") as f:
+        reader = csv.reader(f)
+        try:
+            header_row = next(reader)
+            value_row = next(reader)
+        except StopIteration:
+            raise ValueError(f"Efficiency export {path} is missing header rows.")
+
+        for key, value in zip(header_row, value_row):
+            key = key.strip()
+            value = value.strip()
+            if not key:
+                continue
+            if key in {"C1", "C2", "C3", "C4", "A", "T1", "DI", "DL", "Error"}:
+                try:
+                    coefficients[key] = float(value)
+                except ValueError:
+                    qc_flags.append(f"invalid_{key.lower()}")
+            else:
+                header[key] = value
+
+        table_header: Optional[Sequence[str]] = None
+        rows: List[List[float]] = []
+        for row in reader:
+            if not row or all(not cell.strip() for cell in row):
+                continue
+            if table_header is None:
+                table_header = [cell.strip() for cell in row]
+                continue
+            try:
+                rows.append([float(cell) for cell in row[: len(table_header)]])
+            except ValueError:
+                continue
+
+        if table_header and rows:
+            values = np.array(rows, dtype=float)
+            for idx, name in enumerate(table_header):
+                if name:
+                    table[name] = values[:, idx]
+        else:
+            qc_flags.append("missing_efficiency_table")
+
+    for key in ("C1", "C2", "C3", "C4"):
+        if key not in coefficients:
+            qc_flags.append(f"missing_{key.lower()}")
+
+    return EfficiencyExport(
+        header=header,
+        coefficients=coefficients,
+        table=table,
+        qc_flags=qc_flags,
+    )
+
+
+@dataclass
+class FluxWireTiming:
+    """Timing metadata for flux wire measurements."""
+
+    wire_name: str
+    base_name: str
+    category: str
+    reaction: str
+    products: str
+    irradiation_start: Optional[datetime]
+    irradiation_end: Optional[datetime]
+    irradiation_seconds: float
+    measurement_time: Optional[datetime]
+    cooldown_seconds: float
+    cooldown_hours: float
+    cooldown_days: float
+    qc_flags: List[str] = field(default_factory=list)
+
+
+def read_flux_wire_timing_csv(path: Union[str, Path]) -> List[FluxWireTiming]:
+    """Read flux_wire_timing.csv export."""
+    path = Path(path)
+    timing: List[FluxWireTiming] = []
+
+    with path.open("r", encoding="utf-8", errors="ignore") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            qc_flags: List[str] = []
+            for required in (
+                "wire_name",
+                "base_name",
+                "category",
+                "reaction",
+                "products",
+                "irradiation_start",
+                "irradiation_end",
+                "measurement_time",
+            ):
+                if not row.get(required):
+                    qc_flags.append(f"missing_{required}")
+
+            irradiation_start = _parse_datetime(row.get("irradiation_start", ""))
+            irradiation_end = _parse_datetime(row.get("irradiation_end", ""))
+            measurement_time = _parse_datetime(row.get("measurement_time", ""))
+
+            def _parse_float(field: str) -> float:
+                value = row.get(field, "").strip()
+                if not value:
+                    qc_flags.append(f"missing_{field}")
+                    return 0.0
+                try:
+                    return float(value)
+                except ValueError:
+                    qc_flags.append(f"invalid_{field}")
+                    return 0.0
+
+            irradiation_seconds = _parse_float("irradiation_seconds")
+            cooldown_seconds = _parse_float("cooldown_seconds")
+            cooldown_hours = _parse_float("cooldown_hours")
+            cooldown_days = _parse_float("cooldown_days")
+
+            if irradiation_start and irradiation_end and irradiation_end < irradiation_start:
+                qc_flags.append("irradiation_end_before_start")
+            if irradiation_seconds <= 0:
+                qc_flags.append("missing_irradiation_duration")
+
+            timing.append(
+                FluxWireTiming(
+                    wire_name=row.get("wire_name", "").strip(),
+                    base_name=row.get("base_name", "").strip(),
+                    category=row.get("category", "").strip(),
+                    reaction=row.get("reaction", "").strip(),
+                    products=row.get("products", "").strip(),
+                    irradiation_start=irradiation_start,
+                    irradiation_end=irradiation_end,
+                    irradiation_seconds=irradiation_seconds,
+                    measurement_time=measurement_time,
+                    cooldown_seconds=cooldown_seconds,
+                    cooldown_hours=cooldown_hours,
+                    cooldown_days=cooldown_days,
+                    qc_flags=qc_flags,
+                )
+            )
+
+    return timing

--- a/src/fluxforge/io/hpge.py
+++ b/src/fluxforge/io/hpge.py
@@ -1,0 +1,167 @@
+"""HPGe report/export readers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from fluxforge.io.genie import ReportPeak, parse_genie_report
+from fluxforge.io.metadata import qc_flags_for_spectrum
+
+FLOAT_RE = re.compile(r"[+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?")
+ID_RE = re.compile(r"^\s*ID:\s*(.+)$", re.IGNORECASE | re.MULTILINE)
+FILE_DATE_RE = re.compile(r"^\s*File:\s*(.+?)\s+Date:\s*(.+)$", re.IGNORECASE | re.MULTILINE)
+LT_RT_DT_RE = re.compile(
+    r"LT:\s*([\d.,]+)\s*RT:\s*([\d.,]+)\s*DT:\s*([\d.,]+)\s*%?",
+    re.IGNORECASE,
+)
+DETECTOR_ID_RE = re.compile(r"Detector\s+ID:\s*(.+)$", re.IGNORECASE)
+
+
+def _parse_number(value: str) -> Optional[float]:
+    try:
+        return float(value.replace(",", ""))
+    except ValueError:
+        return None
+
+
+def _parse_datetime(value: str) -> Optional[datetime]:
+    for fmt in (
+        "%B %d, %Y %H:%M:%S",
+        "%B %d, %Y %H:%M",
+        "%b %d, %Y %H:%M:%S",
+        "%b %d, %Y %H:%M",
+        "%m/%d/%Y %H:%M:%S",
+        "%d-%b-%Y %H:%M",
+    ):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+@dataclass
+class HPGeReport:
+    """Parsed HPGe report export."""
+
+    report_id: str
+    file_name: str = ""
+    start_time: Optional[datetime] = None
+    live_time: float = 0.0
+    real_time: float = 0.0
+    dead_time_pct: Optional[float] = None
+    detector_id: str = ""
+    calibration: Dict[str, Any] = field(default_factory=dict)
+    efficiency: Dict[str, Any] = field(default_factory=dict)
+    peaks: List[ReportPeak] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    qc_flags: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "report_id": self.report_id,
+            "file_name": self.file_name,
+            "start_time": self.start_time.isoformat() if self.start_time else None,
+            "live_time": self.live_time,
+            "real_time": self.real_time,
+            "dead_time_pct": self.dead_time_pct,
+            "detector_id": self.detector_id,
+            "calibration": self.calibration,
+            "efficiency": self.efficiency,
+            "peaks": [peak.__dict__ for peak in self.peaks],
+            "metadata": self.metadata,
+            "qc_flags": self.qc_flags,
+        }
+
+
+def read_hpge_report(filepath: Union[str, Path]) -> HPGeReport:
+    """Read HPGe report export (Genie/LabSOCS TXT)."""
+    filepath = Path(filepath)
+    content = filepath.read_text(encoding="utf-8", errors="ignore")
+
+    report_id = ""
+    match = ID_RE.search(content)
+    if match:
+        report_id = match.group(1).strip()
+
+    file_name = ""
+    start_time = None
+    match = FILE_DATE_RE.search(content)
+    if match:
+        file_name = match.group(1).strip()
+        start_time = _parse_datetime(match.group(2).strip())
+
+    live_time = 0.0
+    real_time = 0.0
+    dead_time = None
+    match = LT_RT_DT_RE.search(content)
+    if match:
+        parsed_live = _parse_number(match.group(1))
+        parsed_real = _parse_number(match.group(2))
+        parsed_dead = _parse_number(match.group(3))
+        if parsed_live is not None:
+            live_time = parsed_live
+        if parsed_real is not None:
+            real_time = parsed_real
+        if parsed_dead is not None:
+            dead_time = parsed_dead
+
+    detector_id = ""
+    for line in content.splitlines():
+        match = DETECTOR_ID_RE.search(line)
+        if match:
+            detector_id = match.group(1).strip()
+            break
+
+    calibration: Dict[str, Any] = {}
+    efficiency: Dict[str, Any] = {}
+    for line in content.splitlines():
+        if "Energy" in line and "Ch" in line:
+            numbers = FLOAT_RE.findall(line)
+            if len(numbers) >= 3:
+                calibration["energy"] = [float(n) for n in numbers[:3]]
+        if ":" in line:
+            key, value = line.split(":", 1)
+            key = key.strip()
+            value = value.strip()
+            if key in {"C1", "C2", "C3", "C4", "A", "T1", "DI", "DL"}:
+                parsed = _parse_number(value)
+                if parsed is not None:
+                    efficiency[key] = parsed
+
+    peaks = parse_genie_report(filepath)
+
+    qc_flags = qc_flags_for_spectrum(
+        spectrum_id=report_id or filepath.stem,
+        live_time=live_time,
+        real_time=real_time,
+        start_time=start_time,
+        calibration=calibration,
+        detector_id=detector_id,
+    )
+
+    metadata = {
+        "source_file": str(filepath),
+        "format": "hpge_report",
+    }
+    if dead_time is not None:
+        metadata["dead_time_pct"] = dead_time
+
+    return HPGeReport(
+        report_id=report_id or filepath.stem,
+        file_name=file_name,
+        start_time=start_time,
+        live_time=live_time,
+        real_time=real_time,
+        dead_time_pct=dead_time,
+        detector_id=detector_id,
+        calibration=calibration,
+        efficiency=efficiency,
+        peaks=peaks,
+        metadata=metadata,
+        qc_flags=qc_flags,
+    )

--- a/src/fluxforge/io/hpge.py
+++ b/src/fluxforge/io/hpge.py
@@ -122,7 +122,7 @@ def read_hpge_report(filepath: Union[str, Path]) -> HPGeReport:
     for line in content.splitlines():
         if "Energy" in line and "Ch" in line:
             numbers = FLOAT_RE.findall(line)
-            if len(numbers) >= 3:
+            if len(numbers) >= 2:
                 calibration["energy"] = [float(n) for n in numbers[:3]]
         if ":" in line:
             key, value = line.split(":", 1)

--- a/src/fluxforge/io/metadata.py
+++ b/src/fluxforge/io/metadata.py
@@ -1,0 +1,48 @@
+"""Metadata helpers for spectrum readers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+
+def _missing(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ""
+    return False
+
+
+def qc_flags_for_spectrum(
+    *,
+    spectrum_id: str,
+    live_time: float,
+    real_time: float,
+    start_time: Optional[datetime],
+    calibration: Optional[Dict[str, Any]] = None,
+    detector_id: Optional[str] = None,
+) -> List[str]:
+    """Build QC flags for missing/inconsistent metadata fields."""
+    flags: List[str] = []
+
+    if _missing(spectrum_id):
+        flags.append("missing_spectrum_id")
+
+    if live_time <= 0:
+        flags.append("missing_live_time")
+    if real_time <= 0:
+        flags.append("missing_real_time")
+    if live_time > 0 and real_time > 0 and live_time > real_time:
+        flags.append("live_time_exceeds_real_time")
+
+    if start_time is None:
+        flags.append("missing_start_time")
+
+    if calibration is None or not calibration.get("energy"):
+        flags.append("missing_energy_calibration")
+
+    if detector_id is not None and _missing(detector_id):
+        flags.append("missing_detector_id")
+
+    return flags


### PR DESCRIPTION
### Motivation

- Support parsing of example spectrum exports (Genie-2000 ASCII/ASC, LabSOCS-style CSV, and HPGe report TXT) used in examples and tests. 
- Align metadata extraction with common HDTV and gamma_spec_analysis conventions to improve header handling and calibration capture. 
- Surface simple QC indicators for missing or inconsistent metadata so downstream workflows can detect problematic inputs. 

### Description

- Add `src/fluxforge/io/metadata.py` providing `qc_flags_for_spectrum` and helpers to produce QC flags for spectra. 
- Add `src/fluxforge/io/csv_readers.py` with `read_efficiency_export` and `read_flux_wire_timing_csv` plus `EfficiencyExport` and `FluxWireTiming` dataclasses and per-file QC flags. 
- Add `src/fluxforge/io/hpge.py` implementing `HPGeReport` and `read_hpge_report` to parse LabSOCS/Genie report TXT exports, extract calibration/timing/detector fields, parse peaks via `parse_genie_report`, and attach QC flags. 
- Extend `src/fluxforge/io/genie.py` to tolerate comma-separated numbers, accept additional header patterns (e.g. `Acquisition Date`, `ID`), parse more date formats, and include `qc_flags` in the returned `GammaSpectrum` metadata; and update `src/fluxforge/io/__init__.py` to export the new readers and types. 

### Testing

- No automated test suite was executed for these changes during the rollout. 
- The change set was added and committed to the repository (files created: `csv_readers.py`, `hpge.py`, `metadata.py`, and modifications to `genie.py` and `__init__.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69587d469b3c83218a9c61015cfd855f)