### PR TITLE
feat(core): add versioned analysis workspace state

### DIFF
--- a/.github/project-management/full_parity_ledger.json
+++ b/.github/project-management/full_parity_ledger.json
@@ -84,15 +84,15 @@
       "id": "3.24", "title": "Direct-manipulation spectrum canvas", "roadmap": "Phase 3B", "status": "prototype",
       "source_urls": ["fluxforge-roadmap", "interspec", "peakeasy", "hyperlab"],
       "backend": "prototype", "cli": "not-applicable", "gui": "prototype", "fixture": "planned", "test": "prototype",
-      "evidence": ["src/fluxforge/gui/spectrum_canvas.py", "src/fluxforge/gui/backends/pyqtgraph_backend.py", "tests/test_analysis_workspace_qt.py"],
-      "notes": "Canvas interaction code exists, but the complete peak/ROI/sideband command model and native Windows/Linux evidence are not yet validated."
+      "evidence": ["src/fluxforge/gui/spectrum_canvas.py", "src/fluxforge/gui/backends/pyqtgraph_backend.py", "src/fluxforge/gui/canvas_intents.py", "src/fluxforge/gui/workspace_undo.py", "tests/test_canvas_intents.py", "tests/test_workspace_undo.py", "tests/test_analysis_workspace_qt.py"],
+      "notes": "Renderer-independent intents, focused undo commands, and persisted viewports are implemented with Windows/Linux tests. Direct peak/ROI/sideband mouse manipulation and native desktop automation remain for gui/02, so this stays prototype."
     },
     {
       "id": "3.25", "title": "Modern Qt parity workspaces", "roadmap": "Phase 3B", "status": "prototype",
       "source_urls": ["fluxforge-roadmap", "interspec", "gammavision", "genie"],
       "backend": "prototype", "cli": "prototype", "gui": "prototype", "fixture": "scaffolded", "test": "prototype",
-      "evidence": ["src/fluxforge/gui/panels/modern_shell.py", "src/fluxforge/gui/panels/phase6.py", "tests/test_analysis_workspace_qt.py"],
-      "notes": "Several workspaces are executable; their presence does not close detection-limit, shielding, library, k0, or optimization scientific parity."
+      "evidence": ["src/fluxforge/core/workspace_document.py", "src/fluxforge/io/session.py", "src/fluxforge/io/atomic.py", "src/fluxforge/gui/analysis_workspace.py", "src/fluxforge/gui/main_window.py", "src/fluxforge/gui/panels/modern_shell.py", "src/fluxforge/gui/panels/phase6.py", "tests/test_workspace_document_v2.py", "tests/test_session_v2_migration.py", "tests/test_workspace_session_qt.py", "tests/test_analysis_workspace_qt.py"],
+      "notes": "WorkspaceDocument v2, v1 migration, atomic sessions, and Save/Open replacement are implemented with Windows/Linux tests. Scientific workspace parity for detection limits, shielding, libraries, k0, and optimization remains open, so this stays prototype."
     },
     {
       "id": "3.26", "title": "GUI polish, dark mode, and saved themes", "roadmap": "Phase 3B", "status": "implemented",

--- a/.github/project-management/gui_action_catalog.json
+++ b/.github/project-management/gui_action_catalog.json
@@ -11,8 +11,8 @@
     },
     {
       "surface": "main-window.files-and-examples",
-      "test_ids": ["tests/test_production_gui_mode.py", "tests/test_gui_app.py"],
-      "object_names": ["OpenExampleAction", "OpenSessionAction", "OpenSpectrumAction"]
+      "test_ids": ["tests/test_production_gui_mode.py", "tests/test_gui_app.py", "tests/test_workspace_session_qt.py"],
+      "object_names": ["OpenExampleAction", "OpenSessionAction", "OpenSpectrumAction", "SaveSessionAction", "SaveSessionAsAction"]
     },
     {
       "surface": "main-window.analysis",

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -149,6 +149,11 @@ fluxforge gui --project-dir . --open-example
 The `--developer-tools` flag exposes diagnostics and prototype evidence panels
 for developers. It is intentionally omitted from normal analyst startup.
 
+Use **File > Save Session** for reproducible scientific state. Named workflow
+presets store interface preferences only and never reopen spectrum paths. The
+versioned `.ffs` contract and recovery behavior are documented in
+[`SESSION_FORMAT.md`](SESSION_FORMAT.md).
+
 For a first GUI workflow, load the committed files below; no external data
 download is required:
 

--- a/docs/SESSION_FORMAT.md
+++ b/docs/SESSION_FORMAT.md
@@ -1,0 +1,57 @@
+# FluxForge Session and Workspace Format
+
+FluxForge `.ffs` files are self-contained analysis sessions. New files use the
+version 2 envelope and embed a validated `WorkspaceDocument`:
+
+```json
+{
+  "format": "fluxforge_session",
+  "format_version": 2,
+  "document": {
+    "schema": "fluxforge.workspace_document.v2",
+    "schema_version": 2
+  },
+  "recent_files": [],
+  "device_snapshot": [],
+  "metadata": {},
+  "created_at": "2026-07-22T12:00:00+00:00"
+}
+```
+
+The document, rather than the GUI widgets, owns spectra, spectrum roles, ROIs,
+peak models and assignments, detector profiles and calibrations, fit
+diagnostics, viewports, pinned nuclides, tags, plot settings, workflow state,
+and provenance. `SelectionBus` remains transient UI state and is never written
+as the authoritative ROI model.
+
+## Compatibility
+
+- Version 1 sessions are migrated in memory to version 2 when opened.
+- Missing version fields are interpreted as version 1 only when the payload has
+  the legacy session shape.
+- Unsupported future versions, malformed references, non-finite values,
+  reversed ranges, and invalid covariance matrices fail with a field-specific
+  error instead of being clipped or silently discarded.
+- New saves always write version 2. FluxForge does not write a legacy version 1
+  file.
+
+Legacy fields that cannot be interpreted without guessing are retained in the
+document extensions area. Existing spectrum arrays, calibration dictionaries,
+GPS/device metadata, recent files, and acquisition snapshots are preserved.
+
+## Safe saves
+
+FluxForge serializes and validates the complete payload before touching the
+destination. It then writes and synchronizes a temporary file in the same
+directory and performs one atomic replacement. If writing or replacement
+fails, the previous session remains byte-identical. On Windows, close any
+application holding the file and allow OneDrive or other synchronization tools
+to release the lock before retrying.
+
+## Workflow presets are not sessions
+
+Named workflow presets store reusable interface configuration such as mode,
+library selection, plot preferences, and panel settings. They do not store or
+reopen spectrum paths, spectrum roles, peaks, pinned nuclides, detector state,
+or analysis results. Use **File > Save Session** when scientific state must be
+reproducible.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -171,12 +171,23 @@ Recommended first files:
 
 Recommended first actions:
 
-1. Load the foreground and background spectra.
-2. Zoom into a peak-rich region.
-3. Drag the ROI directly on the main canvas.
-4. Drag the background sidebands if you want sideband-style ROI analysis.
-5. Drag a selected peak centroid to refine the fit anchor.
-6. Use the right-click menu for manual peak insertion, deletion, line-ID clearing, and source-role assignment.
+1. Choose **File > Open Example** for the bundled deterministic workspace, or
+   load the foreground and background files above.
+2. Use the foreground/background/overlay selectors to assign spectrum roles.
+3. Use the mouse wheel or **Zoom + / Zoom -** to inspect a peak-rich region;
+   left-drag pans and **Reset View** restores the complete spectrum.
+4. Choose **Select ROI** and drag the displayed ROI bounds, then run the ROI
+   analysis or statistics action in the bottom workspace.
+5. Run **Auto Find Peaks**, review the proposal dialog, and use the peak table
+   for selection, isotope assignment, tags, and pinned nuclides.
+6. Choose **File > Save Session** (`Ctrl+S`) to write the complete analysis as
+   a versioned `.ffs` file. **Save Session As** uses `Ctrl+Shift+S`; opening a
+   session replaces the current workspace after validation.
+
+Workflow presets are reusable interface settings and never reopen scientific
+data. Use a session—not a workflow preset—when spectra, roles, ROIs, peaks,
+detector calibration, plot ranges, and provenance must be reproducible. See
+[SESSION_FORMAT.md](SESSION_FORMAT.md) for migration and recovery details.
 
 ### Path C: Maintained Replay Workflow
 
@@ -205,14 +216,14 @@ The most important bundled user-facing data locations are:
 ## 6. Where to Find More Detail
 
 - Setup and environment troubleshooting:
-  [docs/INSTALLATION.md](/groupspace/cnerg/users/smandych/projects/ALARA/FluxForge/docs/INSTALLATION.md:1)
+  [INSTALLATION.md](INSTALLATION.md)
 - Full CLI catalog:
-  [docs/CLI_REFERENCE.md](/groupspace/cnerg/users/smandych/projects/ALARA/FluxForge/docs/CLI_REFERENCE.md:1)
+  [CLI_REFERENCE.md](CLI_REFERENCE.md)
 - Maintained cookbook workflows:
-  [docs/EXAMPLE_WORKFLOWS.md](/groupspace/cnerg/users/smandych/projects/ALARA/FluxForge/docs/EXAMPLE_WORKFLOWS.md:1)
+  [EXAMPLE_WORKFLOWS.md](EXAMPLE_WORKFLOWS.md)
 - Full example inventory:
-  [examples/README.md](/groupspace/cnerg/users/smandych/projects/ALARA/FluxForge/examples/README.md:1)
+  [examples/README.md](../examples/README.md)
 - Quick onboarding:
-  [docs/tutorials/0_quick_start.md](/groupspace/cnerg/users/smandych/projects/ALARA/FluxForge/docs/tutorials/0_quick_start.md:1)
+  [tutorials/0_quick_start.md](tutorials/0_quick_start.md)
 - Guided first session:
-  [docs/tutorials/1_getting_started.md](/groupspace/cnerg/users/smandych/projects/ALARA/FluxForge/docs/tutorials/1_getting_started.md:1)
+  [tutorials/1_getting_started.md](tutorials/1_getting_started.md)

--- a/docs/tutorials/1_getting_started.md
+++ b/docs/tutorials/1_getting_started.md
@@ -48,13 +48,23 @@ Use these first files:
 
 Recommended first interactions:
 
-1. Load the foreground and background spectra.
-2. Zoom into a photopeak region.
-3. Drag the ROI directly on the main canvas.
-4. Drag the sideband handles if you want ROI-sideband background handling.
-5. Select a peak and drag its centroid to refine it.
-6. Right-click near a peak to use context actions such as select peak, use peak ROI, clear ID, delete peak, add manual peak, and assign the current source role.
-7. Watch the linked peak table, ROI panel, and other shell panels update as you change the selection.
+1. Choose **File > Open Example**, or load the foreground and background
+   spectra above and assign their roles in the left sidebar.
+2. Use the mouse wheel or **Zoom + / Zoom -** to inspect a photopeak region;
+   left-drag pans and **Reset View** restores the full range.
+3. Choose **Select ROI** and drag the displayed ROI bounds.
+4. Choose the sideband or SNIP method in the ROI tools when you want a
+   background model, then run ROI analysis or ROI statistics.
+5. Run **Auto Find Peaks**, accept the reviewed proposals, and select a row to
+   synchronize the plot, peak tools, and nuclide browser.
+6. Use the peak-table controls to assign or clear an isotope, add a tag, or pin
+   a nuclide.
+7. Choose **File > Save Session** (`Ctrl+S`) to persist spectra, roles, ROIs,
+   peaks, detector state, and plot ranges in a validated `.ffs` file.
+
+Direct plot-sideband handles, centroid dragging, and peak context menus are not
+part of the current production workflow. They remain tracked direct-manipulation
+work rather than being presented as working controls.
 
 ## 3. First CLI Session
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ fluxforge = [
     "gui/themes/*.qss",
     "reporting/templates/*.j2",
     "resources/schemas/*.xsd",
+    "resources/schemas/*.json",
 ]
 
 [tool.black]

--- a/src/fluxforge/core/__init__.py
+++ b/src/fluxforge/core/__init__.py
@@ -1,5 +1,7 @@
 """Core data structures and utilities."""
 
+from importlib import import_module
+
 from fluxforge.core.calibration import (
     ASTM_E181_ENERGY_LIMIT_KEV,
     ASTM_E181_LOCKED_ORDER,
@@ -89,4 +91,35 @@ __all__ = [
     "calculate_ce_table",
     "calculate_closure_metrics",
     "create_validation_bundle",
+    # Loaded lazily so fluxforge.io.spe can import calibration without a
+    # core -> workspace_document -> io package cycle.
+    "WORKSPACE_DOCUMENT_SCHEMA",
+    "WORKSPACE_DOCUMENT_VERSION",
+    "AnalysisROI",
+    "CalibrationModel",
+    "CanvasViewport",
+    "CorrectionSettings",
+    "DetectorGeometry",
+    "DetectorProfile",
+    "EfficiencyModelState",
+    "FitDiagnostics",
+    "NuclideAssignment",
+    "PeakComponent",
+    "PeakModel",
+    "SpectrumRoleAssignment",
+    "WorkspaceDocument",
+    "WorkspaceSpectrum",
+    "WorkspaceValidationError",
 ]
+
+
+_WORKSPACE_DOCUMENT_EXPORTS = frozenset(__all__[-17:])
+
+
+def __getattr__(name: str):
+    if name not in _WORKSPACE_DOCUMENT_EXPORTS:
+        raise AttributeError(name)
+    module = import_module("fluxforge.core.workspace_document")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value

--- a/src/fluxforge/core/workspace_document.py
+++ b/src/fluxforge/core/workspace_document.py
@@ -1,0 +1,1949 @@
+"""Versioned, Qt-independent persisted analysis state."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from math import isfinite
+from numbers import Real
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Mapping, Sequence
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing only; avoids core/io import cycles
+    from fluxforge.io.spe import GammaSpectrum
+
+
+WORKSPACE_DOCUMENT_SCHEMA = "fluxforge.workspace_document.v2"
+WORKSPACE_DOCUMENT_VERSION = 2
+
+
+class WorkspaceValidationError(ValueError):
+    """A field-specific invalid workspace value."""
+
+    def __init__(self, path: str, message: str) -> None:
+        self.path = path
+        self.message = message
+        super().__init__(f"{path}: {message}")
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _frozen_mapping(value: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    return MappingProxyType(
+        {key: _freeze_json(item) for key, item in dict(value or {}).items()}
+    )
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _frozen_mapping(value)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_json(item) for item in value)
+    return deepcopy(value)
+
+
+def _thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return deepcopy(value)
+
+
+def _mapping(value: Any, path: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise WorkspaceValidationError(path, "must be an object")
+    return value
+
+
+def _sequence(value: Any, path: str) -> Sequence[Any]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise WorkspaceValidationError(path, "must be an array")
+    return value
+
+
+def _reject_unknown(payload: Mapping[str, Any], allowed: set[str], path: str) -> None:
+    non_string = [key for key in payload if not isinstance(key, str)]
+    if non_string:
+        raise WorkspaceValidationError(path, "object field names must be strings")
+    unknown = sorted(set(payload).difference(allowed))
+    if unknown:
+        raise WorkspaceValidationError(
+            path, "contains unknown fields: " + ", ".join(unknown)
+        )
+
+
+def _required_text(value: Any, path: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise WorkspaceValidationError(path, "must be a non-empty string")
+    return value.strip()
+
+
+def _optional_text(value: Any, path: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise WorkspaceValidationError(path, "must be a string or null")
+    text = value.strip()
+    return text or None
+
+
+def _text(value: Any, path: str) -> str:
+    """Return a string without accepting or normalizing another JSON type."""
+
+    if not isinstance(value, str):
+        raise WorkspaceValidationError(path, "must be a string")
+    return value
+
+
+def _text_items(value: Any, path: str, *, non_empty: bool = True) -> tuple[str, ...]:
+    items = _sequence(value, path)
+    validator = _required_text if non_empty else _text
+    return tuple(
+        validator(item, f"{path}[{index}]") for index, item in enumerate(items)
+    )
+
+
+def _number(value: Any, path: str, *, minimum: float | None = None) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise WorkspaceValidationError(path, "must be a finite number")
+    result = float(value)
+    if not isfinite(result):
+        raise WorkspaceValidationError(path, "must be finite")
+    if minimum is not None and result < minimum:
+        raise WorkspaceValidationError(path, f"must be at least {minimum}")
+    return result
+
+
+def _optional_number(
+    value: Any, path: str, *, minimum: float | None = None
+) -> float | None:
+    if value is None:
+        return None
+    return _number(value, path, minimum=minimum)
+
+
+def _integer(value: Any, path: str, *, minimum: int | None = None) -> int:
+    """Return a strict integer, rejecting booleans and lossy conversions."""
+
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise WorkspaceValidationError(path, "must be an integer")
+    if minimum is not None and value < minimum:
+        raise WorkspaceValidationError(path, f"must be at least {minimum}")
+    return value
+
+
+def _pair(value: Any, path: str) -> tuple[float, float]:
+    items = _sequence(value, path)
+    if len(items) != 2:
+        raise WorkspaceValidationError(path, "must contain exactly two values")
+    return (_number(items[0], f"{path}[0]"), _number(items[1], f"{path}[1]"))
+
+
+def _optional_pair(value: Any, path: str) -> tuple[float, float] | None:
+    return None if value is None else _pair(value, path)
+
+
+def _validate_range(value: tuple[float, float] | None, path: str) -> None:
+    if value is None:
+        return
+    if not all(isfinite(float(item)) for item in value) or value[0] >= value[1]:
+        raise WorkspaceValidationError(path, "must be a finite increasing range")
+
+
+def _matrix(value: Any, path: str) -> tuple[tuple[float, ...], ...]:
+    if value is None:
+        return ()
+    rows = _sequence(value, path)
+    return tuple(
+        tuple(
+            _number(item, f"{path}[{row_index}][{column_index}]")
+            for column_index, item in enumerate(_sequence(row, f"{path}[{row_index}]"))
+        )
+        for row_index, row in enumerate(rows)
+    )
+
+
+def _validate_covariance(value: tuple[tuple[float, ...], ...], path: str) -> None:
+    if not value:
+        return
+    size = len(value)
+    if any(len(row) != size for row in value):
+        raise WorkspaceValidationError(path, "must be square")
+    matrix = np.asarray(value, dtype=float)
+    if not np.all(np.isfinite(matrix)):
+        raise WorkspaceValidationError(path, "must contain only finite values")
+    if not np.allclose(matrix, matrix.T, rtol=1.0e-10, atol=1.0e-12):
+        raise WorkspaceValidationError(path, "must be symmetric")
+    eigenvalues = np.linalg.eigvalsh((matrix + matrix.T) * 0.5)
+    tolerance = max(float(np.max(np.abs(eigenvalues))), 1.0) * 1.0e-10
+    if float(np.min(eigenvalues)) < -tolerance:
+        raise WorkspaceValidationError(path, "must be positive semidefinite")
+
+
+def _validate_json_finite(value: Any, path: str) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise WorkspaceValidationError(path, "object keys must be strings")
+            _validate_json_finite(item, f"{path}.{key}")
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _validate_json_finite(item, f"{path}[{index}]")
+    elif isinstance(value, float):
+        if not isfinite(value):
+            raise WorkspaceValidationError(path, "must be finite")
+    elif value is None or isinstance(value, (str, bool, int)):
+        return
+    else:
+        raise WorkspaceValidationError(
+            path,
+            f"must contain JSON-compatible values, not {type(value).__name__}",
+        )
+
+
+def _validate_spectrum_payload(value: Any, path: str) -> dict[str, Any]:
+    """Validate the persisted GammaSpectrum shape before its legacy reader runs."""
+
+    data = dict(_mapping(value, path))
+    allowed = {
+        "counts",
+        "counts_uncertainty",
+        "channels",
+        "energies",
+        "live_time",
+        "real_time",
+        "start_time",
+        "spectrum_id",
+        "detector_id",
+        "calibration",
+        "source_type",
+        "device_id",
+        "device_label",
+        "gps",
+        "metadata",
+    }
+    _reject_unknown(data, allowed, path)
+    if "counts" not in data:
+        raise WorkspaceValidationError(f"{path}.counts", "is required")
+    for name in ("counts", "channels"):
+        for index, item in enumerate(_sequence(data.get(name, ()), f"{path}.{name}")):
+            minimum = 0.0 if name == "counts" else None
+            _number(item, f"{path}.{name}[{index}]", minimum=minimum)
+    for name in ("counts_uncertainty", "energies"):
+        raw = data.get(name)
+        if raw is None:
+            continue
+        for index, item in enumerate(_sequence(raw, f"{path}.{name}")):
+            minimum = 0.0 if name == "counts_uncertainty" else None
+            _number(item, f"{path}.{name}[{index}]", minimum=minimum)
+    _number(data.get("live_time", 0.0), f"{path}.live_time", minimum=0.0)
+    _number(data.get("real_time", 0.0), f"{path}.real_time", minimum=0.0)
+    _optional_text(data.get("start_time"), f"{path}.start_time")
+    for name, default in (
+        ("spectrum_id", ""),
+        ("detector_id", ""),
+        ("source_type", "file"),
+        ("device_id", ""),
+        ("device_label", ""),
+    ):
+        _text(data.get(name, default), f"{path}.{name}")
+    for name in ("calibration", "gps", "metadata"):
+        mapping = _mapping(data.get(name, {}), f"{path}.{name}")
+        _validate_json_finite(mapping, f"{path}.{name}")
+    return data
+
+
+@dataclass(frozen=True)
+class WorkspaceSpectrum:
+    spectrum_id: str
+    spectrum: "GammaSpectrum"
+    label: str = ""
+    source_path: str | None = None
+    source_hash: str | None = None
+    detector_profile_id: str | None = None
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+    extensions: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "provenance", _frozen_mapping(self.provenance))
+        object.__setattr__(self, "extensions", _frozen_mapping(self.extensions))
+
+    def validate(self, path: str = "spectra[]") -> None:
+        _required_text(self.spectrum_id, f"{path}.spectrum_id")
+        _text(self.label, f"{path}.label")
+        _optional_text(self.source_path, f"{path}.source_path")
+        _optional_text(self.source_hash, f"{path}.source_hash")
+        _optional_text(self.detector_profile_id, f"{path}.detector_profile_id")
+        if not hasattr(self.spectrum, "counts") or not hasattr(
+            self.spectrum, "to_dict"
+        ):
+            raise WorkspaceValidationError(
+                f"{path}.spectrum", "must be a GammaSpectrum"
+            )
+        counts = np.asarray(self.spectrum.counts, dtype=float)
+        uncertainty = np.asarray(self.spectrum.counts_uncertainty, dtype=float)
+        channels = np.asarray(self.spectrum.channels, dtype=float)
+        if counts.ndim != 1 or not np.all(np.isfinite(counts)):
+            raise WorkspaceValidationError(
+                f"{path}.spectrum.counts", "must be a finite one-dimensional array"
+            )
+        if np.any(counts < 0.0):
+            raise WorkspaceValidationError(
+                f"{path}.spectrum.counts", "must not contain negative counts"
+            )
+        if (
+            uncertainty.shape != counts.shape
+            or np.any(uncertainty < 0.0)
+            or not np.all(np.isfinite(uncertainty))
+        ):
+            raise WorkspaceValidationError(
+                f"{path}.spectrum.counts_uncertainty",
+                "must be finite, non-negative, and match counts",
+            )
+        if channels.shape != counts.shape or not np.all(np.isfinite(channels)):
+            raise WorkspaceValidationError(
+                f"{path}.spectrum.channels", "must be finite and match counts"
+            )
+        energies = getattr(self.spectrum, "energies", None)
+        if energies is not None:
+            energy_values = np.asarray(energies, dtype=float)
+            if energy_values.shape != counts.shape or not np.all(
+                np.isfinite(energy_values)
+            ):
+                raise WorkspaceValidationError(
+                    f"{path}.spectrum.energies", "must be finite and match counts"
+                )
+        _number(self.spectrum.live_time, f"{path}.spectrum.live_time", minimum=0.0)
+        _number(self.spectrum.real_time, f"{path}.spectrum.real_time", minimum=0.0)
+        if self.spectrum.start_time is not None and not isinstance(
+            self.spectrum.start_time, datetime
+        ):
+            raise WorkspaceValidationError(
+                f"{path}.spectrum.start_time", "must be a datetime or null"
+            )
+        for name in (
+            "spectrum_id",
+            "detector_id",
+            "source_type",
+            "device_id",
+            "device_label",
+        ):
+            _text(getattr(self.spectrum, name), f"{path}.spectrum.{name}")
+        for name in ("calibration", "gps", "metadata"):
+            mapping = _mapping(getattr(self.spectrum, name), f"{path}.spectrum.{name}")
+            _validate_json_finite(mapping, f"{path}.spectrum.{name}")
+        _validate_json_finite(self.provenance, f"{path}.provenance")
+        _validate_json_finite(self.extensions, f"{path}.extensions")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "spectrum_id": self.spectrum_id,
+            "label": self.label,
+            "source_path": self.source_path,
+            "source_hash": self.source_hash,
+            "detector_profile_id": self.detector_profile_id,
+            "spectrum": self.spectrum.to_dict(),
+            "provenance": _thaw_json(self.provenance),
+            "extensions": _thaw_json(self.extensions),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "WorkspaceSpectrum":
+        data = _mapping(payload, "spectrum")
+        _reject_unknown(
+            data,
+            {
+                "spectrum_id",
+                "label",
+                "source_path",
+                "source_hash",
+                "detector_profile_id",
+                "spectrum",
+                "provenance",
+                "extensions",
+            },
+            "spectrum",
+        )
+        from fluxforge.io.spe import GammaSpectrum
+
+        try:
+            spectrum = GammaSpectrum.from_dict(
+                _validate_spectrum_payload(data.get("spectrum"), "spectrum.spectrum")
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise WorkspaceValidationError("spectrum.spectrum", str(exc)) from exc
+        result = cls(
+            spectrum_id=_required_text(data.get("spectrum_id"), "spectrum.spectrum_id"),
+            spectrum=spectrum,
+            label=_text(data.get("label", ""), "spectrum.label"),
+            source_path=_optional_text(data.get("source_path"), "spectrum.source_path"),
+            source_hash=_optional_text(data.get("source_hash"), "spectrum.source_hash"),
+            detector_profile_id=_optional_text(
+                data.get("detector_profile_id"), "spectrum.detector_profile_id"
+            ),
+            provenance=_mapping(data.get("provenance", {}), "spectrum.provenance"),
+            extensions=_mapping(data.get("extensions", {}), "spectrum.extensions"),
+        )
+        result.validate("spectrum")
+        return result
+
+
+@dataclass(frozen=True)
+class SpectrumRoleAssignment:
+    role: str
+    spectrum_ids: tuple[str, ...]
+
+    def validate(self, path: str = "spectrum_roles[]") -> None:
+        _required_text(self.role, f"{path}.role")
+        if not self.spectrum_ids:
+            raise WorkspaceValidationError(f"{path}.spectrum_ids", "must not be empty")
+        if len(set(self.spectrum_ids)) != len(self.spectrum_ids):
+            raise WorkspaceValidationError(
+                f"{path}.spectrum_ids", "must contain unique IDs"
+            )
+        for index, spectrum_id in enumerate(self.spectrum_ids):
+            _required_text(spectrum_id, f"{path}.spectrum_ids[{index}]")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {"role": self.role, "spectrum_ids": list(self.spectrum_ids)}
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SpectrumRoleAssignment":
+        data = _mapping(payload, "spectrum_role")
+        _reject_unknown(data, {"role", "spectrum_ids"}, "spectrum_role")
+        ids = tuple(
+            _required_text(value, f"spectrum_role.spectrum_ids[{index}]")
+            for index, value in enumerate(
+                _sequence(data.get("spectrum_ids"), "spectrum_role.spectrum_ids")
+            )
+        )
+        result = cls(
+            role=_required_text(data.get("role"), "spectrum_role.role"),
+            spectrum_ids=ids,
+        )
+        result.validate("spectrum_role")
+        return result
+
+
+@dataclass(frozen=True)
+class AnalysisROI:
+    roi_id: str
+    spectrum_id: str
+    signal_range: tuple[float, float]
+    left_background_range: tuple[float, float]
+    right_background_range: tuple[float, float]
+    associated_peak_ids: tuple[str, ...] = ()
+    fit_revision: int = 0
+    label: str = ""
+    color: str = "#2dd4bf"
+
+    def validate(self, path: str = "rois[]") -> None:
+        _required_text(self.roi_id, f"{path}.roi_id")
+        _required_text(self.spectrum_id, f"{path}.spectrum_id")
+        _validate_range(self.signal_range, f"{path}.signal_range")
+        _validate_range(self.left_background_range, f"{path}.left_background_range")
+        _validate_range(self.right_background_range, f"{path}.right_background_range")
+        if self.left_background_range[1] > self.signal_range[0]:
+            raise WorkspaceValidationError(
+                f"{path}.left_background_range", "must end before the signal range"
+            )
+        if self.right_background_range[0] < self.signal_range[1]:
+            raise WorkspaceValidationError(
+                f"{path}.right_background_range", "must start after the signal range"
+            )
+        _integer(self.fit_revision, f"{path}.fit_revision", minimum=0)
+        if len(set(self.associated_peak_ids)) != len(self.associated_peak_ids):
+            raise WorkspaceValidationError(
+                f"{path}.associated_peak_ids", "must contain unique IDs"
+            )
+        for index, peak_id in enumerate(self.associated_peak_ids):
+            _required_text(peak_id, f"{path}.associated_peak_ids[{index}]")
+        if not isinstance(self.label, str):
+            raise WorkspaceValidationError(f"{path}.label", "must be a string")
+        _required_text(self.color, f"{path}.color")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "roi_id": self.roi_id,
+            "spectrum_id": self.spectrum_id,
+            "signal_range": list(self.signal_range),
+            "left_background_range": list(self.left_background_range),
+            "right_background_range": list(self.right_background_range),
+            "associated_peak_ids": list(self.associated_peak_ids),
+            "fit_revision": self.fit_revision,
+            "label": self.label,
+            "color": self.color,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "AnalysisROI":
+        data = _mapping(payload, "roi")
+        _reject_unknown(
+            data,
+            {
+                "roi_id",
+                "spectrum_id",
+                "signal_range",
+                "left_background_range",
+                "right_background_range",
+                "associated_peak_ids",
+                "fit_revision",
+                "label",
+                "color",
+            },
+            "roi",
+        )
+        result = cls(
+            roi_id=_required_text(data.get("roi_id"), "roi.roi_id"),
+            spectrum_id=_required_text(data.get("spectrum_id"), "roi.spectrum_id"),
+            signal_range=_pair(data.get("signal_range"), "roi.signal_range"),
+            left_background_range=_pair(
+                data.get("left_background_range"), "roi.left_background_range"
+            ),
+            right_background_range=_pair(
+                data.get("right_background_range"), "roi.right_background_range"
+            ),
+            associated_peak_ids=_text_items(
+                data.get("associated_peak_ids", ()), "roi.associated_peak_ids"
+            ),
+            fit_revision=_integer(
+                data.get("fit_revision", 0), "roi.fit_revision", minimum=0
+            ),
+            label=(
+                data.get("label", "")
+                if isinstance(data.get("label", ""), str)
+                else (_raise_validation("roi.label", "must be a string"))
+            ),
+            color=_required_text(data.get("color", "#2dd4bf"), "roi.color"),
+        )
+        result.validate("roi")
+        return result
+
+
+@dataclass(frozen=True)
+class PeakComponent:
+    component_id: str
+    shape: str
+    centroid: float
+    area: float = 0.0
+    amplitude: float = 0.0
+    fwhm: float = 0.0
+    uncertainty: float = 0.0
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "parameters", _frozen_mapping(self.parameters))
+        object.__setattr__(self, "provenance", _frozen_mapping(self.provenance))
+
+    def validate(self, path: str = "components[]") -> None:
+        _required_text(self.component_id, f"{path}.component_id")
+        _required_text(self.shape, f"{path}.shape")
+        _number(self.centroid, f"{path}.centroid")
+        for name in ("area", "amplitude", "fwhm", "uncertainty"):
+            _number(getattr(self, name), f"{path}.{name}", minimum=0.0)
+        _validate_json_finite(self.parameters, f"{path}.parameters")
+        _validate_json_finite(self.provenance, f"{path}.provenance")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "component_id": self.component_id,
+            "shape": self.shape,
+            "centroid": self.centroid,
+            "area": self.area,
+            "amplitude": self.amplitude,
+            "fwhm": self.fwhm,
+            "uncertainty": self.uncertainty,
+            "parameters": _thaw_json(self.parameters),
+            "provenance": _thaw_json(self.provenance),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "PeakComponent":
+        data = _mapping(payload, "component")
+        _reject_unknown(
+            data,
+            {
+                "component_id",
+                "shape",
+                "centroid",
+                "area",
+                "amplitude",
+                "fwhm",
+                "uncertainty",
+                "parameters",
+                "provenance",
+            },
+            "component",
+        )
+        result = cls(
+            component_id=_required_text(
+                data.get("component_id"), "component.component_id"
+            ),
+            shape=_required_text(data.get("shape"), "component.shape"),
+            centroid=_number(data.get("centroid"), "component.centroid"),
+            area=_number(data.get("area", 0.0), "component.area", minimum=0.0),
+            amplitude=_number(
+                data.get("amplitude", 0.0), "component.amplitude", minimum=0.0
+            ),
+            fwhm=_number(data.get("fwhm", 0.0), "component.fwhm", minimum=0.0),
+            uncertainty=_number(
+                data.get("uncertainty", 0.0), "component.uncertainty", minimum=0.0
+            ),
+            parameters=_mapping(data.get("parameters", {}), "component.parameters"),
+            provenance=_mapping(data.get("provenance", {}), "component.provenance"),
+        )
+        result.validate("component")
+        return result
+
+
+@dataclass(frozen=True)
+class NuclideAssignment:
+    nuclide: str
+    line_energy_keV: float
+    library_id: str = ""
+    confidence: float | None = None
+    manual: bool = False
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "provenance", _frozen_mapping(self.provenance))
+
+    def validate(self, path: str = "assignments[]") -> None:
+        _required_text(self.nuclide, f"{path}.nuclide")
+        _text(self.library_id, f"{path}.library_id")
+        _number(self.line_energy_keV, f"{path}.line_energy_keV", minimum=0.0)
+        if self.confidence is not None and not 0.0 <= self.confidence <= 1.0:
+            raise WorkspaceValidationError(f"{path}.confidence", "must be within 0..1")
+        if not isinstance(self.manual, bool):
+            raise WorkspaceValidationError(f"{path}.manual", "must be a boolean")
+        _validate_json_finite(self.provenance, f"{path}.provenance")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "nuclide": self.nuclide,
+            "line_energy_keV": self.line_energy_keV,
+            "library_id": self.library_id,
+            "confidence": self.confidence,
+            "manual": self.manual,
+            "provenance": _thaw_json(self.provenance),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "NuclideAssignment":
+        data = _mapping(payload, "assignment")
+        _reject_unknown(
+            data,
+            {
+                "nuclide",
+                "line_energy_keV",
+                "library_id",
+                "confidence",
+                "manual",
+                "provenance",
+            },
+            "assignment",
+        )
+        manual = data.get("manual", False)
+        if not isinstance(manual, bool):
+            raise WorkspaceValidationError("assignment.manual", "must be a boolean")
+        result = cls(
+            nuclide=_required_text(data.get("nuclide"), "assignment.nuclide"),
+            line_energy_keV=_number(
+                data.get("line_energy_keV"), "assignment.line_energy_keV", minimum=0.0
+            ),
+            library_id=_text(data.get("library_id", ""), "assignment.library_id"),
+            confidence=_optional_number(
+                data.get("confidence"), "assignment.confidence", minimum=0.0
+            ),
+            manual=manual,
+            provenance=_mapping(data.get("provenance", {}), "assignment.provenance"),
+        )
+        result.validate("assignment")
+        return result
+
+
+@dataclass(frozen=True)
+class PeakModel:
+    peak_id: str
+    spectrum_id: str
+    roi_id: str | None
+    centroid_channel: float
+    centroid_energy_keV: float
+    shape: str = "gaussian"
+    components: tuple[PeakComponent, ...] = ()
+    assignments: tuple[NuclideAssignment, ...] = ()
+    tags: tuple[str, ...] = ()
+    status: str = "candidate"
+    manual_overrides: Mapping[str, Any] = field(default_factory=dict)
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+    net_counts: float = 0.0
+    significance: float = 0.0
+    fit_quality: float = 0.0
+    candidate_nuclides: tuple[str, ...] = ()
+    reference_lines_keV: tuple[float, ...] = ()
+    normalized_residuals: tuple[float, ...] = ()
+    residual_channels: tuple[float, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "manual_overrides", _frozen_mapping(self.manual_overrides)
+        )
+        object.__setattr__(self, "provenance", _frozen_mapping(self.provenance))
+
+    def validate(self, path: str = "peaks[]") -> None:
+        _required_text(self.peak_id, f"{path}.peak_id")
+        _required_text(self.spectrum_id, f"{path}.spectrum_id")
+        _optional_text(self.roi_id, f"{path}.roi_id")
+        _required_text(self.shape, f"{path}.shape")
+        _required_text(self.status, f"{path}.status")
+        _number(self.centroid_channel, f"{path}.centroid_channel", minimum=0.0)
+        _number(self.centroid_energy_keV, f"{path}.centroid_energy_keV", minimum=0.0)
+        # Background-subtracted net areas may be negative.  Preserve them so an
+        # analyst can review the invalid/non-detection state instead of clipping.
+        _number(self.net_counts, f"{path}.net_counts")
+        _number(self.significance, f"{path}.significance", minimum=0.0)
+        _number(self.fit_quality, f"{path}.fit_quality", minimum=0.0)
+        component_ids = [component.component_id for component in self.components]
+        if len(component_ids) != len(set(component_ids)):
+            raise WorkspaceValidationError(f"{path}.components", "IDs must be unique")
+        for index, component in enumerate(self.components):
+            component.validate(f"{path}.components[{index}]")
+        for index, assignment in enumerate(self.assignments):
+            assignment.validate(f"{path}.assignments[{index}]")
+        for name, values in (
+            ("tags", self.tags),
+            ("candidate_nuclides", self.candidate_nuclides),
+        ):
+            for index, value in enumerate(values):
+                _required_text(value, f"{path}.{name}[{index}]")
+        if len(self.normalized_residuals) != len(self.residual_channels):
+            raise WorkspaceValidationError(
+                f"{path}.normalized_residuals",
+                "must match residual_channels length",
+            )
+        for name, values in (
+            ("reference_lines_keV", self.reference_lines_keV),
+            ("normalized_residuals", self.normalized_residuals),
+            ("residual_channels", self.residual_channels),
+        ):
+            for index, value in enumerate(values):
+                _number(value, f"{path}.{name}[{index}]")
+        _validate_json_finite(self.manual_overrides, f"{path}.manual_overrides")
+        _validate_json_finite(self.provenance, f"{path}.provenance")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "peak_id": self.peak_id,
+            "spectrum_id": self.spectrum_id,
+            "roi_id": self.roi_id,
+            "centroid_channel": self.centroid_channel,
+            "centroid_energy_keV": self.centroid_energy_keV,
+            "shape": self.shape,
+            "components": [item.to_dict() for item in self.components],
+            "assignments": [item.to_dict() for item in self.assignments],
+            "tags": list(self.tags),
+            "status": self.status,
+            "manual_overrides": _thaw_json(self.manual_overrides),
+            "provenance": _thaw_json(self.provenance),
+            "net_counts": self.net_counts,
+            "significance": self.significance,
+            "fit_quality": self.fit_quality,
+            "candidate_nuclides": list(self.candidate_nuclides),
+            "reference_lines_keV": list(self.reference_lines_keV),
+            "normalized_residuals": list(self.normalized_residuals),
+            "residual_channels": list(self.residual_channels),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "PeakModel":
+        data = _mapping(payload, "peak")
+        allowed = {
+            "peak_id",
+            "spectrum_id",
+            "roi_id",
+            "centroid_channel",
+            "centroid_energy_keV",
+            "shape",
+            "components",
+            "assignments",
+            "tags",
+            "status",
+            "manual_overrides",
+            "provenance",
+            "net_counts",
+            "significance",
+            "fit_quality",
+            "candidate_nuclides",
+            "reference_lines_keV",
+            "normalized_residuals",
+            "residual_channels",
+        }
+        _reject_unknown(data, allowed, "peak")
+        result = cls(
+            peak_id=_required_text(data.get("peak_id"), "peak.peak_id"),
+            spectrum_id=_required_text(data.get("spectrum_id"), "peak.spectrum_id"),
+            roi_id=_optional_text(data.get("roi_id"), "peak.roi_id"),
+            centroid_channel=_number(
+                data.get("centroid_channel"), "peak.centroid_channel", minimum=0.0
+            ),
+            centroid_energy_keV=_number(
+                data.get("centroid_energy_keV"),
+                "peak.centroid_energy_keV",
+                minimum=0.0,
+            ),
+            shape=_required_text(data.get("shape", "gaussian"), "peak.shape"),
+            components=tuple(
+                PeakComponent.from_dict(item)
+                for item in _sequence(data.get("components", ()), "peak.components")
+            ),
+            assignments=tuple(
+                NuclideAssignment.from_dict(item)
+                for item in _sequence(data.get("assignments", ()), "peak.assignments")
+            ),
+            tags=_text_items(data.get("tags", ()), "peak.tags"),
+            status=_required_text(data.get("status", "candidate"), "peak.status"),
+            manual_overrides=_mapping(
+                data.get("manual_overrides", {}), "peak.manual_overrides"
+            ),
+            provenance=_mapping(data.get("provenance", {}), "peak.provenance"),
+            net_counts=_number(data.get("net_counts", 0.0), "peak.net_counts"),
+            significance=_number(
+                data.get("significance", 0.0), "peak.significance", minimum=0.0
+            ),
+            fit_quality=_number(
+                data.get("fit_quality", 0.0), "peak.fit_quality", minimum=0.0
+            ),
+            candidate_nuclides=_text_items(
+                data.get("candidate_nuclides", ()), "peak.candidate_nuclides"
+            ),
+            reference_lines_keV=tuple(
+                _number(item, f"peak.reference_lines_keV[{index}]")
+                for index, item in enumerate(
+                    _sequence(
+                        data.get("reference_lines_keV", ()), "peak.reference_lines_keV"
+                    )
+                )
+            ),
+            normalized_residuals=tuple(
+                _number(item, f"peak.normalized_residuals[{index}]")
+                for index, item in enumerate(
+                    _sequence(
+                        data.get("normalized_residuals", ()),
+                        "peak.normalized_residuals",
+                    )
+                )
+            ),
+            residual_channels=tuple(
+                _number(item, f"peak.residual_channels[{index}]")
+                for index, item in enumerate(
+                    _sequence(
+                        data.get("residual_channels", ()), "peak.residual_channels"
+                    )
+                )
+            ),
+        )
+        result.validate("peak")
+        return result
+
+
+@dataclass(frozen=True)
+class CalibrationModel:
+    model_key: str
+    coefficients: tuple[float, ...]
+    calibration_points: tuple[tuple[float, float], ...] = ()
+    deviation_pairs: tuple[tuple[float, float], ...] = ()
+    covariance: tuple[tuple[float, ...], ...] = ()
+    valid_range: tuple[float, float] | None = None
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "provenance", _frozen_mapping(self.provenance))
+
+    def validate(self, path: str = "calibration") -> None:
+        _required_text(self.model_key, f"{path}.model_key")
+        if not self.coefficients:
+            raise WorkspaceValidationError(f"{path}.coefficients", "must not be empty")
+        for index, value in enumerate(self.coefficients):
+            _number(value, f"{path}.coefficients[{index}]")
+        for name, values in (
+            ("calibration_points", self.calibration_points),
+            ("deviation_pairs", self.deviation_pairs),
+        ):
+            for index, value in enumerate(values):
+                if len(value) != 2:
+                    raise WorkspaceValidationError(
+                        f"{path}.{name}[{index}]", "must contain exactly two values"
+                    )
+                _number(value[0], f"{path}.{name}[{index}][0]")
+                _number(value[1], f"{path}.{name}[{index}][1]")
+        _validate_covariance(self.covariance, f"{path}.covariance")
+        if self.covariance and len(self.covariance) != len(self.coefficients):
+            raise WorkspaceValidationError(
+                f"{path}.covariance", "dimension must match coefficients"
+            )
+        _validate_range(self.valid_range, f"{path}.valid_range")
+        _validate_json_finite(self.provenance, f"{path}.provenance")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "model_key": self.model_key,
+            "coefficients": list(self.coefficients),
+            "calibration_points": [list(item) for item in self.calibration_points],
+            "deviation_pairs": [list(item) for item in self.deviation_pairs],
+            "covariance": [list(row) for row in self.covariance],
+            "valid_range": list(self.valid_range) if self.valid_range else None,
+            "provenance": _thaw_json(self.provenance),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CalibrationModel":
+        data = _mapping(payload, "calibration")
+        _reject_unknown(
+            data,
+            {
+                "model_key",
+                "coefficients",
+                "calibration_points",
+                "deviation_pairs",
+                "covariance",
+                "valid_range",
+                "provenance",
+            },
+            "calibration",
+        )
+        result = cls(
+            model_key=_required_text(data.get("model_key"), "calibration.model_key"),
+            coefficients=tuple(
+                _number(item, f"calibration.coefficients[{index}]")
+                for index, item in enumerate(
+                    _sequence(data.get("coefficients"), "calibration.coefficients")
+                )
+            ),
+            calibration_points=tuple(
+                _pair(item, f"calibration.calibration_points[{index}]")
+                for index, item in enumerate(
+                    _sequence(
+                        data.get("calibration_points", ()),
+                        "calibration.calibration_points",
+                    )
+                )
+            ),
+            deviation_pairs=tuple(
+                _pair(item, f"calibration.deviation_pairs[{index}]")
+                for index, item in enumerate(
+                    _sequence(
+                        data.get("deviation_pairs", ()), "calibration.deviation_pairs"
+                    )
+                )
+            ),
+            covariance=_matrix(data.get("covariance", ()), "calibration.covariance"),
+            valid_range=_optional_pair(
+                data.get("valid_range"), "calibration.valid_range"
+            ),
+            provenance=_mapping(data.get("provenance", {}), "calibration.provenance"),
+        )
+        result.validate("calibration")
+        return result
+
+
+@dataclass(frozen=True)
+class EfficiencyModelState:
+    model_key: str
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+    points: tuple[Mapping[str, Any], ...] = ()
+    covariance: tuple[tuple[float, ...], ...] = ()
+    uncertainty_model: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "parameters", _frozen_mapping(self.parameters))
+        object.__setattr__(
+            self, "points", tuple(_frozen_mapping(item) for item in self.points)
+        )
+        object.__setattr__(
+            self, "uncertainty_model", _frozen_mapping(self.uncertainty_model)
+        )
+
+    def validate(self, path: str = "efficiency_model") -> None:
+        _required_text(self.model_key, f"{path}.model_key")
+        _validate_json_finite(self.parameters, f"{path}.parameters")
+        _validate_json_finite(self.points, f"{path}.points")
+        _validate_covariance(self.covariance, f"{path}.covariance")
+        _validate_json_finite(self.uncertainty_model, f"{path}.uncertainty_model")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "model_key": self.model_key,
+            "parameters": _thaw_json(self.parameters),
+            "points": [_thaw_json(item) for item in self.points],
+            "covariance": [list(row) for row in self.covariance],
+            "uncertainty_model": _thaw_json(self.uncertainty_model),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "EfficiencyModelState":
+        data = _mapping(payload, "efficiency_model")
+        _reject_unknown(
+            data,
+            {"model_key", "parameters", "points", "covariance", "uncertainty_model"},
+            "efficiency_model",
+        )
+        result = cls(
+            model_key=_required_text(
+                data.get("model_key"), "efficiency_model.model_key"
+            ),
+            parameters=_mapping(
+                data.get("parameters", {}), "efficiency_model.parameters"
+            ),
+            points=tuple(
+                _mapping(item, f"efficiency_model.points[{index}]")
+                for index, item in enumerate(
+                    _sequence(data.get("points", ()), "efficiency_model.points")
+                )
+            ),
+            covariance=_matrix(
+                data.get("covariance", ()), "efficiency_model.covariance"
+            ),
+            uncertainty_model=_mapping(
+                data.get("uncertainty_model", {}),
+                "efficiency_model.uncertainty_model",
+            ),
+        )
+        result.validate("efficiency_model")
+        return result
+
+
+@dataclass(frozen=True)
+class DetectorGeometry:
+    crystal_diameter_cm: float | None = None
+    crystal_length_cm: float | None = None
+    dead_layer_um: float | None = None
+    window_material: str | None = None
+    window_thickness_um: float | None = None
+    distance_cm: float | None = None
+    angle_deg: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", _frozen_mapping(self.metadata))
+
+    def validate(self, path: str = "geometry") -> None:
+        _optional_text(self.window_material, f"{path}.window_material")
+        for name in (
+            "crystal_diameter_cm",
+            "crystal_length_cm",
+            "dead_layer_um",
+            "window_thickness_um",
+            "distance_cm",
+        ):
+            _optional_number(getattr(self, name), f"{path}.{name}", minimum=0.0)
+        _optional_number(self.angle_deg, f"{path}.angle_deg")
+        _validate_json_finite(self.metadata, f"{path}.metadata")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "crystal_diameter_cm": self.crystal_diameter_cm,
+            "crystal_length_cm": self.crystal_length_cm,
+            "dead_layer_um": self.dead_layer_um,
+            "window_material": self.window_material,
+            "window_thickness_um": self.window_thickness_um,
+            "distance_cm": self.distance_cm,
+            "angle_deg": self.angle_deg,
+            "metadata": _thaw_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "DetectorGeometry":
+        data = _mapping(payload, "geometry")
+        allowed = {
+            "crystal_diameter_cm",
+            "crystal_length_cm",
+            "dead_layer_um",
+            "window_material",
+            "window_thickness_um",
+            "distance_cm",
+            "angle_deg",
+            "metadata",
+        }
+        _reject_unknown(data, allowed, "geometry")
+        result = cls(
+            crystal_diameter_cm=_optional_number(
+                data.get("crystal_diameter_cm"),
+                "geometry.crystal_diameter_cm",
+                minimum=0.0,
+            ),
+            crystal_length_cm=_optional_number(
+                data.get("crystal_length_cm"),
+                "geometry.crystal_length_cm",
+                minimum=0.0,
+            ),
+            dead_layer_um=_optional_number(
+                data.get("dead_layer_um"), "geometry.dead_layer_um", minimum=0.0
+            ),
+            window_material=_optional_text(
+                data.get("window_material"), "geometry.window_material"
+            ),
+            window_thickness_um=_optional_number(
+                data.get("window_thickness_um"),
+                "geometry.window_thickness_um",
+                minimum=0.0,
+            ),
+            distance_cm=_optional_number(
+                data.get("distance_cm"), "geometry.distance_cm", minimum=0.0
+            ),
+            angle_deg=_optional_number(data.get("angle_deg"), "geometry.angle_deg"),
+            metadata=_mapping(data.get("metadata", {}), "geometry.metadata"),
+        )
+        result.validate("geometry")
+        return result
+
+
+@dataclass(frozen=True)
+class CorrectionSettings:
+    attenuation_enabled: bool = False
+    self_shielding_enabled: bool = False
+    summing_enabled: bool = False
+    dead_time_enabled: bool = True
+    pileup_enabled: bool = False
+    geometry_enabled: bool = True
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "parameters", _frozen_mapping(self.parameters))
+
+    def validate(self, path: str = "corrections") -> None:
+        for name in (
+            "attenuation_enabled",
+            "self_shielding_enabled",
+            "summing_enabled",
+            "dead_time_enabled",
+            "pileup_enabled",
+            "geometry_enabled",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise WorkspaceValidationError(f"{path}.{name}", "must be a boolean")
+        _validate_json_finite(self.parameters, f"{path}.parameters")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "attenuation_enabled": self.attenuation_enabled,
+            "self_shielding_enabled": self.self_shielding_enabled,
+            "summing_enabled": self.summing_enabled,
+            "dead_time_enabled": self.dead_time_enabled,
+            "pileup_enabled": self.pileup_enabled,
+            "geometry_enabled": self.geometry_enabled,
+            "parameters": _thaw_json(self.parameters),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CorrectionSettings":
+        data = _mapping(payload, "corrections")
+        allowed = {
+            "attenuation_enabled",
+            "self_shielding_enabled",
+            "summing_enabled",
+            "dead_time_enabled",
+            "pileup_enabled",
+            "geometry_enabled",
+            "parameters",
+        }
+        _reject_unknown(data, allowed, "corrections")
+        bool_values = {}
+        defaults = {
+            "attenuation_enabled": False,
+            "self_shielding_enabled": False,
+            "summing_enabled": False,
+            "dead_time_enabled": True,
+            "pileup_enabled": False,
+            "geometry_enabled": True,
+        }
+        for key, default in defaults.items():
+            value = data.get(key, default)
+            if not isinstance(value, bool):
+                raise WorkspaceValidationError(
+                    f"corrections.{key}", "must be a boolean"
+                )
+            bool_values[key] = value
+        result = cls(
+            **bool_values,
+            parameters=_mapping(data.get("parameters", {}), "corrections.parameters"),
+        )
+        result.validate("corrections")
+        return result
+
+
+@dataclass(frozen=True)
+class DetectorProfile:
+    detector_profile_id: str
+    detector_id: str = ""
+    energy_calibration: CalibrationModel | None = None
+    fwhm_calibration: CalibrationModel | None = None
+    efficiency_model: EfficiencyModelState | None = None
+    geometry: DetectorGeometry = field(default_factory=DetectorGeometry)
+    uncertainty: Mapping[str, Any] = field(default_factory=dict)
+    covariance: tuple[tuple[float, ...], ...] = ()
+    corrections: CorrectionSettings = field(default_factory=CorrectionSettings)
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+    extensions: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "uncertainty", _frozen_mapping(self.uncertainty))
+        object.__setattr__(self, "provenance", _frozen_mapping(self.provenance))
+        object.__setattr__(self, "extensions", _frozen_mapping(self.extensions))
+
+    def validate(self, path: str = "detector_profiles[]") -> None:
+        _required_text(self.detector_profile_id, f"{path}.detector_profile_id")
+        _text(self.detector_id, f"{path}.detector_id")
+        if self.energy_calibration:
+            self.energy_calibration.validate(f"{path}.energy_calibration")
+        if self.fwhm_calibration:
+            self.fwhm_calibration.validate(f"{path}.fwhm_calibration")
+        if self.efficiency_model:
+            self.efficiency_model.validate(f"{path}.efficiency_model")
+        self.geometry.validate(f"{path}.geometry")
+        self.corrections.validate(f"{path}.corrections")
+        _validate_covariance(self.covariance, f"{path}.covariance")
+        _validate_json_finite(self.uncertainty, f"{path}.uncertainty")
+        _validate_json_finite(self.provenance, f"{path}.provenance")
+        _validate_json_finite(self.extensions, f"{path}.extensions")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "detector_profile_id": self.detector_profile_id,
+            "detector_id": self.detector_id,
+            "energy_calibration": (
+                self.energy_calibration.to_dict() if self.energy_calibration else None
+            ),
+            "fwhm_calibration": (
+                self.fwhm_calibration.to_dict() if self.fwhm_calibration else None
+            ),
+            "efficiency_model": (
+                self.efficiency_model.to_dict() if self.efficiency_model else None
+            ),
+            "geometry": self.geometry.to_dict(),
+            "uncertainty": _thaw_json(self.uncertainty),
+            "covariance": [list(row) for row in self.covariance],
+            "corrections": self.corrections.to_dict(),
+            "provenance": _thaw_json(self.provenance),
+            "extensions": _thaw_json(self.extensions),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "DetectorProfile":
+        data = _mapping(payload, "detector_profile")
+        allowed = {
+            "detector_profile_id",
+            "detector_id",
+            "energy_calibration",
+            "fwhm_calibration",
+            "efficiency_model",
+            "geometry",
+            "uncertainty",
+            "covariance",
+            "corrections",
+            "provenance",
+            "extensions",
+        }
+        _reject_unknown(data, allowed, "detector_profile")
+        result = cls(
+            detector_profile_id=_required_text(
+                data.get("detector_profile_id"),
+                "detector_profile.detector_profile_id",
+            ),
+            detector_id=_text(
+                data.get("detector_id", ""), "detector_profile.detector_id"
+            ),
+            energy_calibration=(
+                CalibrationModel.from_dict(data["energy_calibration"])
+                if data.get("energy_calibration") is not None
+                else None
+            ),
+            fwhm_calibration=(
+                CalibrationModel.from_dict(data["fwhm_calibration"])
+                if data.get("fwhm_calibration") is not None
+                else None
+            ),
+            efficiency_model=(
+                EfficiencyModelState.from_dict(data["efficiency_model"])
+                if data.get("efficiency_model") is not None
+                else None
+            ),
+            geometry=DetectorGeometry.from_dict(data.get("geometry", {})),
+            uncertainty=_mapping(
+                data.get("uncertainty", {}), "detector_profile.uncertainty"
+            ),
+            covariance=_matrix(
+                data.get("covariance", ()), "detector_profile.covariance"
+            ),
+            corrections=CorrectionSettings.from_dict(data.get("corrections", {})),
+            provenance=_mapping(
+                data.get("provenance", {}), "detector_profile.provenance"
+            ),
+            extensions=_mapping(
+                data.get("extensions", {}), "detector_profile.extensions"
+            ),
+        )
+        result.validate("detector_profile")
+        return result
+
+
+@dataclass(frozen=True)
+class FitDiagnostics:
+    diagnostic_id: str
+    spectrum_id: str
+    fit_revision: int
+    status: str
+    roi_id: str | None = None
+    peak_id: str | None = None
+    x: tuple[float, ...] = ()
+    observed: tuple[float, ...] = ()
+    model: tuple[float, ...] = ()
+    uncertainty: tuple[float, ...] = ()
+    normalized_residuals: tuple[float, ...] = ()
+    goodness_of_fit: Mapping[str, Any] = field(default_factory=dict)
+    warning_flags: tuple[str, ...] = ()
+    method: str = ""
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "goodness_of_fit", _frozen_mapping(self.goodness_of_fit)
+        )
+        object.__setattr__(self, "provenance", _frozen_mapping(self.provenance))
+
+    def validate(self, path: str = "fit_diagnostics[]") -> None:
+        _required_text(self.diagnostic_id, f"{path}.diagnostic_id")
+        _required_text(self.spectrum_id, f"{path}.spectrum_id")
+        _optional_text(self.roi_id, f"{path}.roi_id")
+        _optional_text(self.peak_id, f"{path}.peak_id")
+        _text(self.method, f"{path}.method")
+        if self.status not in {"valid", "invalid"}:
+            raise WorkspaceValidationError(f"{path}.status", "must be valid or invalid")
+        _integer(self.fit_revision, f"{path}.fit_revision", minimum=0)
+        lengths = {
+            len(self.x),
+            len(self.observed),
+            len(self.model),
+            len(self.uncertainty),
+            len(self.normalized_residuals),
+        }
+        if self.status == "valid" and (not self.observed or len(lengths) != 1):
+            raise WorkspaceValidationError(
+                path,
+                "valid diagnostics require equal non-empty x/observed/model/uncertainty/residual arrays",
+            )
+        if self.status == "invalid" and any(
+            (
+                self.x,
+                self.observed,
+                self.model,
+                self.uncertainty,
+                self.normalized_residuals,
+            )
+        ):
+            populated_lengths = {
+                len(values)
+                for values in (
+                    self.x,
+                    self.observed,
+                    self.model,
+                    self.uncertainty,
+                    self.normalized_residuals,
+                )
+                if values
+            }
+            if len(populated_lengths) != 1:
+                raise WorkspaceValidationError(
+                    path, "populated diagnostic arrays must have equal lengths"
+                )
+        for name in ("x", "observed", "model", "uncertainty", "normalized_residuals"):
+            for index, value in enumerate(getattr(self, name)):
+                minimum = 0.0 if name == "uncertainty" else None
+                _number(value, f"{path}.{name}[{index}]", minimum=minimum)
+        for index, flag in enumerate(self.warning_flags):
+            _required_text(flag, f"{path}.warning_flags[{index}]")
+        _validate_json_finite(self.goodness_of_fit, f"{path}.goodness_of_fit")
+        _validate_json_finite(self.provenance, f"{path}.provenance")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "diagnostic_id": self.diagnostic_id,
+            "spectrum_id": self.spectrum_id,
+            "roi_id": self.roi_id,
+            "peak_id": self.peak_id,
+            "fit_revision": self.fit_revision,
+            "status": self.status,
+            "x": list(self.x),
+            "observed": list(self.observed),
+            "model": list(self.model),
+            "uncertainty": list(self.uncertainty),
+            "normalized_residuals": list(self.normalized_residuals),
+            "goodness_of_fit": _thaw_json(self.goodness_of_fit),
+            "warning_flags": list(self.warning_flags),
+            "method": self.method,
+            "provenance": _thaw_json(self.provenance),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "FitDiagnostics":
+        data = _mapping(payload, "fit_diagnostics")
+        allowed = {
+            "diagnostic_id",
+            "spectrum_id",
+            "roi_id",
+            "peak_id",
+            "fit_revision",
+            "status",
+            "x",
+            "observed",
+            "model",
+            "uncertainty",
+            "normalized_residuals",
+            "goodness_of_fit",
+            "warning_flags",
+            "method",
+            "provenance",
+        }
+        _reject_unknown(data, allowed, "fit_diagnostics")
+
+        def values(name: str) -> tuple[float, ...]:
+            return tuple(
+                _number(item, f"fit_diagnostics.{name}[{index}]")
+                for index, item in enumerate(
+                    _sequence(data.get(name, ()), f"fit_diagnostics.{name}")
+                )
+            )
+
+        result = cls(
+            diagnostic_id=_required_text(
+                data.get("diagnostic_id"), "fit_diagnostics.diagnostic_id"
+            ),
+            spectrum_id=_required_text(
+                data.get("spectrum_id"), "fit_diagnostics.spectrum_id"
+            ),
+            roi_id=_optional_text(data.get("roi_id"), "fit_diagnostics.roi_id"),
+            peak_id=_optional_text(data.get("peak_id"), "fit_diagnostics.peak_id"),
+            fit_revision=_integer(
+                data.get("fit_revision", 0),
+                "fit_diagnostics.fit_revision",
+                minimum=0,
+            ),
+            status=_required_text(
+                data.get("status", "invalid"), "fit_diagnostics.status"
+            ),
+            x=values("x"),
+            observed=values("observed"),
+            model=values("model"),
+            uncertainty=values("uncertainty"),
+            normalized_residuals=values("normalized_residuals"),
+            goodness_of_fit=_mapping(
+                data.get("goodness_of_fit", {}),
+                "fit_diagnostics.goodness_of_fit",
+            ),
+            warning_flags=_text_items(
+                data.get("warning_flags", ()), "fit_diagnostics.warning_flags"
+            ),
+            method=_text(data.get("method", ""), "fit_diagnostics.method"),
+            provenance=_mapping(
+                data.get("provenance", {}), "fit_diagnostics.provenance"
+            ),
+        )
+        result.validate("fit_diagnostics")
+        return result
+
+
+@dataclass(frozen=True)
+class CanvasViewport:
+    viewport_id: str
+    spectrum_id: str | None = None
+    x_range: tuple[float, float] | None = None
+    y_range: tuple[float, float] | None = None
+    x_unit: str = "channel"
+    y_unit: str = "counts"
+    log_x: bool = False
+    log_y: bool = False
+    overlays: tuple[str, ...] = ()
+    residual_mode: str = "off"
+    selected_roi_id: str | None = None
+    crosshair_enabled: bool = False
+    labels_visible: bool = True
+
+    def validate(self, path: str = "viewports[]") -> None:
+        _required_text(self.viewport_id, f"{path}.viewport_id")
+        _optional_text(self.spectrum_id, f"{path}.spectrum_id")
+        _required_text(self.x_unit, f"{path}.x_unit")
+        _required_text(self.y_unit, f"{path}.y_unit")
+        _optional_text(self.selected_roi_id, f"{path}.selected_roi_id")
+        _validate_range(self.x_range, f"{path}.x_range")
+        _validate_range(self.y_range, f"{path}.y_range")
+        if self.residual_mode not in {"off", "compact", "full"}:
+            raise WorkspaceValidationError(
+                f"{path}.residual_mode", "must be off, compact, or full"
+            )
+        for index, overlay in enumerate(self.overlays):
+            _required_text(overlay, f"{path}.overlays[{index}]")
+        for name in ("log_x", "log_y", "crosshair_enabled", "labels_visible"):
+            if not isinstance(getattr(self, name), bool):
+                raise WorkspaceValidationError(f"{path}.{name}", "must be a boolean")
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "viewport_id": self.viewport_id,
+            "spectrum_id": self.spectrum_id,
+            "x_range": list(self.x_range) if self.x_range else None,
+            "y_range": list(self.y_range) if self.y_range else None,
+            "x_unit": self.x_unit,
+            "y_unit": self.y_unit,
+            "log_x": self.log_x,
+            "log_y": self.log_y,
+            "overlays": list(self.overlays),
+            "residual_mode": self.residual_mode,
+            "selected_roi_id": self.selected_roi_id,
+            "crosshair_enabled": self.crosshair_enabled,
+            "labels_visible": self.labels_visible,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CanvasViewport":
+        data = _mapping(payload, "viewport")
+        allowed = {
+            "viewport_id",
+            "spectrum_id",
+            "x_range",
+            "y_range",
+            "x_unit",
+            "y_unit",
+            "log_x",
+            "log_y",
+            "overlays",
+            "residual_mode",
+            "selected_roi_id",
+            "crosshair_enabled",
+            "labels_visible",
+        }
+        _reject_unknown(data, allowed, "viewport")
+        bool_values = {}
+        for key, default in (
+            ("log_x", False),
+            ("log_y", False),
+            ("crosshair_enabled", False),
+            ("labels_visible", True),
+        ):
+            value = data.get(key, default)
+            if not isinstance(value, bool):
+                raise WorkspaceValidationError(f"viewport.{key}", "must be a boolean")
+            bool_values[key] = value
+        result = cls(
+            viewport_id=_required_text(data.get("viewport_id"), "viewport.viewport_id"),
+            spectrum_id=_optional_text(data.get("spectrum_id"), "viewport.spectrum_id"),
+            x_range=_optional_pair(data.get("x_range"), "viewport.x_range"),
+            y_range=_optional_pair(data.get("y_range"), "viewport.y_range"),
+            x_unit=_required_text(data.get("x_unit", "channel"), "viewport.x_unit"),
+            y_unit=_required_text(data.get("y_unit", "counts"), "viewport.y_unit"),
+            overlays=_text_items(data.get("overlays", ()), "viewport.overlays"),
+            residual_mode=_required_text(
+                data.get("residual_mode", "off"), "viewport.residual_mode"
+            ),
+            selected_roi_id=_optional_text(
+                data.get("selected_roi_id"), "viewport.selected_roi_id"
+            ),
+            **bool_values,
+        )
+        result.validate("viewport")
+        return result
+
+
+@dataclass(frozen=True)
+class WorkspaceDocument:
+    document_id: str = "workspace"
+    title: str = ""
+    created_at: str = field(default_factory=_utc_timestamp)
+    updated_at: str = field(default_factory=_utc_timestamp)
+    spectra: tuple[WorkspaceSpectrum, ...] = ()
+    spectrum_roles: tuple[SpectrumRoleAssignment, ...] = ()
+    active_spectrum_id: str | None = None
+    rois: tuple[AnalysisROI, ...] = ()
+    peaks: tuple[PeakModel, ...] = ()
+    detector_profiles: tuple[DetectorProfile, ...] = ()
+    fit_diagnostics: tuple[FitDiagnostics, ...] = ()
+    viewports: tuple[CanvasViewport, ...] = ()
+    pinned_nuclides: tuple[str, ...] = ()
+    nuclide_tags: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+    plot_settings: Mapping[str, Any] = field(default_factory=dict)
+    workflow_state: Mapping[str, Any] = field(default_factory=dict)
+    provenance: Mapping[str, Any] = field(default_factory=dict)
+    extensions: Mapping[str, Any] = field(default_factory=dict)
+    schema: str = WORKSPACE_DOCUMENT_SCHEMA
+    schema_version: int = WORKSPACE_DOCUMENT_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "nuclide_tags",
+            MappingProxyType(
+                {key: tuple(value) for key, value in dict(self.nuclide_tags).items()}
+            ),
+        )
+        for name in ("plot_settings", "workflow_state", "provenance", "extensions"):
+            object.__setattr__(self, name, _frozen_mapping(getattr(self, name)))
+
+    def spectrum_by_id(self, spectrum_id: str) -> WorkspaceSpectrum | None:
+        return next(
+            (item for item in self.spectra if item.spectrum_id == spectrum_id), None
+        )
+
+    def roi_by_id(self, roi_id: str) -> AnalysisROI | None:
+        return next((item for item in self.rois if item.roi_id == roi_id), None)
+
+    def peak_by_id(self, spectrum_id: str, peak_id: str) -> PeakModel | None:
+        return next(
+            (
+                item
+                for item in self.peaks
+                if item.spectrum_id == spectrum_id and item.peak_id == peak_id
+            ),
+            None,
+        )
+
+    def detector_profile_by_id(self, profile_id: str) -> DetectorProfile | None:
+        return next(
+            (
+                item
+                for item in self.detector_profiles
+                if item.detector_profile_id == profile_id
+            ),
+            None,
+        )
+
+    def viewport_by_id(self, viewport_id: str) -> CanvasViewport | None:
+        return next(
+            (item for item in self.viewports if item.viewport_id == viewport_id), None
+        )
+
+    def validate(self) -> None:
+        if self.schema != WORKSPACE_DOCUMENT_SCHEMA:
+            raise WorkspaceValidationError("schema", "is unsupported")
+        if self.schema_version != WORKSPACE_DOCUMENT_VERSION:
+            raise WorkspaceValidationError("schema_version", "is unsupported")
+        _required_text(self.document_id, "document_id")
+        _text(self.title, "title")
+        _required_text(self.created_at, "created_at")
+        _required_text(self.updated_at, "updated_at")
+
+        spectrum_ids = _validate_unique(
+            [item.spectrum_id for item in self.spectra], "spectra", "spectrum_id"
+        )
+        profile_ids = _validate_unique(
+            [item.detector_profile_id for item in self.detector_profiles],
+            "detector_profiles",
+            "detector_profile_id",
+        )
+        roi_ids = _validate_unique(
+            [item.roi_id for item in self.rois], "rois", "roi_id"
+        )
+        diagnostic_ids = _validate_unique(
+            [item.diagnostic_id for item in self.fit_diagnostics],
+            "fit_diagnostics",
+            "diagnostic_id",
+        )
+        viewport_ids = _validate_unique(
+            [item.viewport_id for item in self.viewports], "viewports", "viewport_id"
+        )
+        del diagnostic_ids, viewport_ids
+        peak_keys: set[tuple[str, str]] = set()
+
+        for index, item in enumerate(self.spectra):
+            item.validate(f"spectra[{index}]")
+            if item.detector_profile_id and item.detector_profile_id not in profile_ids:
+                raise WorkspaceValidationError(
+                    f"spectra[{index}].detector_profile_id",
+                    "references an unknown profile",
+                )
+        if (
+            self.active_spectrum_id is not None
+            and self.active_spectrum_id not in spectrum_ids
+        ):
+            raise WorkspaceValidationError(
+                "active_spectrum_id", "references an unknown spectrum"
+            )
+
+        roles: set[str] = set()
+        for index, role in enumerate(self.spectrum_roles):
+            role.validate(f"spectrum_roles[{index}]")
+            if role.role in roles:
+                raise WorkspaceValidationError(
+                    f"spectrum_roles[{index}].role", "must be unique"
+                )
+            roles.add(role.role)
+            for spectrum_id in role.spectrum_ids:
+                if spectrum_id not in spectrum_ids:
+                    raise WorkspaceValidationError(
+                        f"spectrum_roles[{index}].spectrum_ids",
+                        "references an unknown spectrum",
+                    )
+
+        for index, profile in enumerate(self.detector_profiles):
+            profile.validate(f"detector_profiles[{index}]")
+        for index, peak in enumerate(self.peaks):
+            peak.validate(f"peaks[{index}]")
+            key = (peak.spectrum_id, peak.peak_id)
+            if key in peak_keys:
+                raise WorkspaceValidationError(
+                    f"peaks[{index}].peak_id", "must be unique within its spectrum"
+                )
+            peak_keys.add(key)
+            if peak.spectrum_id not in spectrum_ids:
+                raise WorkspaceValidationError(
+                    f"peaks[{index}].spectrum_id", "references an unknown spectrum"
+                )
+            if peak.roi_id is not None and peak.roi_id not in roi_ids:
+                raise WorkspaceValidationError(
+                    f"peaks[{index}].roi_id", "references an unknown ROI"
+                )
+
+        for index, roi in enumerate(self.rois):
+            roi.validate(f"rois[{index}]")
+            if roi.spectrum_id not in spectrum_ids:
+                raise WorkspaceValidationError(
+                    f"rois[{index}].spectrum_id", "references an unknown spectrum"
+                )
+            for peak_id in roi.associated_peak_ids:
+                if (roi.spectrum_id, peak_id) not in peak_keys:
+                    raise WorkspaceValidationError(
+                        f"rois[{index}].associated_peak_ids",
+                        "references an unknown peak for the ROI spectrum",
+                    )
+
+        for index, diagnostic in enumerate(self.fit_diagnostics):
+            diagnostic.validate(f"fit_diagnostics[{index}]")
+            if diagnostic.spectrum_id not in spectrum_ids:
+                raise WorkspaceValidationError(
+                    f"fit_diagnostics[{index}].spectrum_id",
+                    "references an unknown spectrum",
+                )
+            if diagnostic.roi_id and diagnostic.roi_id not in roi_ids:
+                raise WorkspaceValidationError(
+                    f"fit_diagnostics[{index}].roi_id", "references an unknown ROI"
+                )
+            if (
+                diagnostic.peak_id
+                and (
+                    diagnostic.spectrum_id,
+                    diagnostic.peak_id,
+                )
+                not in peak_keys
+            ):
+                raise WorkspaceValidationError(
+                    f"fit_diagnostics[{index}].peak_id", "references an unknown peak"
+                )
+
+        for index, viewport in enumerate(self.viewports):
+            viewport.validate(f"viewports[{index}]")
+            if viewport.spectrum_id and viewport.spectrum_id not in spectrum_ids:
+                raise WorkspaceValidationError(
+                    f"viewports[{index}].spectrum_id", "references an unknown spectrum"
+                )
+            if viewport.selected_roi_id and viewport.selected_roi_id not in roi_ids:
+                raise WorkspaceValidationError(
+                    f"viewports[{index}].selected_roi_id", "references an unknown ROI"
+                )
+
+        if len(set(self.pinned_nuclides)) != len(self.pinned_nuclides):
+            raise WorkspaceValidationError(
+                "pinned_nuclides", "must contain unique values"
+            )
+        for index, value in enumerate(self.pinned_nuclides):
+            _required_text(value, f"pinned_nuclides[{index}]")
+        for nuclide, tags in self.nuclide_tags.items():
+            _required_text(nuclide, f"nuclide_tags.{nuclide}")
+            if len(set(tags)) != len(tags):
+                raise WorkspaceValidationError(
+                    f"nuclide_tags.{nuclide}", "must contain unique tags"
+                )
+            for index, tag in enumerate(tags):
+                _required_text(tag, f"nuclide_tags.{nuclide}[{index}]")
+        for name in ("plot_settings", "workflow_state", "provenance", "extensions"):
+            _validate_json_finite(getattr(self, name), name)
+
+    def to_dict(self) -> dict[str, Any]:
+        self.validate()
+        return {
+            "schema": self.schema,
+            "schema_version": self.schema_version,
+            "document_id": self.document_id,
+            "title": self.title,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "spectra": [item.to_dict() for item in self.spectra],
+            "spectrum_roles": [item.to_dict() for item in self.spectrum_roles],
+            "active_spectrum_id": self.active_spectrum_id,
+            "rois": [item.to_dict() for item in self.rois],
+            "peaks": [item.to_dict() for item in self.peaks],
+            "detector_profiles": [item.to_dict() for item in self.detector_profiles],
+            "fit_diagnostics": [item.to_dict() for item in self.fit_diagnostics],
+            "viewports": [item.to_dict() for item in self.viewports],
+            "pinned_nuclides": list(self.pinned_nuclides),
+            "nuclide_tags": {
+                key: list(values) for key, values in self.nuclide_tags.items()
+            },
+            "plot_settings": _thaw_json(self.plot_settings),
+            "workflow_state": _thaw_json(self.workflow_state),
+            "provenance": _thaw_json(self.provenance),
+            "extensions": _thaw_json(self.extensions),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "WorkspaceDocument":
+        data = _mapping(payload, "document")
+        allowed = {
+            "schema",
+            "schema_version",
+            "document_id",
+            "title",
+            "created_at",
+            "updated_at",
+            "spectra",
+            "spectrum_roles",
+            "active_spectrum_id",
+            "rois",
+            "peaks",
+            "detector_profiles",
+            "fit_diagnostics",
+            "viewports",
+            "pinned_nuclides",
+            "nuclide_tags",
+            "plot_settings",
+            "workflow_state",
+            "provenance",
+            "extensions",
+        }
+        _reject_unknown(data, allowed, "document")
+        schema = data.get("schema")
+        version = data.get("schema_version")
+        if schema != WORKSPACE_DOCUMENT_SCHEMA:
+            raise WorkspaceValidationError("schema", "is unsupported")
+        if version != WORKSPACE_DOCUMENT_VERSION:
+            raise WorkspaceValidationError("schema_version", "is unsupported")
+        raw_tags = _mapping(data.get("nuclide_tags", {}), "document.nuclide_tags")
+        result = cls(
+            document_id=_required_text(data.get("document_id"), "document.document_id"),
+            title=_text(data.get("title", ""), "document.title"),
+            created_at=_required_text(data.get("created_at"), "document.created_at"),
+            updated_at=_required_text(data.get("updated_at"), "document.updated_at"),
+            spectra=tuple(
+                WorkspaceSpectrum.from_dict(item)
+                for item in _sequence(data.get("spectra", ()), "document.spectra")
+            ),
+            spectrum_roles=tuple(
+                SpectrumRoleAssignment.from_dict(item)
+                for item in _sequence(
+                    data.get("spectrum_roles", ()), "document.spectrum_roles"
+                )
+            ),
+            active_spectrum_id=_optional_text(
+                data.get("active_spectrum_id"), "document.active_spectrum_id"
+            ),
+            rois=tuple(
+                AnalysisROI.from_dict(item)
+                for item in _sequence(data.get("rois", ()), "document.rois")
+            ),
+            peaks=tuple(
+                PeakModel.from_dict(item)
+                for item in _sequence(data.get("peaks", ()), "document.peaks")
+            ),
+            detector_profiles=tuple(
+                DetectorProfile.from_dict(item)
+                for item in _sequence(
+                    data.get("detector_profiles", ()), "document.detector_profiles"
+                )
+            ),
+            fit_diagnostics=tuple(
+                FitDiagnostics.from_dict(item)
+                for item in _sequence(
+                    data.get("fit_diagnostics", ()), "document.fit_diagnostics"
+                )
+            ),
+            viewports=tuple(
+                CanvasViewport.from_dict(item)
+                for item in _sequence(data.get("viewports", ()), "document.viewports")
+            ),
+            pinned_nuclides=_text_items(
+                data.get("pinned_nuclides", ()), "document.pinned_nuclides"
+            ),
+            nuclide_tags={
+                _required_text(key, "document.nuclide_tags key"): _text_items(
+                    value, f"document.nuclide_tags.{key}"
+                )
+                for key, value in raw_tags.items()
+            },
+            plot_settings=_mapping(
+                data.get("plot_settings", {}), "document.plot_settings"
+            ),
+            workflow_state=_mapping(
+                data.get("workflow_state", {}), "document.workflow_state"
+            ),
+            provenance=_mapping(data.get("provenance", {}), "document.provenance"),
+            extensions=_mapping(data.get("extensions", {}), "document.extensions"),
+            schema=_required_text(schema, "schema"),
+            schema_version=_integer(version, "schema_version", minimum=1),
+        )
+        result.validate()
+        return result
+
+
+def _validate_unique(values: list[str], path: str, field_name: str) -> set[str]:
+    seen: set[str] = set()
+    for index, value in enumerate(values):
+        _required_text(value, f"{path}[{index}].{field_name}")
+        if value in seen:
+            raise WorkspaceValidationError(
+                f"{path}[{index}].{field_name}", "must be unique"
+            )
+        seen.add(value)
+    return seen
+
+
+def _raise_validation(path: str, message: str) -> Any:
+    """Expression helper used while constructing frozen dataclasses."""
+
+    raise WorkspaceValidationError(path, message)
+
+
+__all__ = [
+    "WORKSPACE_DOCUMENT_SCHEMA",
+    "WORKSPACE_DOCUMENT_VERSION",
+    "AnalysisROI",
+    "CalibrationModel",
+    "CanvasViewport",
+    "CorrectionSettings",
+    "DetectorGeometry",
+    "DetectorProfile",
+    "EfficiencyModelState",
+    "FitDiagnostics",
+    "NuclideAssignment",
+    "PeakComponent",
+    "PeakModel",
+    "SpectrumRoleAssignment",
+    "WorkspaceDocument",
+    "WorkspaceSpectrum",
+    "WorkspaceValidationError",
+]

--- a/src/fluxforge/gui/__init__.py
+++ b/src/fluxforge/gui/__init__.py
@@ -30,6 +30,7 @@ from fluxforge.gui.file_workflow import RecentFilesManager, normalize_dropped_pa
 from fluxforge.gui.nuclide_search import NuclideSearchController
 from fluxforge.gui.qt_compat import QT_AVAILABLE
 from fluxforge.gui.selection_bus import SelectionBus, SelectionState
+from fluxforge.gui.canvas_intents import CanvasIntent, CanvasIntentKind
 from fluxforge.gui.workflow_presets import (
     DEFAULT_WORKFLOW_PRESETS,
     WorkflowPreset,
@@ -48,6 +49,8 @@ from fluxforge.gui.widgets import MethodSelectorWidget
 __all__ = [
     "DEFAULT_DOCK_ZONES",
     "CalibrationWorkspaceDialog",
+    "CanvasIntent",
+    "CanvasIntentKind",
     "DockZone",
     "FluxForgeMainWindow",
     "HierarchicalSpectrumBuffer",

--- a/src/fluxforge/gui/analysis_workspace.py
+++ b/src/fluxforge/gui/analysis_workspace.py
@@ -2,25 +2,40 @@
 
 from __future__ import annotations
 
-import copy
+import dataclasses
 import re
+from copy import copy as shallow_copy, deepcopy
 from dataclasses import dataclass, replace
-from typing import Callable, Sequence
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, Sequence
+
+import numpy as np
 
 from fluxforge.core.analysis_workspace import (
     ActivityCalculationResult,
     EfficiencyCalibrationFitResult,
     PeakCandidate,
+    ROIComponentFit,
     ROIAnalysisResult,
+    ROISpectrumStatistic,
     ROIStatisticsResult,
     SurveyPoint,
 )
-from fluxforge.gui.qt_compat import QT_AVAILABLE
+from fluxforge.core.workspace_document import (
+    AnalysisROI,
+    CalibrationModel,
+    CanvasViewport,
+    DetectorProfile,
+    FitDiagnostics,
+    NuclideAssignment,
+    PeakModel,
+    SpectrumRoleAssignment,
+    WorkspaceDocument,
+    WorkspaceSpectrum,
+)
+from fluxforge.data.efficiency import EfficiencyCurve
 from fluxforge.io.flux_wire import EfficiencyCalibration
 from fluxforge.io.spe import GammaSpectrum
-
-if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
-    from fluxforge.gui.qt_compat import QUndoCommand
 
 
 @dataclass(frozen=True)
@@ -72,18 +87,41 @@ class AnalysisWorkspaceState:
 
 
 WorkspaceListener = Callable[[AnalysisWorkspaceState], None]
+WorkspaceDocumentListener = Callable[[WorkspaceDocument], None]
 
 
 class AnalysisWorkspaceController:
-    """Observable state store for the modern analysis shell."""
+    """Observable adapter over the canonical, persisted workspace document.
 
-    def __init__(self, initial_state: AnalysisWorkspaceState | None = None) -> None:
-        self._state = initial_state or AnalysisWorkspaceState()
+    ``AnalysisWorkspaceState`` remains available while the Qt surfaces migrate, but
+    it is a projection.  All persisted state is owned by ``WorkspaceDocument``.
+    The adapter replaces only document leaves, so spectrum arrays and unrelated
+    analysis results are never copied during ordinary UI mutations.
+    """
+
+    def __init__(
+        self,
+        initial_state: AnalysisWorkspaceState | WorkspaceDocument | None = None,
+    ) -> None:
         self._listeners: list[WorkspaceListener] = []
+        self._document_listeners: list[WorkspaceDocumentListener] = []
+        if isinstance(initial_state, WorkspaceDocument):
+            initial_state.validate()
+            self._document = initial_state
+            self._state = self._state_from_document(initial_state)
+        else:
+            self._state = initial_state or AnalysisWorkspaceState()
+            self._document = self._document_from_state(self._state)
 
     @property
     def state(self) -> AnalysisWorkspaceState:
         return self._state
+
+    @property
+    def document(self) -> WorkspaceDocument:
+        """Return the immutable canonical analysis document."""
+
+        return self._document
 
     def subscribe(self, listener: WorkspaceListener) -> None:
         if listener not in self._listeners:
@@ -93,14 +131,48 @@ class AnalysisWorkspaceController:
         if listener in self._listeners:
             self._listeners.remove(listener)
 
+    def subscribe_document(self, listener: WorkspaceDocumentListener) -> None:
+        if listener not in self._document_listeners:
+            self._document_listeners.append(listener)
+
+    def unsubscribe_document(self, listener: WorkspaceDocumentListener) -> None:
+        if listener in self._document_listeners:
+            self._document_listeners.remove(listener)
+
+    def set_document(self, document: WorkspaceDocument) -> WorkspaceDocument:
+        """Replace the canonical document and rebuild the legacy projection."""
+
+        if not isinstance(document, WorkspaceDocument):
+            raise TypeError("document must be a WorkspaceDocument")
+        document.validate()
+        self._document = document
+        self._state = self._state_from_document(document)
+        self._notify()
+        return document
+
     def set_state(self, state: AnalysisWorkspaceState) -> AnalysisWorkspaceState:
+        """Accept a legacy projection and synchronize its persisted leaves."""
+
+        if not isinstance(state, AnalysisWorkspaceState):
+            raise TypeError("state must be an AnalysisWorkspaceState")
+        previous_state = self._state
         self._state = state
-        for listener in tuple(self._listeners):
-            listener(state)
+        self._document = self._document_from_state(
+            state,
+            base=self._document,
+            previous_state=previous_state,
+        )
+        self._notify()
         return state
 
     def update(self, **changes) -> AnalysisWorkspaceState:
         return self.set_state(replace(self._state, **changes))
+
+    def _notify(self) -> None:
+        for listener in tuple(self._document_listeners):
+            listener(self._document)
+        for listener in tuple(self._listeners):
+            listener(self._state)
 
     def spectrum(self, key: str | None = None) -> GammaSpectrum | None:
         target = key or self._state.active_spectrum_key
@@ -136,7 +208,9 @@ class AnalysisWorkspaceController:
         key: str | None = None,
     ) -> str:
         resolved_label = str(
-            label or spectrum.spectrum_id or (source_path.rsplit("/", 1)[-1] if source_path else "Spectrum")
+            label
+            or spectrum.spectrum_id
+            or (source_path.rsplit("/", 1)[-1] if source_path else "Spectrum")
         )
         resolved_key = key or self._unique_loaded_key(resolved_label)
         records = [
@@ -173,11 +247,17 @@ class AnalysisWorkspaceController:
                         key=slot.key,
                         label=slot.label,
                         spectrum=spectrum,
-                        source_key=source_key if source_key is not None else slot.source_key,
-                        source_label=(
-                            source_label if source_label is not None else slot.source_label
+                        source_key=(
+                            source_key if source_key is not None else slot.source_key
                         ),
-                        source_path=source_path if source_path is not None else slot.source_path,
+                        source_label=(
+                            source_label
+                            if source_label is not None
+                            else slot.source_label
+                        ),
+                        source_path=(
+                            source_path if source_path is not None else slot.source_path
+                        ),
                     )
                 )
                 matched = True
@@ -187,7 +267,11 @@ class AnalysisWorkspaceController:
             slots.append(
                 SpectrumSlot(
                     key=key,
-                    label=key.title(),
+                    label=(
+                        "Secondary Overlay"
+                        if key == "overlay"
+                        else key.replace("_", " ").title()
+                    ),
                     spectrum=spectrum,
                     source_key=source_key,
                     source_label=source_label,
@@ -233,13 +317,382 @@ class AnalysisWorkspaceController:
         return None
 
     def replace_peak(self, updated_peak: PeakCandidate) -> AnalysisWorkspaceState:
-        peaks = [
-            updated_peak if peak.peak_id == updated_peak.peak_id else peak
-            for peak in self._state.peaks
-        ]
+        peaks = list(self._state.peaks)
+        for index, peak in enumerate(peaks):
+            if peak.peak_id == updated_peak.peak_id:
+                peaks[index] = updated_peak
+                break
+        else:
+            peaks.append(updated_peak)
         return self.update(peaks=tuple(peaks))
 
-    def set_pinned_nuclides(self, pinned_nuclides: Sequence[str]) -> AnalysisWorkspaceState:
+    # Canonical leaf-edit API used by focused undo commands.  These methods
+    # intentionally retain every document field outside the named leaf.
+
+    def replace_peak_models(
+        self,
+        peaks: Sequence[PeakModel],
+        *,
+        spectrum_id: str | None = None,
+    ) -> WorkspaceDocument:
+        target = spectrum_id or self._document.active_spectrum_id
+        replacements = tuple(peaks)
+        if target is None and replacements:
+            target = replacements[0].spectrum_id
+        if target is None:
+            merged = self._document.peaks
+        else:
+            if any(item.spectrum_id != target for item in replacements):
+                raise ValueError(
+                    "all replacement peaks must target the selected spectrum"
+                )
+            pending = list(replacements)
+            merged_items: list[PeakModel] = []
+            last_target_position: int | None = None
+            for item in self._document.peaks:
+                if item.spectrum_id != target:
+                    merged_items.append(item)
+                    continue
+                if pending:
+                    merged_items.append(pending.pop(0))
+                    last_target_position = len(merged_items)
+            if pending:
+                insert_at = (
+                    last_target_position
+                    if last_target_position is not None
+                    else len(merged_items)
+                )
+                merged_items[insert_at:insert_at] = pending
+            merged = tuple(merged_items)
+        valid_peak_ids = {item.peak_id for item in replacements}
+        projected_rois = tuple(
+            replace(
+                roi,
+                associated_peak_ids=tuple(
+                    peak_id
+                    for peak_id in roi.associated_peak_ids
+                    if roi.spectrum_id != target or peak_id in valid_peak_ids
+                ),
+            )
+            for roi in self._document.rois
+        )
+        rois = (
+            self._document.rois
+            if projected_rois == self._document.rois
+            else projected_rois
+        )
+        diagnostics = tuple(
+            (
+                replace(item, peak_id=None)
+                if item.spectrum_id == target
+                and item.peak_id is not None
+                and item.peak_id not in valid_peak_ids
+                else item
+            )
+            for item in self._document.fit_diagnostics
+        )
+        return self._replace_document(
+            peaks=merged,
+            rois=rois,
+            fit_diagnostics=diagnostics,
+        )
+
+    def replace_all_peak_models(self, peaks: Sequence[PeakModel]) -> WorkspaceDocument:
+        """Replace the ordered peak-leaf collection without retaining spectra."""
+
+        return self._replace_document(peaks=tuple(peaks))
+
+    def upsert_peak_model(
+        self, peak: PeakModel, *, index: int | None = None
+    ) -> WorkspaceDocument:
+        items = list(self._document.peaks)
+        key = (peak.spectrum_id, peak.peak_id)
+        for current_index, current in enumerate(items):
+            if (current.spectrum_id, current.peak_id) == key:
+                items[current_index] = peak
+                break
+        else:
+            if index is None:
+                items.append(peak)
+            else:
+                items.insert(max(0, min(index, len(items))), peak)
+        return self._replace_document(peaks=tuple(items))
+
+    def delete_peak_model(self, spectrum_id: str, peak_id: str) -> WorkspaceDocument:
+        peaks = tuple(
+            item
+            for item in self._document.peaks
+            if (item.spectrum_id, item.peak_id) != (spectrum_id, peak_id)
+        )
+        rois = tuple(
+            (
+                replace(
+                    item,
+                    associated_peak_ids=tuple(
+                        value for value in item.associated_peak_ids if value != peak_id
+                    ),
+                )
+                if item.spectrum_id == spectrum_id
+                else item
+            )
+            for item in self._document.rois
+        )
+        diagnostics = tuple(
+            (
+                replace(item, peak_id=None)
+                if item.spectrum_id == spectrum_id and item.peak_id == peak_id
+                else item
+            )
+            for item in self._document.fit_diagnostics
+        )
+        return self._replace_document(
+            peaks=peaks,
+            rois=rois,
+            fit_diagnostics=diagnostics,
+        )
+
+    def upsert_roi(
+        self, roi: AnalysisROI, *, index: int | None = None
+    ) -> WorkspaceDocument:
+        items = list(self._document.rois)
+        for current_index, current in enumerate(items):
+            if current.roi_id == roi.roi_id:
+                items[current_index] = roi
+                break
+        else:
+            if index is None:
+                items.append(roi)
+            else:
+                items.insert(max(0, min(index, len(items))), roi)
+        return self._replace_document(rois=tuple(items))
+
+    def delete_roi(self, roi_id: str) -> WorkspaceDocument:
+        rois = tuple(item for item in self._document.rois if item.roi_id != roi_id)
+        peaks = tuple(
+            replace(item, roi_id=None) if item.roi_id == roi_id else item
+            for item in self._document.peaks
+        )
+        diagnostics = tuple(
+            replace(item, roi_id=None) if item.roi_id == roi_id else item
+            for item in self._document.fit_diagnostics
+        )
+        viewports = tuple(
+            (
+                replace(item, selected_roi_id=None)
+                if item.selected_roi_id == roi_id
+                else item
+            )
+            for item in self._document.viewports
+        )
+        return self._replace_document(
+            rois=rois,
+            peaks=peaks,
+            fit_diagnostics=diagnostics,
+            viewports=viewports,
+        )
+
+    def upsert_fit_diagnostic(self, diagnostic: FitDiagnostics) -> WorkspaceDocument:
+        items = list(self._document.fit_diagnostics)
+        for index, current in enumerate(items):
+            if current.diagnostic_id == diagnostic.diagnostic_id:
+                items[index] = diagnostic
+                break
+        else:
+            items.append(diagnostic)
+        return self._replace_document(fit_diagnostics=tuple(items))
+
+    def assign_spectrum_role(
+        self,
+        role: str,
+        spectrum_ids: str | Sequence[str] | None,
+    ) -> WorkspaceDocument:
+        if isinstance(spectrum_ids, str):
+            resolved_ids = (spectrum_ids,)
+        else:
+            resolved_ids = tuple(spectrum_ids or ())
+        roles = [item for item in self._document.spectrum_roles if item.role != role]
+        if resolved_ids:
+            roles.append(SpectrumRoleAssignment(role=role, spectrum_ids=resolved_ids))
+        return self._replace_document(spectrum_roles=tuple(roles))
+
+    def upsert_detector_profile(self, profile: DetectorProfile) -> WorkspaceDocument:
+        items = list(self._document.detector_profiles)
+        for index, current in enumerate(items):
+            if current.detector_profile_id == profile.detector_profile_id:
+                items[index] = profile
+                break
+        else:
+            items.append(profile)
+        return self._replace_document(detector_profiles=tuple(items))
+
+    def delete_detector_profile(self, profile_id: str) -> WorkspaceDocument:
+        profiles = tuple(
+            item
+            for item in self._document.detector_profiles
+            if item.detector_profile_id != profile_id
+        )
+        spectra = tuple(
+            (
+                replace(item, detector_profile_id=None)
+                if item.detector_profile_id == profile_id
+                else item
+            )
+            for item in self._document.spectra
+        )
+        return self._replace_document(detector_profiles=profiles, spectra=spectra)
+
+    def apply_calibration(
+        self,
+        spectrum_id: str,
+        calibration_state: CalibrationModel | DetectorProfile | None,
+    ) -> WorkspaceDocument:
+        """Apply one calibration/profile leaf to a copied spectrum container.
+
+        Counts, uncertainties, and channel arrays remain shared read-only inputs;
+        only the mutable ``GammaSpectrum`` container, calibration mapping, and
+        derived energy array are replaced.  This prevents a calibration preview
+        or undo operation from mutating the spectrum held by an earlier state.
+        """
+
+        workspace_spectrum = self._document.spectrum_by_id(spectrum_id)
+        if workspace_spectrum is None:
+            raise KeyError(f"Unknown spectrum ID: {spectrum_id}")
+        if calibration_state is not None and not isinstance(
+            calibration_state, (CalibrationModel, DetectorProfile)
+        ):
+            raise TypeError(
+                "calibration_state must be CalibrationModel, DetectorProfile, or None"
+            )
+
+        profiles = list(self._document.detector_profiles)
+        profile_id = workspace_spectrum.detector_profile_id
+        if isinstance(calibration_state, DetectorProfile):
+            profile = calibration_state
+            profile_id = profile.detector_profile_id
+            calibration = profile.energy_calibration
+        else:
+            profile = (
+                self._document.detector_profile_by_id(profile_id)
+                if profile_id is not None
+                else None
+            )
+            if profile is None and calibration_state is not None:
+                profile_id = f"{spectrum_id}-detector"
+                profile = DetectorProfile(
+                    detector_profile_id=profile_id,
+                    detector_id=str(workspace_spectrum.spectrum.detector_id or ""),
+                    energy_calibration=calibration_state,
+                )
+            elif profile is not None:
+                profile = replace(profile, energy_calibration=calibration_state)
+            calibration = calibration_state
+
+        if profile is not None:
+            for index, current in enumerate(profiles):
+                if current.detector_profile_id == profile.detector_profile_id:
+                    profiles[index] = profile
+                    break
+            else:
+                profiles.append(profile)
+
+        current_spectrum = workspace_spectrum.spectrum
+        calibrated_spectrum = shallow_copy(current_spectrum)
+        calibration_payload = dict(current_spectrum.calibration or {})
+        if calibration is None:
+            calibration_payload.pop("energy", None)
+            calibration_payload.pop("deviation_pairs", None)
+            calibrated_spectrum.energies = None
+        else:
+            calibration_payload["energy"] = [
+                float(value) for value in calibration.coefficients
+            ]
+            calibration_payload["deviation_pairs"] = [
+                {
+                    "energy_keV": float(energy),
+                    "correction_keV": float(correction),
+                }
+                for energy, correction in calibration.deviation_pairs
+            ]
+        calibrated_spectrum.calibration = calibration_payload
+        if calibration is not None:
+            calibrated_spectrum.energies = calibrated_spectrum.calibrate_channels()
+
+        spectra = tuple(
+            (
+                replace(
+                    item,
+                    spectrum=calibrated_spectrum,
+                    detector_profile_id=profile_id,
+                )
+                if item.spectrum_id == spectrum_id
+                else item
+            )
+            for item in self._document.spectra
+        )
+        return self._replace_document(
+            spectra=spectra,
+            detector_profiles=tuple(profiles),
+        )
+
+    def restore_calibration_state(
+        self, spectrum_id: str, state: Any
+    ) -> WorkspaceDocument:
+        """Restore the exact persisted leaves captured before calibration."""
+
+        from fluxforge.gui.workspace_undo import CalibrationUndoState
+
+        if not isinstance(state, CalibrationUndoState):
+            raise TypeError("state must be a CalibrationUndoState")
+        workspace_spectrum = self._document.spectrum_by_id(spectrum_id)
+        if workspace_spectrum is None:
+            raise KeyError(f"Unknown spectrum ID: {spectrum_id}")
+
+        restored_spectrum = shallow_copy(workspace_spectrum.spectrum)
+        restored_spectrum.calibration = deepcopy(state.calibration_payload)
+        restored_spectrum.energies = (
+            np.asarray(state.energies, dtype=float)
+            if state.energies is not None
+            else None
+        )
+        spectra = tuple(
+            (
+                replace(
+                    item,
+                    spectrum=restored_spectrum,
+                    detector_profile_id=state.detector_profile_id,
+                )
+                if item.spectrum_id == spectrum_id
+                else item
+            )
+            for item in self._document.spectra
+        )
+        return self._replace_document(
+            spectra=spectra,
+            detector_profiles=state.detector_profiles,
+        )
+
+    def upsert_viewport(self, viewport: CanvasViewport) -> WorkspaceDocument:
+        items = list(self._document.viewports)
+        for index, current in enumerate(items):
+            if current.viewport_id == viewport.viewport_id:
+                items[index] = viewport
+                break
+        else:
+            items.append(viewport)
+        return self._replace_document(viewports=tuple(items))
+
+    def delete_viewport(self, viewport_id: str) -> WorkspaceDocument:
+        return self._replace_document(
+            viewports=tuple(
+                item
+                for item in self._document.viewports
+                if item.viewport_id != viewport_id
+            )
+        )
+
+    def set_pinned_nuclides(
+        self, pinned_nuclides: Sequence[str]
+    ) -> AnalysisWorkspaceState:
         deduped: list[str] = []
         for nuclide in pinned_nuclides:
             if nuclide and nuclide not in deduped:
@@ -262,7 +715,9 @@ class AnalysisWorkspaceController:
         visible: bool | None = None,
     ) -> AnalysisWorkspaceState:
         payload = {
-            "background_mode": mode if mode is not None else self._state.background_mode,
+            "background_mode": (
+                mode if mode is not None else self._state.background_mode
+            ),
             "background_scale": (
                 float(scale) if scale is not None else self._state.background_scale
             ),
@@ -294,7 +749,11 @@ class AnalysisWorkspaceController:
         self,
         calibration: EfficiencyCalibration | None,
     ) -> AnalysisWorkspaceState:
-        return self.update(detector_efficiency=copy.deepcopy(calibration))
+        return self.update(
+            detector_efficiency=(
+                dataclasses.replace(calibration) if calibration is not None else None
+            )
+        )
 
     def set_activity_results(
         self,
@@ -314,10 +773,14 @@ class AnalysisWorkspaceController:
     ) -> AnalysisWorkspaceState:
         return self.update(roi_statistics=result)
 
-    def set_survey_points(self, survey_points: Sequence[SurveyPoint]) -> AnalysisWorkspaceState:
+    def set_survey_points(
+        self, survey_points: Sequence[SurveyPoint]
+    ) -> AnalysisWorkspaceState:
         return self.update(survey_points=tuple(survey_points))
 
-    def set_cascade_sum_lines(self, energies_keV: Sequence[float]) -> AnalysisWorkspaceState:
+    def set_cascade_sum_lines(
+        self, energies_keV: Sequence[float]
+    ) -> AnalysisWorkspaceState:
         return self.update(
             cascade_sum_lines_keV=tuple(float(value) for value in energies_keV)
         )
@@ -327,7 +790,8 @@ class AnalysisWorkspaceController:
             "active_spectrum_key": self._state.active_spectrum_key,
             "spectrum_keys": [slot.key for slot in self._state.spectra],
             "slot_sources": {
-                slot.key: slot.source_label or slot.label for slot in self._state.spectra
+                slot.key: slot.source_label or slot.label
+                for slot in self._state.spectra
             },
             "loaded_spectrum_count": len(self._state.loaded_spectra),
             "peak_count": len(self._state.peaks),
@@ -351,6 +815,385 @@ class AnalysisWorkspaceController:
             "cascade_sum_line_count": len(self._state.cascade_sum_lines_keV),
         }
 
+    def _replace_document(self, **changes: Any) -> WorkspaceDocument:
+        changes.setdefault("updated_at", _workspace_timestamp())
+        document = replace(self._document, **changes)
+        return self.set_document(document)
+
+    def _document_from_state(
+        self,
+        state: AnalysisWorkspaceState,
+        *,
+        base: WorkspaceDocument | None = None,
+        previous_state: AnalysisWorkspaceState | None = None,
+    ) -> WorkspaceDocument:
+        base = base or WorkspaceDocument()
+        spectra_by_id = {item.spectrum_id: item for item in base.spectra}
+
+        # Loaded records define stable spectrum identities.  A slot that has not
+        # yet been registered is added under its source key (or role key).
+        ordered_ids: list[str] = []
+        for record in state.loaded_spectra:
+            prior = spectra_by_id.get(record.key)
+            spectra_by_id[record.key] = WorkspaceSpectrum(
+                spectrum_id=record.key,
+                spectrum=record.spectrum,
+                label=record.label,
+                source_path=record.source_path,
+                source_hash=prior.source_hash if prior else None,
+                detector_profile_id=prior.detector_profile_id if prior else None,
+                provenance=prior.provenance if prior else {},
+                extensions=prior.extensions if prior else {},
+            )
+            ordered_ids.append(record.key)
+
+        roles: list[SpectrumRoleAssignment] = []
+        base_roles_by_name = {item.role: item for item in base.spectrum_roles}
+        projected_role_names: set[str] = set()
+        slot_spectrum_ids: dict[str, str] = {}
+        for slot in state.spectra:
+            spectrum_id = slot.source_key or slot.key
+            # Avoid making two different slot spectra share an identity.
+            if (
+                spectrum_id in spectra_by_id
+                and spectra_by_id[spectrum_id].spectrum is not slot.spectrum
+                and slot.source_key is None
+            ):
+                spectrum_id = self._available_spectrum_id(
+                    spectrum_id, set(spectra_by_id)
+                )
+            prior = spectra_by_id.get(spectrum_id)
+            spectra_by_id[spectrum_id] = WorkspaceSpectrum(
+                spectrum_id=spectrum_id,
+                spectrum=slot.spectrum,
+                label=slot.source_label or slot.label,
+                source_path=slot.source_path,
+                source_hash=prior.source_hash if prior else None,
+                detector_profile_id=prior.detector_profile_id if prior else None,
+                provenance=prior.provenance if prior else {},
+                extensions={
+                    **dict(prior.extensions if prior else {}),
+                    "slot_label": slot.label,
+                },
+            )
+            if spectrum_id not in ordered_ids:
+                ordered_ids.append(spectrum_id)
+            prior_role = base_roles_by_name.get(slot.key)
+            retained_secondary_ids = (
+                tuple(
+                    item for item in prior_role.spectrum_ids[1:] if item != spectrum_id
+                )
+                if prior_role is not None
+                else ()
+            )
+            roles.append(
+                SpectrumRoleAssignment(
+                    role=slot.key,
+                    spectrum_ids=(spectrum_id,) + retained_secondary_ids,
+                )
+            )
+            projected_role_names.add(slot.key)
+            slot_spectrum_ids[slot.key] = spectrum_id
+
+        # The legacy UI projects one primary spectrum per role. Preserve any
+        # additional role members, and roles with no legacy slot, whenever a
+        # spectrum-inventory edit is synchronized back into the v2 document.
+        roles.extend(
+            item
+            for item in base.spectrum_roles
+            if item.role not in projected_role_names
+        )
+
+        # Retain document-only spectra (for example secondary spectra not yet
+        # represented by a legacy slot) after the projected inventory.
+        for spectrum_id in tuple(spectra_by_id):
+            if spectrum_id not in ordered_ids:
+                ordered_ids.append(spectrum_id)
+        spectra = tuple(spectra_by_id[item] for item in ordered_ids)
+
+        active_spectrum_id = slot_spectrum_ids.get(state.active_spectrum_key)
+        if active_spectrum_id is None and state.active_spectrum_key in spectra_by_id:
+            active_spectrum_id = state.active_spectrum_key
+        if active_spectrum_id is None and spectra:
+            active_spectrum_id = spectra[0].spectrum_id
+
+        existing_peaks = {(item.spectrum_id, item.peak_id): item for item in base.peaks}
+        active_legacy_peaks = tuple(
+            self._peak_model_from_candidate(
+                item,
+                active_spectrum_id or state.active_spectrum_key,
+                existing_peaks.get(
+                    (active_spectrum_id or state.active_spectrum_key, item.peak_id)
+                ),
+            )
+            for item in state.peaks
+        )
+        if active_spectrum_id is None:
+            peaks = base.peaks if not active_legacy_peaks else active_legacy_peaks
+        else:
+            peaks = (
+                tuple(
+                    item
+                    for item in base.peaks
+                    if item.spectrum_id != active_spectrum_id
+                )
+                + active_legacy_peaks
+            )
+
+        active_peak_ids = {item.peak_id for item in active_legacy_peaks}
+        projected_rois = tuple(
+            replace(
+                roi,
+                associated_peak_ids=tuple(
+                    item
+                    for item in roi.associated_peak_ids
+                    if roi.spectrum_id != active_spectrum_id or item in active_peak_ids
+                ),
+            )
+            for roi in base.rois
+        )
+        rois = base.rois if projected_rois == base.rois else projected_rois
+
+        spectrum_inventory_changed = previous_state is None or not (
+            _spectrum_slots_equivalent(state.spectra, previous_state.spectra)
+            and _loaded_records_equivalent(
+                state.loaded_spectra, previous_state.loaded_spectra
+            )
+        )
+        if not spectrum_inventory_changed:
+            spectra = base.spectra
+            roles = list(base.spectrum_roles)
+        if (
+            previous_state is not None
+            and state.active_spectrum_key == previous_state.active_spectrum_key
+        ):
+            active_spectrum_id = base.active_spectrum_id
+        if previous_state is not None and state.peaks == previous_state.peaks:
+            peaks = base.peaks
+            rois = base.rois
+
+        workflow = dict(base.workflow_state)
+        workflow["analysis_workspace_v1"] = self._legacy_workflow_payload(state)
+        document = replace(
+            base,
+            updated_at=_workspace_timestamp(),
+            spectra=spectra,
+            spectrum_roles=tuple(roles),
+            active_spectrum_id=active_spectrum_id,
+            rois=rois,
+            peaks=peaks,
+            pinned_nuclides=(
+                base.pinned_nuclides
+                if previous_state is not None
+                and state.pinned_nuclides == previous_state.pinned_nuclides
+                else state.pinned_nuclides
+            ),
+            workflow_state=workflow,
+        )
+        return document
+
+    def _state_from_document(
+        self, document: WorkspaceDocument
+    ) -> AnalysisWorkspaceState:
+        by_id = {item.spectrum_id: item for item in document.spectra}
+        loaded = tuple(
+            LoadedSpectrumRecord(
+                key=item.spectrum_id,
+                label=item.label or item.spectrum_id,
+                spectrum=item.spectrum,
+                source_path=item.source_path,
+            )
+            for item in document.spectra
+        )
+        slots: list[SpectrumSlot] = []
+        for role in document.spectrum_roles:
+            if not role.spectrum_ids:
+                continue
+            workspace_spectrum = by_id.get(role.spectrum_ids[0])
+            if workspace_spectrum is None:
+                continue
+            slot_label = str(
+                workspace_spectrum.extensions.get("slot_label")
+                or role.role.replace("_", " ").title()
+            )
+            slots.append(
+                SpectrumSlot(
+                    key=role.role,
+                    label=slot_label,
+                    spectrum=workspace_spectrum.spectrum,
+                    source_key=workspace_spectrum.spectrum_id,
+                    source_label=workspace_spectrum.label
+                    or workspace_spectrum.spectrum_id,
+                    source_path=workspace_spectrum.source_path,
+                )
+            )
+
+        active_key = document.active_spectrum_id or "foreground"
+        for role in document.spectrum_roles:
+            if document.active_spectrum_id in role.spectrum_ids:
+                active_key = role.role
+                break
+        peaks = tuple(
+            self._candidate_from_peak_model(item)
+            for item in document.peaks
+            if item.spectrum_id == document.active_spectrum_id
+        )
+        legacy_payload = document.workflow_state.get("analysis_workspace_v1", {})
+        legacy = self._legacy_state_values(legacy_payload)
+        selected = legacy.pop("selected_peak_id", None)
+        if selected and all(item.peak_id != selected for item in peaks):
+            selected = peaks[0].peak_id if peaks else None
+        return AnalysisWorkspaceState(
+            spectra=tuple(slots),
+            loaded_spectra=loaded,
+            active_spectrum_key=active_key,
+            peaks=peaks,
+            selected_peak_id=selected,
+            pinned_nuclides=document.pinned_nuclides,
+            **legacy,
+        )
+
+    @staticmethod
+    def _peak_model_from_candidate(
+        candidate: PeakCandidate,
+        spectrum_id: str,
+        prior: PeakModel | None = None,
+    ) -> PeakModel:
+        assignments: tuple[NuclideAssignment, ...] = ()
+        if candidate.nuclide:
+            line_energy = (
+                candidate.reference_lines_keV[0]
+                if candidate.reference_lines_keV
+                else candidate.energy_keV
+            )
+            assignments = (
+                NuclideAssignment(
+                    nuclide=candidate.nuclide,
+                    line_energy_keV=float(line_energy),
+                    manual=True,
+                ),
+            )
+        overrides = dict(prior.manual_overrides if prior else {})
+        overrides["roi_bounds_keV"] = [
+            float(candidate.roi_bounds_keV[0]),
+            float(candidate.roi_bounds_keV[1]),
+        ]
+        return PeakModel(
+            peak_id=candidate.peak_id,
+            spectrum_id=spectrum_id,
+            roi_id=prior.roi_id if prior else None,
+            centroid_channel=float(candidate.channel),
+            centroid_energy_keV=float(candidate.energy_keV),
+            shape=prior.shape if prior else "gaussian",
+            components=prior.components if prior else (),
+            assignments=assignments,
+            tags=candidate.tags,
+            status=candidate.status,
+            manual_overrides=overrides,
+            provenance=(
+                prior.provenance if prior else {"source": "legacy_peak_candidate"}
+            ),
+            net_counts=float(candidate.net_counts),
+            significance=float(candidate.significance),
+            fit_quality=float(candidate.fit_quality),
+            candidate_nuclides=candidate.candidate_nuclides,
+            reference_lines_keV=candidate.reference_lines_keV,
+            normalized_residuals=candidate.normalized_residuals,
+            residual_channels=candidate.residual_channels,
+        )
+
+    @staticmethod
+    def _candidate_from_peak_model(peak: PeakModel) -> PeakCandidate:
+        raw_bounds = peak.manual_overrides.get("roi_bounds_keV")
+        if isinstance(raw_bounds, (list, tuple)) and len(raw_bounds) == 2:
+            roi_bounds = (float(raw_bounds[0]), float(raw_bounds[1]))
+        else:
+            roi_bounds = (
+                max(float(peak.centroid_energy_keV) - 2.0, 0.0),
+                float(peak.centroid_energy_keV) + 2.0,
+            )
+        nuclide = peak.assignments[0].nuclide if peak.assignments else None
+        return PeakCandidate(
+            peak_id=peak.peak_id,
+            channel=peak.centroid_channel,
+            energy_keV=peak.centroid_energy_keV,
+            significance=peak.significance,
+            roi_bounds_keV=roi_bounds,
+            net_counts=peak.net_counts,
+            fit_quality=peak.fit_quality,
+            status=peak.status,
+            nuclide=nuclide,
+            candidate_nuclides=peak.candidate_nuclides,
+            reference_lines_keV=peak.reference_lines_keV,
+            tags=peak.tags,
+            normalized_residuals=peak.normalized_residuals,
+            residual_channels=peak.residual_channels,
+        )
+
+    @staticmethod
+    def _legacy_workflow_payload(state: AnalysisWorkspaceState) -> dict[str, Any]:
+        return {
+            "selected_peak_id": state.selected_peak_id,
+            "peak_search_method": state.peak_search_method,
+            "bayesian_source_id": state.bayesian_source_id,
+            "ml_source_id": state.ml_source_id,
+            "roi_background_method": state.roi_background_method,
+            "background_mode": state.background_mode,
+            "background_scale": state.background_scale,
+            "background_visible": state.background_visible,
+            "efficiency_fit": _json_safe(state.efficiency_fit),
+            "detector_efficiency": _json_safe(state.detector_efficiency),
+            "activity_results": _json_safe(state.activity_results),
+            "roi_analysis": _json_safe(state.roi_analysis),
+            "roi_statistics": _json_safe(state.roi_statistics),
+            "survey_points": _json_safe(state.survey_points),
+            "cascade_sum_lines_keV": list(state.cascade_sum_lines_keV),
+        }
+
+    @staticmethod
+    def _legacy_state_values(payload: Any) -> dict[str, Any]:
+        if not isinstance(payload, Mapping):
+            payload = {}
+        return {
+            "peak_search_method": str(payload.get("peak_search_method", "mariscotti")),
+            "bayesian_source_id": str(
+                payload.get("bayesian_source_id", "fluxforge_bundled_gamma")
+            ),
+            "ml_source_id": str(payload.get("ml_source_id", "fluxforge_bundled_gamma")),
+            "roi_background_method": str(
+                payload.get("roi_background_method", "roi_sideband")
+            ),
+            "background_mode": str(payload.get("background_mode", "simple")),
+            "background_scale": float(payload.get("background_scale", 1.0)),
+            "background_visible": bool(payload.get("background_visible", True)),
+            "efficiency_fit": _decode_efficiency_fit(payload.get("efficiency_fit")),
+            "detector_efficiency": _decode_dataclass(
+                EfficiencyCalibration, payload.get("detector_efficiency")
+            ),
+            "activity_results": tuple(
+                item
+                for item in (
+                    _decode_dataclass(ActivityCalculationResult, raw)
+                    for raw in _payload_sequence(payload.get("activity_results"))
+                )
+                if item is not None
+            ),
+            "roi_analysis": _decode_roi_analysis(payload.get("roi_analysis")),
+            "roi_statistics": _decode_roi_statistics(payload.get("roi_statistics")),
+            "survey_points": tuple(
+                item
+                for item in (
+                    _decode_dataclass(SurveyPoint, raw)
+                    for raw in _payload_sequence(payload.get("survey_points"))
+                )
+                if item is not None
+            ),
+            "cascade_sum_lines_keV": tuple(
+                float(item)
+                for item in _payload_sequence(payload.get("cascade_sum_lines_keV"))
+            ),
+        }
+
     def _unique_loaded_key(self, label: str) -> str:
         parts = re.findall(r"[a-z0-9]+", label.lower())
         base = "-".join(parts) or "spectrum"
@@ -362,44 +1205,186 @@ class AnalysisWorkspaceController:
             index += 1
         return f"{base}-{index}"
 
-
-if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
-
-    class WorkspaceStateCommand(QUndoCommand):
-        """Undoable replacement of the shared analysis workspace state."""
-
-        def __init__(
-            self,
-            controller: AnalysisWorkspaceController,
-            *,
-            description: str,
-            before: AnalysisWorkspaceState,
-            after: AnalysisWorkspaceState,
-        ) -> None:
-            super().__init__(description)
-            self.controller = controller
-            self.before = copy.deepcopy(before)
-            self.after = copy.deepcopy(after)
-
-        def undo(self) -> None:
-            self.controller.set_state(copy.deepcopy(self.before))
-
-        def redo(self) -> None:
-            self.controller.set_state(copy.deepcopy(self.after))
+    @staticmethod
+    def _available_spectrum_id(base: str, existing: set[str]) -> str:
+        index = 2
+        while f"{base}-{index}" in existing:
+            index += 1
+        return f"{base}-{index}"
 
 
-else:
+def _payload_sequence(value: Any) -> tuple[Any, ...]:
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    return ()
 
-    class WorkspaceStateCommand:  # pragma: no cover - import-safe placeholder
-        def __init__(
-            self,
-            controller: AnalysisWorkspaceController,
-            *,
-            description: str,
-            before: AnalysisWorkspaceState,
-            after: AnalysisWorkspaceState,
-        ) -> None:
-            self.controller = controller
-            self.description = description
-            self.before = before
-            self.after = after
+
+def _workspace_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _spectrum_slots_equivalent(
+    left: Sequence[SpectrumSlot], right: Sequence[SpectrumSlot]
+) -> bool:
+    if len(left) != len(right):
+        return False
+    return all(
+        a.key == b.key
+        and a.label == b.label
+        and a.spectrum is b.spectrum
+        and a.source_key == b.source_key
+        and a.source_label == b.source_label
+        and a.source_path == b.source_path
+        for a, b in zip(left, right)
+    )
+
+
+def _loaded_records_equivalent(
+    left: Sequence[LoadedSpectrumRecord], right: Sequence[LoadedSpectrumRecord]
+) -> bool:
+    if len(left) != len(right):
+        return False
+    return all(
+        a.key == b.key
+        and a.label == b.label
+        and a.spectrum is b.spectrum
+        and a.source_path == b.source_path
+        for a, b in zip(left, right)
+    )
+
+
+def _json_safe(value: Any) -> Any:
+    """Convert legacy DTOs to strict JSON data for ``workflow_state``."""
+
+    if value is None or isinstance(value, (str, int, bool)):
+        return value
+    if isinstance(value, float):
+        return float(value)
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return [_json_safe(item) for item in value.tolist()]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list)):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, EfficiencyCurve):
+        return {
+            "model_type": value.model_type,
+            "parameters": _json_safe(value.parameters),
+            "energy_range": _json_safe(value.energy_range),
+            "detector_id": value.detector_id,
+            "calibration_date": value.calibration_date,
+            "calibration_sources": _json_safe(value.calibration_sources),
+            "geometry": _json_safe(value.geometry),
+            "uncertainty_model": _json_safe(value.uncertainty_model),
+        }
+    if dataclasses.is_dataclass(value):
+        return {
+            field.name: _json_safe(getattr(value, field.name))
+            for field in dataclasses.fields(value)
+            if not field.name.startswith("_")
+        }
+    raise TypeError(f"Unsupported workspace workflow value: {type(value).__name__}")
+
+
+def _decode_dataclass(cls, payload: Any):
+    if not isinstance(payload, Mapping):
+        return None
+    allowed = {field.name for field in dataclasses.fields(cls) if field.init}
+    try:
+        return cls(**{key: payload[key] for key in allowed if key in payload})
+    except (TypeError, ValueError):
+        return None
+
+
+def _decode_efficiency_curve(payload: Any) -> EfficiencyCurve | None:
+    if not isinstance(payload, Mapping):
+        return None
+    try:
+        energy_range = tuple(
+            float(value) for value in payload.get("energy_range", (0.0, 10000.0))
+        )
+        if len(energy_range) != 2:
+            return None
+        return EfficiencyCurve(
+            model_type=str(payload.get("model_type") or "polynomial"),
+            parameters=dict(payload.get("parameters") or {}),
+            energy_range=(energy_range[0], energy_range[1]),
+            detector_id=str(payload.get("detector_id") or ""),
+            calibration_date=str(payload.get("calibration_date") or ""),
+            calibration_sources=[
+                str(item) for item in payload.get("calibration_sources", ())
+            ],
+            geometry=dict(payload.get("geometry") or {}),
+            uncertainty_model=(
+                dict(payload["uncertainty_model"])
+                if isinstance(payload.get("uncertainty_model"), Mapping)
+                else None
+            ),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _decode_efficiency_fit(payload: Any) -> EfficiencyCalibrationFitResult | None:
+    if not isinstance(payload, Mapping):
+        return None
+    curve = _decode_efficiency_curve(payload.get("curve"))
+    if curve is None:
+        return None
+    try:
+        return EfficiencyCalibrationFitResult(
+            model_key=str(payload.get("model_key") or ""),
+            model_label=str(payload.get("model_label") or ""),
+            curve=curve,
+            residuals=tuple(float(item) for item in payload.get("residuals", ())),
+            rmse=float(payload.get("rmse", 0.0)),
+            points_used=int(payload.get("points_used", 0)),
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def _decode_roi_analysis(payload: Any) -> ROIAnalysisResult | None:
+    if not isinstance(payload, Mapping):
+        return None
+    try:
+        values = dict(payload)
+        values["roi_bounds_keV"] = tuple(values.get("roi_bounds_keV", ()))
+        values["sideband_bounds_keV"] = tuple(
+            tuple(item) for item in values.get("sideband_bounds_keV", ())
+        )
+        values["overlap_components"] = tuple(
+            item
+            for item in (
+                _decode_dataclass(ROIComponentFit, raw)
+                for raw in _payload_sequence(values.get("overlap_components"))
+            )
+            if item is not None
+        )
+        values["notes"] = tuple(values.get("notes", ()))
+        return ROIAnalysisResult(**values)
+    except (TypeError, ValueError):
+        return None
+
+
+def _decode_roi_statistics(payload: Any) -> ROIStatisticsResult | None:
+    if not isinstance(payload, Mapping):
+        return None
+    try:
+        values = dict(payload)
+        values["roi_bounds_keV"] = tuple(values.get("roi_bounds_keV", ()))
+        values["samples"] = tuple(
+            item
+            for item in (
+                _decode_dataclass(ROISpectrumStatistic, raw)
+                for raw in _payload_sequence(values.get("samples"))
+            )
+            if item is not None
+        )
+        return ROIStatisticsResult(**values)
+    except (TypeError, ValueError):
+        return None

--- a/src/fluxforge/gui/backends/pyqtgraph_backend.py
+++ b/src/fluxforge/gui/backends/pyqtgraph_backend.py
@@ -7,6 +7,7 @@ from typing import Sequence
 import numpy as np
 
 from fluxforge.core.analysis_workspace import PeakCandidate
+from fluxforge.core.workspace_document import CanvasViewport
 from fluxforge.gui.qt_compat import QT_AVAILABLE, QT_IMPORT_ERROR
 from fluxforge.gui.selection_bus import SelectionBus, SelectionState
 from fluxforge.gui.spectrum_canvas import (
@@ -90,7 +91,10 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
             self._cascade_sum_lines: list[object] = []
             self._overlay_traces: list[object] = []
             self._peak_scatter = None
+            self._residual_peaks: tuple[PeakCandidate, ...] = ()
             self._residual_visible = False
+            self._residual_mode = "off"
+            self._crosshair_enabled = False
             self._log_scale = False
             self._peak_labels_visible = True
             self._x_axis_is_energy = False
@@ -188,6 +192,22 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
             self._roi_region.setVisible(False)
             self._roi_region.sigRegionChangeFinished.connect(self._publish_roi_region)
             self.plot_item.addItem(self._roi_region)
+
+            self._crosshair_vertical = pg.InfiniteLine(
+                angle=90,
+                movable=False,
+                pen=pg.mkPen(color="#94a3b8", width=1, style=pg.QtCore.Qt.DashLine),
+            )
+            self._crosshair_horizontal = pg.InfiniteLine(
+                angle=0,
+                movable=False,
+                pen=pg.mkPen(color="#94a3b8", width=1, style=pg.QtCore.Qt.DashLine),
+            )
+            for line in (self._crosshair_vertical, self._crosshair_horizontal):
+                line.setZValue(30)
+                line.setVisible(False)
+                self.plot_item.addItem(line, ignoreBounds=True)
+            self.plot.scene().sigMouseMoved.connect(self._move_crosshair)
             shell.addWidget(self.plot, 1)
 
             self.residual_row = QWidget(self)
@@ -416,10 +436,10 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
         def set_peak_residuals(
             self, peaks: Sequence[PeakCandidate], *, visible: bool
         ) -> None:
-            self._residual_visible = bool(visible)
-            self.residual_row.setVisible(bool(visible and peaks))
+            self._residual_peaks = tuple(peaks)
+            self._residual_mode = "compact" if visible else "off"
             for index, curve in enumerate(self.residual_curves):
-                if not visible or index >= len(peaks):
+                if index >= len(peaks):
                     curve.setData([], [])
                     self.residual_plots[index].setTitle("Residuals")
                     continue
@@ -445,6 +465,41 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
                 self.residual_plots[index].setTitle(
                     f"{peak.energy_keV:.1f} keV · max |z| {severity:.2f}"
                 )
+            self._apply_residual_visibility()
+
+        def set_residual_mode(self, mode: str) -> None:
+            """Show or hide the already-rendered residual diagnostics."""
+
+            if mode not in {"off", "compact", "full"}:
+                raise ValueError("Residual mode must be off, compact, or full")
+            self._residual_mode = mode
+            self._apply_residual_visibility()
+
+        def _apply_residual_visibility(self) -> None:
+            self._residual_visible = self._residual_mode != "off"
+            self.residual_row.setVisible(
+                bool(self._residual_visible and self._residual_peaks)
+            )
+
+        def set_crosshair_enabled(self, enabled: bool) -> None:
+            """Toggle the plot crosshair without changing the current viewport."""
+
+            self._crosshair_enabled = bool(enabled)
+            if self._crosshair_enabled:
+                x_range, y_range = self.plot_item.viewRange()
+                self._crosshair_vertical.setPos((x_range[0] + x_range[1]) / 2.0)
+                self._crosshair_horizontal.setPos((y_range[0] + y_range[1]) / 2.0)
+            self._crosshair_vertical.setVisible(self._crosshair_enabled)
+            self._crosshair_horizontal.setVisible(self._crosshair_enabled)
+
+        def _move_crosshair(self, scene_position) -> None:
+            if not self._crosshair_enabled:
+                return
+            if not self.plot.sceneBoundingRect().contains(scene_position):
+                return
+            data_position = self.plot_item.getViewBox().mapSceneToView(scene_position)
+            self._crosshair_vertical.setPos(float(data_position.x()))
+            self._crosshair_horizontal.setPos(float(data_position.y()))
 
         def clear(self) -> None:
             self.buffer = HierarchicalSpectrumBuffer.from_counts(())
@@ -520,6 +575,60 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
         def set_peak_labels_visible(self, visible: bool) -> None:
             self._peak_labels_visible = bool(visible)
             self.set_annotation_lines(self._annotation_specs)
+
+        def viewport_state(
+            self,
+            *,
+            viewport_id: str = "primary-spectrum",
+            spectrum_id: str | None = None,
+            selected_roi_id: str | None = None,
+        ) -> CanvasViewport:
+            """Capture the current pan/zoom and display toggles without Qt types."""
+
+            x_range, y_range = self.plot_item.viewRange()
+            viewport = CanvasViewport(
+                viewport_id=viewport_id,
+                spectrum_id=spectrum_id,
+                x_range=(float(x_range[0]), float(x_range[1])),
+                y_range=(float(y_range[0]), float(y_range[1])),
+                x_unit="energy_keV" if self._x_axis_is_energy else "channel",
+                y_unit="counts",
+                log_y=self._log_scale,
+                overlays=tuple(
+                    name
+                    for name, enabled in (
+                        ("peak-labels", self._peak_labels_visible),
+                        ("roi", self._roi_region.isVisible()),
+                    )
+                    if enabled
+                ),
+                residual_mode=self._residual_mode,
+                selected_roi_id=selected_roi_id,
+                crosshair_enabled=self._crosshair_enabled,
+                labels_visible=self._peak_labels_visible,
+            )
+            viewport.validate("viewport")
+            return viewport
+
+        def apply_viewport_state(self, viewport: CanvasViewport) -> None:
+            """Restore a validated view after spectrum data has been loaded."""
+
+            viewport.validate("viewport")
+            self.set_log_scale(viewport.log_y)
+            self.set_peak_labels_visible(viewport.labels_visible)
+            roi_visible = "roi" in viewport.overlays
+            self.roi_button.blockSignals(True)
+            self.roi_button.setChecked(roi_visible)
+            self.roi_button.blockSignals(False)
+            self._set_roi_visible(roi_visible)
+            self.set_residual_mode(viewport.residual_mode)
+            if viewport.x_range is not None or viewport.y_range is not None:
+                self.plot_item.disableAutoRange()
+            if viewport.x_range is not None:
+                self.plot_item.setXRange(*viewport.x_range, padding=0.0)
+            if viewport.y_range is not None:
+                self.plot_item.setYRange(*viewport.y_range, padding=0.0)
+            self.set_crosshair_enabled(viewport.crosshair_enabled)
 
         def _on_selection_changed(self, state: SelectionState) -> None:
             if state.roi_bounds_keV is not None:
@@ -613,6 +722,24 @@ else:
             )
 
         def clear(self) -> None:
+            raise RuntimeError(
+                "PyQtGraph renderer is unavailable. Install the `native-gui` extra."
+            )
+
+        def viewport_state(
+            self,
+            *,
+            viewport_id: str = "primary-spectrum",
+            spectrum_id: str | None = None,
+            selected_roi_id: str | None = None,
+        ) -> CanvasViewport:
+            del viewport_id, spectrum_id, selected_roi_id
+            raise RuntimeError(
+                "PyQtGraph renderer is unavailable. Install the `native-gui` extra."
+            )
+
+        def apply_viewport_state(self, viewport: CanvasViewport) -> None:
+            del viewport
             raise RuntimeError(
                 "PyQtGraph renderer is unavailable. Install the `native-gui` extra."
             )

--- a/src/fluxforge/gui/canvas_intents.py
+++ b/src/fluxforge/gui/canvas_intents.py
@@ -1,0 +1,314 @@
+"""Renderer-independent interaction events for scientific canvases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from math import isfinite
+from typing import Any, Mapping
+
+
+CANVAS_INTENT_SCHEMA = "fluxforge.canvas_intent.v1"
+CANVAS_INTENT_VERSION = 1
+
+_INTENT_FIELDS = frozenset(
+    {
+        "schema",
+        "version",
+        "kind",
+        "spectrum_id",
+        "roi_id",
+        "peak_id",
+        "component_ids",
+        "bounds",
+        "left_background",
+        "right_background",
+        "position",
+        "nuclide",
+        "tag",
+        "role",
+        "viewport_id",
+        "x_range",
+        "y_range",
+        "enabled",
+        "drag_token",
+    }
+)
+
+
+class CanvasIntentKind(str, Enum):
+    """Stable operations emitted by a spectrum renderer."""
+
+    CREATE_ROI = "roi.create"
+    SELECT_ROI = "roi.select"
+    DELETE_ROI = "roi.delete"
+    MOVE_ROI = "roi.move"
+    MOVE_BACKGROUND = "roi.background.move"
+    ADD_PEAK = "peak.add"
+    MOVE_PEAK = "peak.move"
+    DELETE_PEAK = "peak.delete"
+    SPLIT_PEAK = "peak.split"
+    MERGE_PEAKS = "peak.merge"
+    ASSIGN_NUCLIDE = "nuclide.assign"
+    CLEAR_NUCLIDE = "nuclide.clear"
+    PIN_NUCLIDE = "nuclide.pin"
+    UNPIN_NUCLIDE = "nuclide.unpin"
+    TAG_NUCLIDE = "nuclide.tag"
+    ASSIGN_SPECTRUM_ROLE = "spectrum.role.assign"
+    CHANGE_VIEWPORT = "viewport.change"
+    TOGGLE_CROSSHAIR = "viewport.crosshair"
+    SET_LOG_SCALE = "viewport.log_scale"
+    SET_LABELS_VISIBLE = "viewport.labels"
+
+
+_ROI_ID_KINDS = {
+    CanvasIntentKind.SELECT_ROI,
+    CanvasIntentKind.DELETE_ROI,
+    CanvasIntentKind.MOVE_ROI,
+    CanvasIntentKind.MOVE_BACKGROUND,
+}
+_PEAK_ID_KINDS = {
+    CanvasIntentKind.MOVE_PEAK,
+    CanvasIntentKind.DELETE_PEAK,
+    CanvasIntentKind.SPLIT_PEAK,
+    CanvasIntentKind.ASSIGN_NUCLIDE,
+    CanvasIntentKind.CLEAR_NUCLIDE,
+}
+_BOUNDS_KINDS = {
+    CanvasIntentKind.CREATE_ROI,
+    CanvasIntentKind.MOVE_ROI,
+}
+_ENABLED_KINDS = {
+    CanvasIntentKind.TOGGLE_CROSSHAIR,
+    CanvasIntentKind.SET_LOG_SCALE,
+    CanvasIntentKind.SET_LABELS_VISIBLE,
+}
+
+
+@dataclass(frozen=True)
+class CanvasIntent:
+    """One validated UI intent independent of any plotting toolkit.
+
+    The event is deliberately descriptive rather than executable.  A controller
+    translates it into a focused document edit and, where appropriate, one
+    mergeable undo command after a drag completes.
+    """
+
+    kind: CanvasIntentKind
+    spectrum_id: str | None = None
+    roi_id: str | None = None
+    peak_id: str | None = None
+    component_ids: tuple[str, ...] = ()
+    bounds: tuple[float, float] | None = None
+    left_background: tuple[float, float] | None = None
+    right_background: tuple[float, float] | None = None
+    position: float | None = None
+    nuclide: str | None = None
+    tag: str | None = None
+    role: str | None = None
+    viewport_id: str | None = None
+    x_range: tuple[float, float] | None = None
+    y_range: tuple[float, float] | None = None
+    enabled: bool | None = None
+    drag_token: str | None = None
+    schema: str = CANVAS_INTENT_SCHEMA
+    version: int = CANVAS_INTENT_VERSION
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "kind", CanvasIntentKind(self.kind))
+        self.validate()
+
+    def validate(self) -> None:
+        """Raise ``ValueError`` when required intent data is absent or invalid."""
+
+        if self.schema != CANVAS_INTENT_SCHEMA or self.version != CANVAS_INTENT_VERSION:
+            raise ValueError("Unsupported CanvasIntent schema or version.")
+        if self.kind not in {
+            CanvasIntentKind.PIN_NUCLIDE,
+            CanvasIntentKind.UNPIN_NUCLIDE,
+            CanvasIntentKind.TAG_NUCLIDE,
+        } and not _text(self.spectrum_id):
+            raise ValueError(f"{self.kind.value} requires spectrum_id.")
+        if self.kind in _ROI_ID_KINDS and not _text(self.roi_id):
+            raise ValueError(f"{self.kind.value} requires roi_id.")
+        if self.kind in _PEAK_ID_KINDS and not _text(self.peak_id):
+            raise ValueError(f"{self.kind.value} requires peak_id.")
+        if self.kind in _BOUNDS_KINDS:
+            _validate_range(self.bounds, "bounds")
+        if self.kind is CanvasIntentKind.MOVE_BACKGROUND:
+            if self.left_background is None and self.right_background is None:
+                raise ValueError("roi.background.move requires a background range.")
+            if self.left_background is not None:
+                _validate_range(self.left_background, "left_background")
+            if self.right_background is not None:
+                _validate_range(self.right_background, "right_background")
+        if self.kind in {CanvasIntentKind.ADD_PEAK, CanvasIntentKind.MOVE_PEAK}:
+            if (
+                self.position is None
+                or isinstance(self.position, bool)
+                or not isfinite(float(self.position))
+            ):
+                raise ValueError(f"{self.kind.value} requires a finite position.")
+        if self.kind is CanvasIntentKind.MERGE_PEAKS:
+            if len(set(self.component_ids)) < 2:
+                raise ValueError(
+                    "peak.merge requires at least two unique component IDs."
+                )
+        if self.kind is CanvasIntentKind.ASSIGN_NUCLIDE and not _text(self.nuclide):
+            raise ValueError("nuclide.assign requires nuclide.")
+        if self.kind in {
+            CanvasIntentKind.PIN_NUCLIDE,
+            CanvasIntentKind.UNPIN_NUCLIDE,
+            CanvasIntentKind.TAG_NUCLIDE,
+        } and not _text(self.nuclide):
+            raise ValueError(f"{self.kind.value} requires nuclide.")
+        if self.kind is CanvasIntentKind.TAG_NUCLIDE and not _text(self.tag):
+            raise ValueError("nuclide.tag requires tag.")
+        if self.kind is CanvasIntentKind.ASSIGN_SPECTRUM_ROLE and not _text(self.role):
+            raise ValueError("spectrum.role.assign requires role.")
+        if self.kind is CanvasIntentKind.CHANGE_VIEWPORT:
+            if not _text(self.viewport_id):
+                raise ValueError("viewport.change requires viewport_id.")
+            if self.x_range is None and self.y_range is None:
+                raise ValueError("viewport.change requires an axis range.")
+            if self.x_range is not None:
+                _validate_range(self.x_range, "x_range")
+            if self.y_range is not None:
+                _validate_range(self.y_range, "y_range")
+        if self.kind in _ENABLED_KINDS and self.enabled is None:
+            raise ValueError(f"{self.kind.value} requires enabled.")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a compact JSON-serializable representation."""
+
+        payload: dict[str, Any] = {
+            "schema": self.schema,
+            "version": self.version,
+            "kind": self.kind.value,
+        }
+        for key in (
+            "spectrum_id",
+            "roi_id",
+            "peak_id",
+            "position",
+            "nuclide",
+            "tag",
+            "role",
+            "viewport_id",
+            "enabled",
+            "drag_token",
+        ):
+            value = getattr(self, key)
+            if value is not None:
+                payload[key] = value
+        if self.component_ids:
+            payload["component_ids"] = list(self.component_ids)
+        for key in (
+            "bounds",
+            "left_background",
+            "right_background",
+            "x_range",
+            "y_range",
+        ):
+            value = getattr(self, key)
+            if value is not None:
+                payload[key] = list(value)
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CanvasIntent":
+        """Parse and validate a serialized intent."""
+
+        if not isinstance(payload, Mapping):
+            raise ValueError("CanvasIntent payload must be an object.")
+        unknown = sorted(set(payload).difference(_INTENT_FIELDS))
+        if unknown:
+            raise ValueError(
+                "CanvasIntent payload contains unknown fields: " + ", ".join(unknown)
+            )
+        if payload.get("schema") != CANVAS_INTENT_SCHEMA:
+            raise ValueError("Unsupported CanvasIntent schema or version.")
+        version = payload.get("version")
+        if isinstance(version, bool) or not isinstance(version, int):
+            raise ValueError("CanvasIntent version must be an integer.")
+
+        def pair(name: str) -> tuple[float, float] | None:
+            raw = payload.get(name)
+            if raw is None:
+                return None
+            if not isinstance(raw, (list, tuple)) or len(raw) != 2:
+                raise ValueError(f"{name} must contain two numbers.")
+            return (
+                _finite_number(raw[0], f"{name}[0]"),
+                _finite_number(raw[1], f"{name}[1]"),
+            )
+
+        component_ids = payload.get("component_ids", ())
+        if not isinstance(component_ids, (list, tuple)):
+            raise ValueError("component_ids must be an array.")
+        raw_enabled = payload.get("enabled")
+        if raw_enabled is not None and not isinstance(raw_enabled, bool):
+            raise ValueError("enabled must be a boolean.")
+        return cls(
+            kind=CanvasIntentKind(str(payload.get("kind") or "")),
+            spectrum_id=_optional_text(payload.get("spectrum_id")),
+            roi_id=_optional_text(payload.get("roi_id")),
+            peak_id=_optional_text(payload.get("peak_id")),
+            component_ids=tuple(str(value) for value in component_ids),
+            bounds=pair("bounds"),
+            left_background=pair("left_background"),
+            right_background=pair("right_background"),
+            position=(
+                _finite_number(payload["position"], "position")
+                if payload.get("position") is not None
+                else None
+            ),
+            nuclide=_optional_text(payload.get("nuclide")),
+            tag=_optional_text(payload.get("tag")),
+            role=_optional_text(payload.get("role")),
+            viewport_id=_optional_text(payload.get("viewport_id")),
+            x_range=pair("x_range"),
+            y_range=pair("y_range"),
+            enabled=raw_enabled,
+            drag_token=_optional_text(payload.get("drag_token")),
+            schema=str(payload.get("schema") or ""),
+            version=version,
+        )
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _optional_text(value: object) -> str | None:
+    text = _text(value)
+    return text or None
+
+
+def _validate_range(value: tuple[float, float] | None, name: str) -> None:
+    if value is None:
+        raise ValueError(f"{name} is required.")
+    lower = _finite_number(value[0], f"{name}[0]")
+    upper = _finite_number(value[1], f"{name}[1]")
+    if not isfinite(lower) or not isfinite(upper) or lower >= upper:
+        raise ValueError(f"{name} must be a finite increasing range.")
+
+
+def _finite_number(value: object, name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a finite number.")
+    try:
+        result = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite number.") from exc
+    if not isfinite(result):
+        raise ValueError(f"{name} must be a finite number.")
+    return result
+
+
+__all__ = [
+    "CANVAS_INTENT_SCHEMA",
+    "CANVAS_INTENT_VERSION",
+    "CanvasIntent",
+    "CanvasIntentKind",
+]

--- a/src/fluxforge/gui/dialogs/calibration_dialog.py
+++ b/src/fluxforge/gui/dialogs/calibration_dialog.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Callable
 
 import numpy as np
@@ -2339,8 +2339,9 @@ if (
         def _apply_workspace_results(self) -> None:
             if self._energy_fit is None:
                 return
-            self._spectrum.calibration["energy"] = list(self._energy_fit.coefficients)
-            self._spectrum.calibration["deviation_pairs"] = [
+            calibration = dict(self._spectrum.calibration)
+            calibration["energy"] = list(self._energy_fit.coefficients)
+            calibration["deviation_pairs"] = [
                 {
                     "energy_keV": pair.energy_keV,
                     "correction_keV": pair.correction_keV,
@@ -2348,7 +2349,20 @@ if (
                 }
                 for pair in self._energy_fit.deviation_pairs
             ]
-            self._spectrum.energies = self._spectrum.calibrate_channels()
+            if self._fwhm_fit is not None:
+                calibration["fwhm"] = {
+                    "model": self._fwhm_fit.model,
+                    "coefficients": list(self._fwhm_fit.coefficients),
+                }
+            # GammaSpectrum is mutable for parser compatibility, so applying a
+            # calibration must create a new spectrum value.  ``replace`` keeps
+            # the large count/channel arrays by identity while ``__post_init__``
+            # derives a fresh energy axis from the new calibration mapping.
+            updated_spectrum = replace(
+                self._spectrum,
+                calibration=calibration,
+                energies=None,
+            )
             self.selection_bus.publish(
                 self.selection_bus.state.__class__(
                     peak_energy_keV=self.selection_bus.state.peak_energy_keV,
@@ -2361,7 +2375,8 @@ if (
                 )
             )
             if self.on_apply is not None:
-                self.on_apply(self._spectrum, self._energy_fit, self._fwhm_fit)
+                self.on_apply(updated_spectrum, self._energy_fit, self._fwhm_fit)
+            self._spectrum = updated_spectrum
             self.energy_summary.setText(
                 self.energy_summary.text()
                 + "\nApplied to the workspace spectrum and broadcast to the shell."

--- a/src/fluxforge/gui/main_window.py
+++ b/src/fluxforge/gui/main_window.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
 
@@ -18,11 +19,18 @@ from fluxforge.gui.analysis_workspace import (
 )
 from fluxforge.gui.qt_compat import QT_AVAILABLE, QT_IMPORT_ERROR
 from fluxforge.gui.selection_bus import SelectionBus, SelectionState
-from fluxforge.io import read_ffs_session, read_spectrum_any
+from fluxforge.gui.workspace_undo import ApplyCalibrationCommand
+from fluxforge.io import (
+    FluxForgeSession,
+    read_ffs_session,
+    read_spectrum_any,
+    write_ffs_session,
+)
 from fluxforge.core.predictive import (
     estimate_count_target_forecast,
     estimate_recalibration_forecast,
 )
+from fluxforge.core.workspace_document import CalibrationModel, DetectorProfile
 from fluxforge.reporting.engine import ReportingEngine
 from fluxforge.standards import (
     QAMonitor,
@@ -166,6 +174,12 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             self.analysis_workspace = AnalysisWorkspaceController(
                 self._build_initial_workspace_state(include_example=load_example)
             )
+            self._session_path: Path | None = None
+            self._session_device_snapshot: list[dict] = []
+            self._session_metadata: dict = {}
+            self._session_created_at: str | None = None
+            self._session_recent_files: tuple[str, ...] = ()
+            self._document_dirty = False
             self._calibration_dialog = None
             self._unfolding_dialog = None
             self._qa_history_dialog = None
@@ -192,6 +206,9 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             self.mode_manager.subscribe(self._on_mode_state_changed)
             self.selection_bus.subscribe(self._on_selection_changed)
             self.analysis_workspace.subscribe(self._on_workspace_state_changed)
+            self.analysis_workspace.subscribe_document(
+                self._on_workspace_document_changed
+            )
             self._on_mode_state_changed(self.mode_manager.state)
             self._on_workspace_state_changed(self.analysis_workspace.state)
 
@@ -279,6 +296,23 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                     enabled=True,
                     handler=self._open_session_dialog,
                     object_name="OpenSessionAction",
+                )
+            )
+            self._save_session_action = self._action(
+                "Save Session",
+                "Ctrl+S",
+                enabled=True,
+                handler=self.save_session,
+                object_name="SaveSessionAction",
+            )
+            file_menu.addAction(self._save_session_action)
+            file_menu.addAction(
+                self._action(
+                    "Save Session As...",
+                    "Ctrl+Shift+S",
+                    enabled=True,
+                    handler=self._save_session_as_dialog,
+                    object_name="SaveSessionAsAction",
                 )
             )
             file_menu.addAction(
@@ -790,13 +824,95 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             if filename:
                 self._open_dialog_path(filename)
 
+        def _save_session_as_dialog(self) -> bool:
+            initial = str(
+                self._session_path
+                or (
+                    Path(self.recent_files.files()[0]).with_suffix(".ffs")
+                    if self.recent_files.files()
+                    else Path("fluxforge-analysis.ffs")
+                )
+            )
+            filename, _selected_filter = QFileDialog.getSaveFileName(
+                self,
+                "Save FluxForge session",
+                initial,
+                "FluxForge sessions (*.ffs);;All files (*)",
+            )
+            if not filename:
+                return False
+            return self.save_session(filename)
+
+        def save_session(self, path: str | Path | None = None) -> bool:
+            """Atomically save the complete canonical analysis document."""
+
+            if isinstance(path, bool):
+                # QAction.triggered supplies its checked state.
+                path = None
+            target = Path(path) if path is not None else self._session_path
+            if target is None:
+                return self._save_session_as_dialog()
+            if target.suffix.lower() != ".ffs":
+                target = target.with_suffix(".ffs")
+
+            viewport = (
+                self.central_tabs.viewport_state()
+                if hasattr(self.central_tabs, "viewport_state")
+                else None
+            )
+            if viewport is not None:
+                self.analysis_workspace.upsert_viewport(viewport)
+            recent_files = tuple(
+                dict.fromkeys(
+                    (
+                        str(target),
+                        *self._session_recent_files,
+                        *self.recent_files.files(),
+                    )
+                )
+            )
+            session = FluxForgeSession(
+                document=self.analysis_workspace.document,
+                recent_files=recent_files,
+                device_snapshot=deepcopy(self._session_device_snapshot),
+                metadata=deepcopy(self._session_metadata),
+                created_at=self._session_created_at,
+            )
+            try:
+                write_ffs_session(target, session)
+            except Exception as exc:
+                QMessageBox.critical(
+                    self,
+                    "Could not save session",
+                    f"FluxForge could not save {target}.\n\n{exc}",
+                )
+                return False
+            self._session_path = target.resolve()
+            self._session_created_at = session.created_at
+            self._session_recent_files = tuple(session.recent_files)
+            self.recent_files.record(target)
+            self._document_dirty = False
+            self.undo_stack.setClean()
+            self.setWindowModified(False)
+            self.file_label.setText(f"File: {target.name}")
+            self.statusBar().showMessage(f"Session saved: {target.name}", 4000)
+            return True
+
         def _load_example_workspace(self) -> None:
             """Load the bundled deterministic HPGe example on explicit request."""
 
             self.qa_monitor.seed_demo_history()
-            self.analysis_workspace.set_state(
-                self._build_initial_workspace_state(include_example=True)
+            self.analysis_workspace.set_document(
+                AnalysisWorkspaceController(
+                    self._build_initial_workspace_state(include_example=True)
+                ).document
             )
+            self._session_path = None
+            self._session_device_snapshot = []
+            self._session_metadata = {}
+            self._session_created_at = None
+            self._session_recent_files = ()
+            self.undo_stack.clear()
             self._refresh_analysis_workspace_derivatives()
             self.file_label.setText("File: bundled HPGe example")
             self.statusBar().showMessage("Bundled HPGe example loaded", 4000)
@@ -872,6 +988,8 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                     (
                         "Ctrl+O — Open spectrum",
                         "Ctrl+Shift+O — Open FluxForge session",
+                        "Ctrl+S — Save FluxForge session",
+                        "Ctrl+Shift+S — Save FluxForge session as",
                         "Ctrl+E — Export report",
                         "Ctrl+Z / Ctrl+Shift+Z — Undo / redo",
                         "Ctrl+L — Toggle logarithmic spectrum scale",
@@ -1037,40 +1155,28 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             source = Path(path)
             if source.suffix.lower() == ".ffs":
                 session = read_ffs_session(source)
-                loaded_keys: list[str] = []
-                for index, spectrum in enumerate(session.spectra):
-                    session_source = (
-                        session.source_files[index]
-                        if index < len(session.source_files)
-                        else None
-                    )
-                    label = (
-                        Path(session_source).name
-                        if session_source
-                        else (
-                            spectrum.spectrum_id
-                            or f"{source.stem} spectrum {index + 1}"
-                        )
-                    )
-                    loaded_keys.append(
-                        self.analysis_workspace.register_loaded_spectrum(
-                            spectrum,
-                            label=label,
-                            source_path=session_source,
-                        )
-                    )
-                if loaded_keys:
-                    active_index = min(
-                        max(session.active_spectrum_index, 0),
-                        len(loaded_keys) - 1,
-                    )
-                    active_key = loaded_keys[active_index]
-                    slot_key = self.analysis_workspace.state.active_spectrum_key
-                    self.analysis_workspace.assign_loaded_spectrum_to_slot(
-                        active_key,
-                        slot_key,
-                    )
-                self.recent_files.record_many(session.recent_files or [source])
+                self.analysis_workspace.set_document(session.document)
+                self._session_path = source.resolve()
+                self._session_device_snapshot = deepcopy(session.device_snapshot)
+                self._session_metadata = deepcopy(session.metadata)
+                self._session_created_at = session.created_at
+                self._session_recent_files = tuple(session.recent_files)
+                self.undo_stack.clear()
+                self.undo_stack.setClean()
+                viewport = session.document.viewport_by_id("primary-spectrum")
+                if viewport is not None and hasattr(
+                    self.central_tabs, "apply_viewport_state"
+                ):
+                    self.central_tabs.apply_viewport_state(viewport)
+                    self._log_scale_action.setChecked(viewport.log_y)
+                    self._peak_labels_action.setChecked(viewport.labels_visible)
+                if viewport is not None and viewport.selected_roi_id:
+                    roi = session.document.roi_by_id(viewport.selected_roi_id)
+                    if roi is not None:
+                        self.selection_bus.publish_roi(*roi.signal_range)
+                self.recent_files.record_many((source, *session.recent_files))
+                self._document_dirty = False
+                self.setWindowModified(False)
             else:
                 spectrum = read_spectrum_any(source)
                 loaded_key = self.analysis_workspace.register_loaded_spectrum(
@@ -1088,6 +1194,13 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 self.recent_files.record(source)
             self.file_label.setText(f"File: {source.name}")
             self._refresh_analysis_workspace_derivatives()
+            if source.suffix.lower() == ".ffs":
+                self._document_dirty = False
+                self.setWindowModified(False)
+
+        def _on_workspace_document_changed(self, _document) -> None:
+            self._document_dirty = True
+            self.setWindowModified(True)
 
         def dragEnterEvent(self, event) -> None:
             mime_data = event.mimeData()
@@ -1491,26 +1604,7 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
 
         def _snapshot_current_workflow(self) -> dict[str, object]:
             state = self.analysis_workspace.state
-            loaded_spectra = []
-            seen_paths: set[str] = set()
-            for record in state.loaded_spectra:
-                source_path = str(record.source_path or "").strip()
-                if not source_path or source_path in seen_paths:
-                    continue
-                seen_paths.add(source_path)
-                loaded_spectra.append(
-                    {
-                        "source_path": source_path,
-                        "label": record.label,
-                    }
-                )
-            slot_assignments = {
-                slot.key: str(slot.source_path)
-                for slot in state.spectra
-                if slot.source_path
-            }
             workspace_payload = {
-                "active_spectrum_key": state.active_spectrum_key,
                 "peak_search_method": state.peak_search_method,
                 "bayesian_source_id": state.bayesian_source_id,
                 "ml_source_id": state.ml_source_id,
@@ -1518,12 +1612,9 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 "background_mode": state.background_mode,
                 "background_scale": float(state.background_scale),
                 "background_visible": bool(state.background_visible),
-                "pinned_nuclides": list(state.pinned_nuclides),
-                "loaded_spectra": loaded_spectra,
-                "slot_assignments": slot_assignments,
             }
             payload = {
-                "version": 1,
+                "version": 2,
                 "mode_state": self.mode_manager.describe(),
                 "library_state": self.library_manager.describe(),
                 "view_state": {
@@ -1635,54 +1726,6 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             )
             self.selection_bus.publish(SelectionState())
 
-        def _restore_loaded_spectra_from_payload(
-            self,
-            payload: dict[str, object],
-        ) -> list[str]:
-            loaded_entries = payload.get("loaded_spectra")
-            if not isinstance(loaded_entries, list) or not loaded_entries:
-                return []
-
-            self._reset_analysis_workspace()
-            loaded_key_by_path: dict[str, str] = {}
-            missing_paths: list[str] = []
-            for entry in loaded_entries:
-                if not isinstance(entry, dict):
-                    continue
-                source_path = str(entry.get("source_path") or "").strip()
-                if not source_path:
-                    continue
-                path = Path(source_path)
-                if not path.exists():
-                    missing_paths.append(source_path)
-                    continue
-                spectrum = read_spectrum_any(path)
-                loaded_key = self.analysis_workspace.register_loaded_spectrum(
-                    spectrum,
-                    label=str(entry.get("label") or path.name),
-                    source_path=str(path),
-                )
-                loaded_key_by_path[str(path)] = loaded_key
-
-            slot_assignments = payload.get("slot_assignments")
-            if isinstance(slot_assignments, dict):
-                for slot_key, source_path in slot_assignments.items():
-                    resolved_path = str(source_path or "").strip()
-                    loaded_key = loaded_key_by_path.get(resolved_path)
-                    if loaded_key:
-                        self.analysis_workspace.assign_loaded_spectrum_to_slot(
-                            loaded_key,
-                            str(slot_key),
-                        )
-
-            if loaded_key_by_path and not slot_assignments:
-                first_key = next(iter(loaded_key_by_path.values()))
-                self.analysis_workspace.assign_loaded_spectrum_to_slot(
-                    first_key,
-                    "foreground",
-                )
-            return missing_paths
-
         def _apply_workflow_payload(self, payload: dict[str, object]) -> None:
             mode_payload, library_payload = (
                 self.workflow_presets.extract_mode_and_library_state(payload)
@@ -1693,11 +1736,7 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 self.library_manager.apply_state(library_payload)
 
             workspace_payload = payload.get("workspace_state")
-            missing_paths: list[str] = []
             if isinstance(workspace_payload, dict):
-                missing_paths = self._restore_loaded_spectra_from_payload(
-                    workspace_payload
-                )
                 config_payload = {
                     key: workspace_payload.get(key)
                     for key in (
@@ -1743,15 +1782,6 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                         else None
                     ),
                 )
-                pinned = workspace_payload.get("pinned_nuclides")
-                if isinstance(pinned, list):
-                    self.analysis_workspace.set_pinned_nuclides(
-                        [str(item) for item in pinned]
-                    )
-                active_spectrum_key = workspace_payload.get("active_spectrum_key")
-                if active_spectrum_key:
-                    self.analysis_workspace.select_spectrum(str(active_spectrum_key))
-
             view_payload = payload.get("view_state")
             if isinstance(view_payload, dict):
                 if "log_scale" in view_payload:
@@ -1787,12 +1817,6 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 bottom_widget.apply_workflow_state(bottom_payload)
 
             self._refresh_analysis_workspace_derivatives()
-            if missing_paths:
-                self.statusBar().showMessage(
-                    "Workflow restored with missing spectrum files: "
-                    + ", ".join(Path(path).name for path in missing_paths),
-                    8000,
-                )
 
         def _open_pu_isotopics_wizard(self) -> None:
             if self.mode_manager.state.mode is GUIMode.SIMPLE:
@@ -1816,8 +1840,101 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             energy_fit,
             fwhm_fit,
         ) -> None:
-            if hasattr(self.central_tabs, "load_spectrum"):
-                self.central_tabs.load_spectrum(spectrum)
+            spectrum_id = self.analysis_workspace.document.active_spectrum_id
+            workspace_spectrum = (
+                self.analysis_workspace.document.spectrum_by_id(spectrum_id)
+                if spectrum_id is not None
+                else None
+            )
+            if spectrum_id is None or workspace_spectrum is None:
+                return
+            existing_profile = (
+                self.analysis_workspace.document.detector_profile_by_id(
+                    workspace_spectrum.detector_profile_id
+                )
+                if workspace_spectrum.detector_profile_id
+                else None
+            )
+            profile_base = existing_profile or DetectorProfile(
+                detector_profile_id=f"{spectrum_id}-detector-profile",
+                detector_id=str(workspace_spectrum.spectrum.detector_id or ""),
+            )
+            prior_leaf = existing_profile
+            if prior_leaf is None:
+                prior_coefficients = tuple(
+                    float(value)
+                    for value in workspace_spectrum.spectrum.calibration.get(
+                        "energy", ()
+                    )
+                )
+                raw_deviation_pairs = workspace_spectrum.spectrum.calibration.get(
+                    "deviation_pairs", ()
+                )
+                prior_deviation_pairs = tuple(
+                    (
+                        float(item.get("energy_keV", 0.0)),
+                        float(item.get("correction_keV", 0.0)),
+                    )
+                    for item in raw_deviation_pairs
+                    if isinstance(item, dict)
+                )
+                prior_leaf = replace(
+                    profile_base,
+                    energy_calibration=(
+                        CalibrationModel(
+                            model_key="legacy-polynomial",
+                            coefficients=prior_coefficients,
+                            deviation_pairs=prior_deviation_pairs,
+                        )
+                        if prior_coefficients
+                        else None
+                    ),
+                )
+            energy_model = CalibrationModel(
+                model_key=f"polynomial-{energy_fit.order}",
+                coefficients=tuple(float(value) for value in energy_fit.coefficients),
+                deviation_pairs=tuple(
+                    (float(pair.energy_keV), float(pair.correction_keV))
+                    for pair in energy_fit.deviation_pairs
+                ),
+                provenance={
+                    "chi_squared": float(energy_fit.chi_squared),
+                    "reduced_chi_squared": float(energy_fit.reduced_chi_squared),
+                    "rms_keV": float(energy_fit.rms_keV),
+                },
+            )
+            fwhm_model = (
+                CalibrationModel(
+                    model_key=str(fwhm_fit.model),
+                    coefficients=tuple(float(value) for value in fwhm_fit.coefficients),
+                    provenance={
+                        "chi_squared": float(fwhm_fit.chi_squared),
+                        "reduced_chi_squared": float(fwhm_fit.reduced_chi_squared),
+                        "rms_keV": float(fwhm_fit.rms_keV),
+                    },
+                )
+                if fwhm_fit is not None
+                else (
+                    existing_profile.fwhm_calibration
+                    if existing_profile is not None
+                    else None
+                )
+            )
+            profile = replace(
+                profile_base,
+                energy_calibration=energy_model,
+                fwhm_calibration=fwhm_model,
+            )
+            command = ApplyCalibrationCommand(
+                self.analysis_workspace,
+                spectrum_id=spectrum_id,
+                before=prior_leaf,
+                after=profile,
+            )
+            if self.undo_stack is not None:
+                self.undo_stack.push(command)
+            else:
+                command.redo()
             self._refresh_analysis_workspace_derivatives()
             self.file_label.setText(
                 f"File: {spectrum.spectrum_id or 'workspace spectrum'}"

--- a/src/fluxforge/gui/panels/modern_shell.py
+++ b/src/fluxforge/gui/panels/modern_shell.py
@@ -69,7 +69,11 @@ from fluxforge.data.nuclear_data_sources import list_nuclear_data_sources_by_cap
 from fluxforge.gui.analysis_workspace import (
     AnalysisWorkspaceController,
     SpectrumSlot,
-    WorkspaceStateCommand,
+)
+from fluxforge.gui.workspace_undo import (
+    ReplacePeakSetCommand,
+    TogglePinnedNuclideCommand,
+    UpdatePeakCommand,
 )
 from fluxforge.gui.backends import PYQTGRAPH_AVAILABLE, pyqtgraph_backend_status
 from fluxforge.gui.dialogs.auto_peak_review_dialog import AutoPeakReviewDialog
@@ -911,16 +915,92 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             )
 
         def _commit_state_change(self, description: str, before, after) -> None:
-            if self.undo_stack is not None:
-                self.undo_stack.push(
-                    WorkspaceStateCommand(
+            if self.undo_stack is None:
+                self.workspace_controller.set_state(after)
+                return
+
+            if before.peaks != after.peaks:
+                spectrum_id = self.workspace_controller.document.active_spectrum_id
+                if spectrum_id is None:
+                    self.workspace_controller.set_state(after)
+                    return
+                existing = {
+                    peak.peak_id: peak
+                    for peak in self.workspace_controller.document.peaks
+                    if peak.spectrum_id == spectrum_id
+                }
+                before_models = tuple(
+                    self.workspace_controller._peak_model_from_candidate(
+                        peak, spectrum_id, existing.get(peak.peak_id)
+                    )
+                    for peak in before.peaks
+                )
+                before_by_id = {peak.peak_id: peak for peak in before_models}
+                after_models = tuple(
+                    self.workspace_controller._peak_model_from_candidate(
+                        peak, spectrum_id, before_by_id.get(peak.peak_id)
+                    )
+                    for peak in after.peaks
+                )
+                changed_before = {
+                    peak.peak_id: peak
+                    for peak in before_models
+                    if next(
+                        (item for item in after_models if item.peak_id == peak.peak_id),
+                        None,
+                    )
+                    != peak
+                }
+                changed_after = {
+                    peak.peak_id: peak
+                    for peak in after_models
+                    if before_by_id.get(peak.peak_id) != peak
+                }
+                if (
+                    len(changed_before) == 1
+                    and len(changed_after) == 1
+                    and set(changed_before) == set(changed_after)
+                ):
+                    peak_id = next(iter(changed_after))
+                    command = UpdatePeakCommand(
                         self.workspace_controller,
+                        before=changed_before[peak_id],
+                        after=changed_after[peak_id],
                         description=description,
-                        before=before,
-                        after=after,
+                    )
+                else:
+                    command = ReplacePeakSetCommand(
+                        self.workspace_controller,
+                        spectrum_id=spectrum_id,
+                        before=before_models,
+                        after=after_models,
+                        description=description,
+                    )
+                self.undo_stack.push(command)
+                if before.peak_search_method != after.peak_search_method:
+                    self.workspace_controller.set_peak_search_method(
+                        after.peak_search_method
+                    )
+                if before.selected_peak_id != after.selected_peak_id:
+                    self.workspace_controller.select_peak(after.selected_peak_id)
+                return
+
+            if before.pinned_nuclides != after.pinned_nuclides:
+                self.undo_stack.push(
+                    TogglePinnedNuclideCommand(
+                        self.workspace_controller,
+                        before=before.pinned_nuclides,
+                        after=after.pinned_nuclides,
+                        description=description,
                     )
                 )
+                if before.cascade_sum_lines_keV != after.cascade_sum_lines_keV:
+                    self.workspace_controller.set_cascade_sum_lines(
+                        after.cascade_sum_lines_keV
+                    )
                 return
+
+            # Non-persisted derived values do not warrant a full-document copy.
             self.workspace_controller.set_state(after)
 
         def _sync_state(self, state) -> None:

--- a/src/fluxforge/gui/panels/modern_shell_center.py
+++ b/src/fluxforge/gui/panels/modern_shell_center.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import numpy as np
 
 from fluxforge.core.analysis_workspace import subtract_background_counts
+from fluxforge.core.workspace_document import CanvasViewport
 from fluxforge.core.predictive import (
     estimate_count_target_forecast,
     estimate_dead_time_forecast,
@@ -378,6 +379,22 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 and hasattr(self.canvas, "set_peak_labels_visible")
             ):
                 self.canvas.set_peak_labels_visible(bool(visible))
+
+        def viewport_state(self) -> CanvasViewport | None:
+            if not PYQTGRAPH_AVAILABLE or not hasattr(self, "canvas"):
+                return None
+            document = self.workspace_controller.document
+            current = document.viewport_by_id("primary-spectrum")
+            selected_roi_id = current.selected_roi_id if current is not None else None
+            return self.canvas.viewport_state(
+                viewport_id="primary-spectrum",
+                spectrum_id=document.active_spectrum_id,
+                selected_roi_id=selected_roi_id,
+            )
+
+        def apply_viewport_state(self, viewport: CanvasViewport) -> None:
+            if PYQTGRAPH_AVAILABLE and hasattr(self, "canvas"):
+                self.canvas.apply_viewport_state(viewport)
 
         def _slot_tab_changed(self, index: int) -> None:
             if index < 0 or index >= len(self.workspace_controller.state.spectra):

--- a/src/fluxforge/gui/spectrum_canvas.py
+++ b/src/fluxforge/gui/spectrum_canvas.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Sequence
 
 from fluxforge.core.analysis_workspace import PeakCandidate
+from fluxforge.core.workspace_document import CanvasViewport
 
 
 @dataclass(frozen=True)
@@ -143,11 +144,29 @@ class SpectrumCanvas:
 
         del energies_keV
 
-    def set_peak_residuals(self, peaks: Sequence[PeakCandidate], *, visible: bool) -> None:
+    def set_peak_residuals(
+        self, peaks: Sequence[PeakCandidate], *, visible: bool
+    ) -> None:
         """Optional update for mini residual subplots."""
 
         del peaks
         del visible
+
+    def viewport_state(
+        self,
+        *,
+        viewport_id: str = "primary-spectrum",
+        spectrum_id: str | None = None,
+        selected_roi_id: str | None = None,
+    ) -> CanvasViewport:
+        """Return renderer-independent persisted view state."""
+
+        raise NotImplementedError
+
+    def apply_viewport_state(self, viewport: CanvasViewport) -> None:
+        """Restore renderer-independent persisted view state."""
+
+        raise NotImplementedError
 
 
 def _downsample_counts(counts: Sequence[float], *, factor: int) -> tuple[float, ...]:

--- a/src/fluxforge/gui/workflow_presets.py
+++ b/src/fluxforge/gui/workflow_presets.py
@@ -23,7 +23,7 @@ WorkflowPresetListener = Callable[[tuple[WorkflowPreset, ...], Optional[str]], N
 
 def _default_quantumgold_payload() -> dict[str, Any]:
     return {
-        "version": 1,
+        "version": 2,
         "mode_state": {
             "mode": "expert",
             "standard": None,
@@ -46,7 +46,6 @@ def _default_quantumgold_payload() -> dict[str, Any]:
             "current_tab": "Spectrum",
         },
         "workspace_state": {
-            "active_spectrum_key": "foreground",
             "peak_search_method": "mariscotti",
             "bayesian_source_id": "fluxforge_bundled_gamma",
             "ml_source_id": "fluxforge_bundled_gamma",
@@ -54,9 +53,6 @@ def _default_quantumgold_payload() -> dict[str, Any]:
             "background_mode": "simple",
             "background_scale": 1.0,
             "background_visible": True,
-            "pinned_nuclides": [],
-            "loaded_spectra": [],
-            "slot_assignments": {},
         },
         "sidebar_state": {
             "nuclide_query": "cs",
@@ -119,7 +115,7 @@ def _default_quantumgold_payload() -> dict[str, Any]:
 
 def _default_astm_ldrd_payload() -> dict[str, Any]:
     return {
-        "version": 1,
+        "version": 2,
         "mode_state": {
             "mode": "standards",
             "standard": "ASTM E261",
@@ -142,7 +138,6 @@ def _default_astm_ldrd_payload() -> dict[str, Any]:
             "current_tab": "Spectrum",
         },
         "workspace_state": {
-            "active_spectrum_key": "foreground",
             "peak_search_method": "mariscotti",
             "bayesian_source_id": "decay_2012",
             "ml_source_id": "decay_2012",
@@ -150,9 +145,6 @@ def _default_astm_ldrd_payload() -> dict[str, Any]:
             "background_mode": "scaled",
             "background_scale": 1.0,
             "background_visible": True,
-            "pinned_nuclides": [],
-            "loaded_spectra": [],
-            "slot_assignments": {},
         },
         "sidebar_state": {
             "nuclide_query": "co",

--- a/src/fluxforge/gui/workspace_undo.py
+++ b/src/fluxforge/gui/workspace_undo.py
@@ -1,0 +1,651 @@
+"""Focused undo commands for canonical analysis-workspace leaf edits.
+
+These commands intentionally retain only immutable domain leaves and stable IDs.
+In particular, they never retain a ``WorkspaceDocument``, the legacy projected
+``AnalysisWorkspaceState``, a ``GammaSpectrum``, or any spectrum array.  A drag
+may issue many previews, but ``MoveROIBoundsCommand`` merges committed updates
+that share one explicit drag token into a single undo-stack entry.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Protocol, Sequence, TypeAlias
+
+from fluxforge.core.workspace_document import (
+    AnalysisROI,
+    CalibrationModel,
+    CanvasViewport,
+    DetectorProfile,
+    FitDiagnostics,
+    PeakModel,
+    WorkspaceDocument,
+)
+from fluxforge.gui.qt_compat import QT_AVAILABLE
+
+if QT_AVAILABLE:  # pragma: no branch - selected once at import time
+    from fluxforge.gui.qt_compat import QUndoCommand
+else:  # pragma: no cover - import-safe fallback for non-GUI installations
+
+    class QUndoCommand:  # type: ignore[no-redef]
+        """Minimal import-safe stand-in; Qt is required to use an undo stack."""
+
+        def __init__(self, text: str = "") -> None:
+            self._text = text
+
+        def text(self) -> str:
+            return self._text
+
+        def id(self) -> int:
+            return -1
+
+        def mergeWith(self, other: object) -> bool:  # noqa: N802 - Qt API
+            return False
+
+
+CalibrationLeaf: TypeAlias = CalibrationModel | DetectorProfile | None
+
+
+@dataclass(frozen=True)
+class CalibrationUndoState:
+    """Small exact snapshot of calibration-owned persisted leaves."""
+
+    detector_profile_id: str | None
+    detector_profiles: tuple[DetectorProfile, ...]
+    calibration_payload: dict
+    energies: tuple[float, ...] | None
+
+    @classmethod
+    def from_document(
+        cls, document: WorkspaceDocument, spectrum_id: str
+    ) -> "CalibrationUndoState":
+        record = document.spectrum_by_id(spectrum_id)
+        if record is None:
+            raise KeyError(f"Unknown spectrum ID: {spectrum_id}")
+        energies = (
+            tuple(float(value) for value in record.spectrum.energies)
+            if record.spectrum.energies is not None
+            else None
+        )
+        return cls(
+            detector_profile_id=record.detector_profile_id,
+            detector_profiles=tuple(document.detector_profiles),
+            calibration_payload=deepcopy(dict(record.spectrum.calibration or {})),
+            energies=energies,
+        )
+
+
+class WorkspaceLeafController(Protocol):
+    """Small controller surface required by the focused commands."""
+
+    def replace_peak_models(
+        self, peaks: Sequence[PeakModel], *, spectrum_id: str | None = None
+    ) -> object: ...
+
+    def replace_all_peak_models(self, peaks: Sequence[PeakModel]) -> object: ...
+
+    def upsert_peak_model(
+        self, peak: PeakModel, *, index: int | None = None
+    ) -> object: ...
+
+    def delete_peak_model(self, spectrum_id: str, peak_id: str) -> object: ...
+
+    def upsert_roi(self, roi: AnalysisROI, *, index: int | None = None) -> object: ...
+
+    def delete_roi(self, roi_id: str) -> object: ...
+
+    def upsert_fit_diagnostic(self, diagnostic: FitDiagnostics) -> object: ...
+
+    def assign_spectrum_role(
+        self, role: str, spectrum_ids: str | Sequence[str] | None
+    ) -> object: ...
+
+    def upsert_detector_profile(self, profile: DetectorProfile) -> object: ...
+
+    def delete_detector_profile(self, profile_id: str) -> object: ...
+
+    def upsert_viewport(self, viewport: CanvasViewport) -> object: ...
+
+    def delete_viewport(self, viewport_id: str) -> object: ...
+
+    def set_pinned_nuclides(self, pinned_nuclides: Sequence[str]) -> object: ...
+
+    def apply_calibration(
+        self, spectrum_id: str, calibration_state: CalibrationLeaf
+    ) -> object: ...
+
+    def restore_calibration_state(
+        self, spectrum_id: str, state: CalibrationUndoState
+    ) -> object: ...
+
+
+class _WorkspaceLeafCommand(QUndoCommand):
+    """Shared command base that retains only the controller reference."""
+
+    def __init__(self, controller: WorkspaceLeafController, description: str) -> None:
+        super().__init__(description)
+        self.controller = controller
+
+
+class ReplacePeakSetCommand(_WorkspaceLeafCommand):
+    """Replace all peak-model leaves for one spectrum."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        spectrum_id: str,
+        before: Sequence[PeakModel],
+        after: Sequence[PeakModel],
+        before_document_peaks: Sequence[PeakModel] | None = None,
+        related_rois: Sequence[AnalysisROI] | None = None,
+        related_diagnostics: Sequence[FitDiagnostics] | None = None,
+        description: str = "Replace peaks",
+    ) -> None:
+        super().__init__(controller, description)
+        self.spectrum_id = spectrum_id
+        self.before = tuple(before)
+        self.after = tuple(after)
+        if any(peak.spectrum_id != spectrum_id for peak in self.before + self.after):
+            raise ValueError("all peaks must belong to spectrum_id")
+        removed_peak_ids = {item.peak_id for item in self.before} - {
+            item.peak_id for item in self.after
+        }
+        document = _controller_document(controller)
+        if before_document_peaks is None and document is not None:
+            before_document_peaks = document.peaks
+        self.before_document_peaks = (
+            tuple(before_document_peaks) if before_document_peaks is not None else None
+        )
+        if related_rois is None:
+            related_rois = (
+                tuple(
+                    item
+                    for item in document.rois
+                    if item.spectrum_id == spectrum_id
+                    and removed_peak_ids.intersection(item.associated_peak_ids)
+                )
+                if document is not None
+                else ()
+            )
+        if related_diagnostics is None:
+            related_diagnostics = (
+                tuple(
+                    item
+                    for item in document.fit_diagnostics
+                    if item.spectrum_id == spectrum_id
+                    and item.peak_id in removed_peak_ids
+                )
+                if document is not None
+                else ()
+            )
+        self.related_rois = tuple(related_rois)
+        self.related_diagnostics = tuple(related_diagnostics)
+
+    def undo(self) -> None:
+        if self.before_document_peaks is not None:
+            self.controller.replace_all_peak_models(self.before_document_peaks)
+        else:
+            self.controller.replace_peak_models(
+                self.before, spectrum_id=self.spectrum_id
+            )
+        for roi in self.related_rois:
+            self.controller.upsert_roi(roi)
+        for diagnostic in self.related_diagnostics:
+            self.controller.upsert_fit_diagnostic(diagnostic)
+
+    def redo(self) -> None:
+        self.controller.replace_peak_models(self.after, spectrum_id=self.spectrum_id)
+
+
+class UpdatePeakCommand(_WorkspaceLeafCommand):
+    """Add or replace one peak-model leaf."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        before: PeakModel | None,
+        after: PeakModel,
+        description: str = "Update peak",
+    ) -> None:
+        super().__init__(controller, description)
+        if before is not None and (
+            before.spectrum_id,
+            before.peak_id,
+        ) != (after.spectrum_id, after.peak_id):
+            raise ValueError("before and after must identify the same peak")
+        self.spectrum_id = after.spectrum_id
+        self.peak_id = after.peak_id
+        self.before = before
+        self.after = after
+
+    def undo(self) -> None:
+        if self.before is None:
+            self.controller.delete_peak_model(self.spectrum_id, self.peak_id)
+        else:
+            self.controller.upsert_peak_model(self.before)
+
+    def redo(self) -> None:
+        self.controller.upsert_peak_model(self.after)
+
+
+class DeletePeakCommand(_WorkspaceLeafCommand):
+    """Delete one peak and retain only directly affected leaves for undo."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        peak: PeakModel,
+        peak_index: int | None = None,
+        related_rois: Sequence[AnalysisROI] | None = None,
+        related_diagnostics: Sequence[FitDiagnostics] | None = None,
+        description: str = "Delete peak",
+    ) -> None:
+        super().__init__(controller, description)
+        self.peak = peak
+        self.spectrum_id = peak.spectrum_id
+        self.peak_id = peak.peak_id
+        document = _controller_document(controller)
+        if peak_index is None and document is not None:
+            peak_index = next(
+                (
+                    index
+                    for index, item in enumerate(document.peaks)
+                    if (item.spectrum_id, item.peak_id)
+                    == (self.spectrum_id, self.peak_id)
+                ),
+                None,
+            )
+        self.peak_index = peak_index
+        if related_rois is None:
+            related_rois = (
+                tuple(
+                    item
+                    for item in document.rois
+                    if item.spectrum_id == self.spectrum_id
+                    and self.peak_id in item.associated_peak_ids
+                )
+                if document is not None
+                else ()
+            )
+        if related_diagnostics is None:
+            related_diagnostics = (
+                tuple(
+                    item
+                    for item in document.fit_diagnostics
+                    if item.spectrum_id == self.spectrum_id
+                    and item.peak_id == self.peak_id
+                )
+                if document is not None
+                else ()
+            )
+        self.related_rois = tuple(related_rois)
+        self.related_diagnostics = tuple(related_diagnostics)
+
+    def undo(self) -> None:
+        self.controller.upsert_peak_model(self.peak, index=self.peak_index)
+        for roi in self.related_rois:
+            self.controller.upsert_roi(roi)
+        for diagnostic in self.related_diagnostics:
+            self.controller.upsert_fit_diagnostic(diagnostic)
+
+    def redo(self) -> None:
+        self.controller.delete_peak_model(self.spectrum_id, self.peak_id)
+
+
+class UpdatePeakAssignmentCommand(_WorkspaceLeafCommand):
+    """Update assignments/tags represented by old and new peak leaves."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        before: PeakModel,
+        after: PeakModel,
+        description: str = "Update peak assignment",
+    ) -> None:
+        super().__init__(controller, description)
+        if (before.spectrum_id, before.peak_id) != (
+            after.spectrum_id,
+            after.peak_id,
+        ):
+            raise ValueError("before and after must identify the same peak")
+        self.before = before
+        self.after = after
+
+    def undo(self) -> None:
+        self.controller.upsert_peak_model(self.before)
+
+    def redo(self) -> None:
+        self.controller.upsert_peak_model(self.after)
+
+
+class TogglePinnedNuclideCommand(_WorkspaceLeafCommand):
+    """Replace the small ordered set of pinned nuclide identifiers."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        before: Sequence[str],
+        after: Sequence[str],
+        description: str = "Update pinned nuclides",
+    ) -> None:
+        super().__init__(controller, description)
+        self.before = tuple(before)
+        self.after = tuple(after)
+
+    def undo(self) -> None:
+        self.controller.set_pinned_nuclides(self.before)
+
+    def redo(self) -> None:
+        self.controller.set_pinned_nuclides(self.after)
+
+
+class UpsertROICommand(_WorkspaceLeafCommand):
+    """Add or replace one ROI leaf."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        before: AnalysisROI | None,
+        after: AnalysisROI,
+        description: str = "Update ROI",
+    ) -> None:
+        super().__init__(controller, description)
+        if before is not None and before.roi_id != after.roi_id:
+            raise ValueError("before and after must identify the same ROI")
+        self.roi_id = after.roi_id
+        self.before = before
+        self.after = after
+
+    def undo(self) -> None:
+        if self.before is None:
+            self.controller.delete_roi(self.roi_id)
+        else:
+            self.controller.upsert_roi(self.before)
+
+    def redo(self) -> None:
+        self.controller.upsert_roi(self.after)
+
+
+class DeleteROICommand(_WorkspaceLeafCommand):
+    """Delete one ROI and retain only directly affected leaves for undo."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        roi: AnalysisROI,
+        roi_index: int | None = None,
+        related_peaks: Sequence[PeakModel] | None = None,
+        related_diagnostics: Sequence[FitDiagnostics] | None = None,
+        related_viewports: Sequence[CanvasViewport] | None = None,
+        description: str = "Delete ROI",
+    ) -> None:
+        super().__init__(controller, description)
+        self.roi = roi
+        self.roi_id = roi.roi_id
+        document = _controller_document(controller)
+        if roi_index is None and document is not None:
+            roi_index = next(
+                (
+                    index
+                    for index, item in enumerate(document.rois)
+                    if item.roi_id == self.roi_id
+                ),
+                None,
+            )
+        self.roi_index = roi_index
+        if related_peaks is None:
+            related_peaks = (
+                tuple(item for item in document.peaks if item.roi_id == self.roi_id)
+                if document is not None
+                else ()
+            )
+        if related_diagnostics is None:
+            related_diagnostics = (
+                tuple(
+                    item
+                    for item in document.fit_diagnostics
+                    if item.roi_id == self.roi_id
+                )
+                if document is not None
+                else ()
+            )
+        if related_viewports is None:
+            related_viewports = (
+                tuple(
+                    item
+                    for item in document.viewports
+                    if item.selected_roi_id == self.roi_id
+                )
+                if document is not None
+                else ()
+            )
+        self.related_peaks = tuple(related_peaks)
+        self.related_diagnostics = tuple(related_diagnostics)
+        self.related_viewports = tuple(related_viewports)
+
+    def undo(self) -> None:
+        self.controller.upsert_roi(self.roi, index=self.roi_index)
+        for peak in self.related_peaks:
+            self.controller.upsert_peak_model(peak)
+        for diagnostic in self.related_diagnostics:
+            self.controller.upsert_fit_diagnostic(diagnostic)
+        for viewport in self.related_viewports:
+            self.controller.upsert_viewport(viewport)
+
+    def redo(self) -> None:
+        self.controller.delete_roi(self.roi_id)
+
+
+def _controller_document(
+    controller: WorkspaceLeafController,
+) -> WorkspaceDocument | None:
+    """Return a controller's canonical document without widening the protocol."""
+
+    document = getattr(controller, "document", None)
+    return document if isinstance(document, WorkspaceDocument) else None
+
+
+class MoveROIBoundsCommand(_WorkspaceLeafCommand):
+    """Commit one ROI-bound drag, merging updates from the same drag gesture."""
+
+    COMMAND_ID = 0x464652  # stable, process-independent ``FFR`` identifier
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        before: AnalysisROI,
+        after: AnalysisROI,
+        drag_token: str,
+        description: str = "Move ROI bounds",
+    ) -> None:
+        super().__init__(controller, description)
+        if (before.spectrum_id, before.roi_id) != (
+            after.spectrum_id,
+            after.roi_id,
+        ):
+            raise ValueError("before and after must identify the same ROI")
+        if not drag_token:
+            raise ValueError("drag_token must be a non-empty stable gesture ID")
+        self.spectrum_id = before.spectrum_id
+        self.roi_id = before.roi_id
+        self.drag_token = drag_token
+        self.before = before
+        self.after = after
+
+    def id(self) -> int:
+        return self.COMMAND_ID
+
+    def mergeWith(self, other: object) -> bool:  # noqa: N802 - Qt API
+        if not isinstance(other, MoveROIBoundsCommand):
+            return False
+        if (
+            self.controller is not other.controller
+            or self.spectrum_id != other.spectrum_id
+            or self.roi_id != other.roi_id
+            or self.drag_token != other.drag_token
+        ):
+            return False
+        self.after = other.after
+        return True
+
+    def undo(self) -> None:
+        self.controller.upsert_roi(self.before)
+
+    def redo(self) -> None:
+        self.controller.upsert_roi(self.after)
+
+
+class AssignSpectrumRoleCommand(_WorkspaceLeafCommand):
+    """Replace one named spectrum-role assignment."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        role: str,
+        before: Sequence[str],
+        after: Sequence[str],
+        description: str = "Assign spectrum role",
+    ) -> None:
+        super().__init__(controller, description)
+        self.role = role
+        self.before = tuple(before)
+        self.after = tuple(after)
+
+    def undo(self) -> None:
+        self.controller.assign_spectrum_role(self.role, self.before)
+
+    def redo(self) -> None:
+        self.controller.assign_spectrum_role(self.role, self.after)
+
+
+class UpdateDetectorProfileCommand(_WorkspaceLeafCommand):
+    """Add or replace one detector-profile leaf."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        before: DetectorProfile | None,
+        after: DetectorProfile,
+        description: str = "Update detector profile",
+    ) -> None:
+        super().__init__(controller, description)
+        if before is not None and (
+            before.detector_profile_id != after.detector_profile_id
+        ):
+            raise ValueError("before and after must identify the same detector profile")
+        self.profile_id = after.detector_profile_id
+        self.before = before
+        self.after = after
+
+    def undo(self) -> None:
+        if self.before is None:
+            self.controller.delete_detector_profile(self.profile_id)
+        else:
+            self.controller.upsert_detector_profile(self.before)
+
+    def redo(self) -> None:
+        self.controller.upsert_detector_profile(self.after)
+
+
+class UpdateCanvasViewportCommand(_WorkspaceLeafCommand):
+    """Add or replace one persisted canvas viewport leaf."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        before: CanvasViewport | None,
+        after: CanvasViewport,
+        description: str = "Update canvas view",
+    ) -> None:
+        super().__init__(controller, description)
+        if before is not None and before.viewport_id != after.viewport_id:
+            raise ValueError("before and after must identify the same viewport")
+        self.viewport_id = after.viewport_id
+        self.before = before
+        self.after = after
+
+    def undo(self) -> None:
+        if self.before is None:
+            self.controller.delete_viewport(self.viewport_id)
+        else:
+            self.controller.upsert_viewport(self.before)
+
+    def redo(self) -> None:
+        self.controller.upsert_viewport(self.after)
+
+
+class ApplyCalibrationCommand(_WorkspaceLeafCommand):
+    """Apply a calibration leaf without retaining a spectrum or its arrays."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        spectrum_id: str,
+        before: CalibrationLeaf,
+        after: CalibrationLeaf,
+        before_state: CalibrationUndoState | None = None,
+        description: str = "Apply calibration",
+    ) -> None:
+        super().__init__(controller, description)
+        for value in (before, after):
+            if value is not None and not isinstance(
+                value, (CalibrationModel, DetectorProfile)
+            ):
+                raise TypeError(
+                    "calibration state must be CalibrationModel, DetectorProfile, or None"
+                )
+        self.spectrum_id = spectrum_id
+        self.before = before
+        self.after = after
+        document = _controller_document(controller)
+        self.before_state = (
+            before_state
+            if before_state is not None
+            else (
+                CalibrationUndoState.from_document(document, spectrum_id)
+                if document is not None
+                else None
+            )
+        )
+
+    def undo(self) -> None:
+        if self.before_state is not None:
+            self.controller.restore_calibration_state(
+                self.spectrum_id, self.before_state
+            )
+        else:
+            self.controller.apply_calibration(self.spectrum_id, self.before)
+
+    def redo(self) -> None:
+        self.controller.apply_calibration(self.spectrum_id, self.after)
+
+
+__all__ = [
+    "ApplyCalibrationCommand",
+    "AssignSpectrumRoleCommand",
+    "CalibrationUndoState",
+    "DeletePeakCommand",
+    "DeleteROICommand",
+    "MoveROIBoundsCommand",
+    "ReplacePeakSetCommand",
+    "TogglePinnedNuclideCommand",
+    "UpdateCanvasViewportCommand",
+    "UpdateDetectorProfileCommand",
+    "UpdatePeakAssignmentCommand",
+    "UpdatePeakCommand",
+    "UpsertROICommand",
+    "WorkspaceLeafController",
+]

--- a/src/fluxforge/io/__init__.py
+++ b/src/fluxforge/io/__init__.py
@@ -90,6 +90,10 @@ from fluxforge.io.reader_factory import (
 )
 from fluxforge.io.session import (
     FluxForgeSession,
+    SESSION_FORMAT,
+    SESSION_FORMAT_VERSION,
+    SessionFormatError,
+    migrate_session_payload,
     read_ffs_session,
     session_from_spectra,
     write_ffs_session,
@@ -220,6 +224,10 @@ __all__ = [
     "write_n42_file",
     # Session I/O
     "FluxForgeSession",
+    "SESSION_FORMAT",
+    "SESSION_FORMAT_VERSION",
+    "SessionFormatError",
+    "migrate_session_payload",
     "read_ffs_session",
     "session_from_spectra",
     "write_ffs_session",

--- a/src/fluxforge/io/atomic.py
+++ b/src/fluxforge/io/atomic.py
@@ -1,0 +1,174 @@
+"""Crash-safe atomic JSON persistence helpers.
+
+The target file is never opened for writing.  JSON is serialized in memory, then
+written and synced through a temporary file in the target directory before one
+atomic replacement.  This keeps an existing document intact if serialization,
+temporary-file writing, or replacement fails.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, TextIO
+
+
+class AtomicWriteError(OSError):
+    """An I/O failure during an atomic persistence operation."""
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        phase: str,
+        cause: BaseException,
+        replacement_completed: bool = False,
+    ) -> None:
+        self.path = path
+        self.phase = phase
+        self.replacement_completed = replacement_completed
+
+        if phase == "create":
+            guidance = (
+                "Could not create a temporary file beside the target. Check that "
+                "the folder exists and is writable."
+            )
+        elif phase == "write":
+            guidance = (
+                "Could not completely write and sync the temporary file. The "
+                "original file remains unchanged."
+            )
+        elif phase == "replace":
+            guidance = (
+                "Could not atomically replace the target; the original file "
+                "remains unchanged. Close applications that may have the file "
+                "open and allow OneDrive or other sync software to release any "
+                "Windows file lock before retrying."
+            )
+        elif phase == "directory-sync":
+            guidance = (
+                "The target was replaced, but its parent directory could not be "
+                "synced. The new file is visible, although crash durability could "
+                "not be confirmed."
+            )
+        else:
+            guidance = "Atomic persistence failed."
+
+        super().__init__(f"{guidance} Target: {path}. Cause: {cause}")
+
+
+def _write_serialized(stream: TextIO, serialized: str) -> None:
+    """Write and durably flush serialized JSON to an open temporary stream."""
+
+    stream.write(serialized)
+    stream.flush()
+    os.fsync(stream.fileno())
+
+
+def _fsync_parent_directory(directory: Path) -> None:
+    """Persist replacement metadata on POSIX filesystems."""
+
+    if os.name != "posix":
+        return
+
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    directory_fd = os.open(directory, flags)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def atomic_write_json(
+    path: str | os.PathLike[str],
+    payload: Any,
+    *,
+    indent: int | None = 2,
+    sort_keys: bool = False,
+) -> Path:
+    """Serialize *payload* and atomically replace the JSON file at *path*.
+
+    Serialization happens before any filesystem operation. Non-finite floats are
+    rejected so a successful write is always standards-compliant JSON. The
+    destination directory must already exist.
+
+    Returns
+    -------
+    pathlib.Path
+        The destination path after a successful, durable replacement.
+    """
+
+    target = Path(path)
+    serialized = json.dumps(
+        payload,
+        indent=indent,
+        sort_keys=sort_keys,
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    if not serialized.endswith("\n"):
+        serialized += "\n"
+
+    directory = target.parent
+    temporary: Path | None = None
+
+    try:
+        try:
+            file_descriptor, temporary_name = tempfile.mkstemp(
+                dir=directory,
+                prefix=f".{target.name}.",
+                suffix=".tmp",
+            )
+            temporary = Path(temporary_name)
+        except OSError as exc:
+            raise AtomicWriteError(target, phase="create", cause=exc) from exc
+
+        try:
+            try:
+                stream = os.fdopen(
+                    file_descriptor,
+                    mode="w",
+                    encoding="utf-8",
+                    newline="\n",
+                )
+            except Exception:
+                try:
+                    os.close(file_descriptor)
+                except OSError:
+                    pass
+                raise
+            with stream:
+                _write_serialized(stream, serialized)
+        except Exception as exc:
+            raise AtomicWriteError(target, phase="write", cause=exc) from exc
+
+        try:
+            os.replace(temporary, target)
+        except OSError as exc:
+            raise AtomicWriteError(target, phase="replace", cause=exc) from exc
+
+        temporary = None
+        try:
+            _fsync_parent_directory(directory)
+        except OSError as exc:
+            raise AtomicWriteError(
+                target,
+                phase="directory-sync",
+                cause=exc,
+                replacement_completed=True,
+            ) from exc
+    finally:
+        if temporary is not None:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                # Preserve the primary error. Cleanup is best-effort when an
+                # external Windows/OneDrive lock also prevents temp deletion.
+                pass
+
+    return target
+
+
+__all__ = ["AtomicWriteError", "atomic_write_json"]

--- a/src/fluxforge/io/session.py
+++ b/src/fluxforge/io/session.py
@@ -1,71 +1,188 @@
-"""FluxForge `.ffs` session file read/write helpers."""
+"""Versioned FluxForge ``.ffs`` session persistence and v1 migration."""
 
 from __future__ import annotations
 
-import json
-from dataclasses import dataclass, field
+from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
+from fluxforge.core.workspace_document import (
+    SpectrumRoleAssignment,
+    WorkspaceDocument,
+    WorkspaceSpectrum,
+)
 from fluxforge.hal import DeviceRegistry
+from fluxforge.io.atomic import atomic_write_json
 from fluxforge.io.spe import GammaSpectrum
 
 
-SESSION_FORMAT_VERSION = 1
+SESSION_FORMAT = "fluxforge_session"
+SESSION_FORMAT_VERSION = 2
+
+_V1_FIELDS = frozenset(
+    {
+        "format",
+        "format_version",
+        "created_at",
+        "active_spectrum_index",
+        "source_files",
+        "recent_files",
+        "device_snapshot",
+        "metadata",
+        "spectra",
+    }
+)
+_V2_FIELDS = frozenset(
+    {
+        "format",
+        "format_version",
+        "document",
+        "recent_files",
+        "device_snapshot",
+        "metadata",
+        "created_at",
+    }
+)
 
 
-@dataclass
+class SessionFormatError(ValueError):
+    """A malformed or unsupported FluxForge session envelope."""
+
+
 class FluxForgeSession:
-    """Serializable session container for the modern GUI and CLI."""
+    """Canonical v2 session with legacy attribute compatibility.
 
-    spectra: list[GammaSpectrum] = field(default_factory=list)
-    active_spectrum_index: int = 0
-    source_files: list[str] = field(default_factory=list)
-    recent_files: list[str] = field(default_factory=list)
-    device_snapshot: list[dict[str, str]] = field(default_factory=list)
-    metadata: dict[str, Any] = field(default_factory=dict)
-    created_at: str = field(
-        default_factory=lambda: datetime.now(timezone.utc)
-        .replace(microsecond=0)
-        .isoformat()
-    )
+    ``document`` is the persisted scientific state.  The ``spectra``,
+    ``active_spectrum_index`` and ``source_files`` properties retain the v1 API
+    used by existing GUI code while new callers can work directly with the
+    :class:`~fluxforge.core.workspace_document.WorkspaceDocument`.
+    """
+
+    def __init__(
+        self,
+        spectra: Iterable[GammaSpectrum] = (),
+        active_spectrum_index: int = 0,
+        source_files: Iterable[str | Path] = (),
+        recent_files: Iterable[str | Path] = (),
+        device_snapshot: Iterable[Mapping[str, Any]] = (),
+        metadata: Mapping[str, Any] | None = None,
+        created_at: str | None = None,
+        *,
+        document: WorkspaceDocument | None = None,
+    ) -> None:
+        if document is None:
+            document = _document_from_spectra(
+                spectra,
+                active_spectrum_index=active_spectrum_index,
+                source_files=source_files,
+                document_id="workspace",
+            )
+        elif list(spectra) or list(source_files) or active_spectrum_index != 0:
+            raise ValueError(
+                "Pass either document or legacy spectra/source/index fields, not both."
+            )
+        document.validate()
+        self.document = document
+        self.recent_files = [str(Path(value)) for value in recent_files]
+        self.device_snapshot = [deepcopy(dict(item)) for item in device_snapshot]
+        self.metadata = deepcopy(dict(metadata or {}))
+        self.created_at = created_at if created_at is not None else _utc_timestamp()
+
+    @property
+    def spectra(self) -> list[GammaSpectrum]:
+        """Return spectra in their persisted document order (v1 facade)."""
+
+        return [item.spectrum for item in self.document.spectra]
+
+    @property
+    def active_spectrum_index(self) -> int:
+        """Return the active spectrum's document index (v1 facade)."""
+
+        active_id = self.document.active_spectrum_id
+        if active_id is None:
+            return 0
+        for index, item in enumerate(self.document.spectra):
+            if item.spectrum_id == active_id:
+                return index
+        raise SessionFormatError(
+            f"Active spectrum {active_id!r} is not present in the workspace."
+        )
+
+    @property
+    def source_files(self) -> list[str]:
+        """Return one source path per spectrum where available (v1 facade)."""
+
+        paths = [str(item.source_path or "") for item in self.document.spectra]
+        for extension_key in (
+            "legacy_unmatched_source_files",
+            "unmatched_source_files",
+        ):
+            unmatched = self.document.extensions.get(extension_key, [])
+            if isinstance(unmatched, (list, tuple)):
+                paths.extend(str(value) for value in unmatched)
+        return paths
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert the session to a JSON-serializable payload."""
+        """Return the canonical v2 JSON envelope."""
 
+        self.document.validate()
+        _require_string(self.created_at, "created_at", allow_empty=True)
         return {
-            "format": "fluxforge_session",
+            "format": SESSION_FORMAT,
             "format_version": SESSION_FORMAT_VERSION,
-            "created_at": self.created_at,
-            "active_spectrum_index": self.active_spectrum_index,
-            "source_files": list(self.source_files),
+            "document": self.document.to_dict(),
             "recent_files": list(self.recent_files),
-            "device_snapshot": list(self.device_snapshot),
-            "metadata": dict(self.metadata),
-            "spectra": [spectrum.to_dict() for spectrum in self.spectra],
+            "device_snapshot": deepcopy(self.device_snapshot),
+            "metadata": deepcopy(self.metadata),
+            "created_at": self.created_at,
         }
 
     @classmethod
-    def from_dict(cls, payload: dict[str, Any]) -> "FluxForgeSession":
-        """Build a session object from a persisted payload."""
+    def from_dict(cls, payload: Mapping[str, Any]) -> "FluxForgeSession":
+        """Build a session from a v1, unversioned, or v2 payload."""
 
-        spectra = [
-            GammaSpectrum.from_dict(record) for record in payload.get("spectra", [])
-        ]
+        migrated = migrate_session_payload(payload)
         return cls(
-            spectra=spectra,
-            active_spectrum_index=int(payload.get("active_spectrum_index", 0) or 0),
-            source_files=[str(value) for value in payload.get("source_files", [])],
-            recent_files=[str(value) for value in payload.get("recent_files", [])],
-            device_snapshot=[
-                {str(key): str(value) for key, value in dict(item).items()}
-                for item in payload.get("device_snapshot", [])
-                if isinstance(item, dict)
-            ],
-            metadata=dict(payload.get("metadata", {})),
-            created_at=str(payload.get("created_at") or ""),
+            document=WorkspaceDocument.from_dict(migrated["document"]),
+            recent_files=migrated["recent_files"],
+            device_snapshot=migrated["device_snapshot"],
+            metadata=migrated["metadata"],
+            created_at=migrated["created_at"],
         )
+
+
+def migrate_session_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Purely migrate a legacy session payload to the canonical v2 envelope.
+
+    The input mapping is never mutated. Calling this function again on its v2
+    result produces an equal value. Unknown legacy top-level data and source
+    paths that cannot be matched by index are retained in document extensions.
+    """
+
+    if not isinstance(payload, Mapping):
+        raise SessionFormatError("FluxForge session payload must be a JSON object.")
+    source = deepcopy(dict(payload))
+    declared_format = source.get("format")
+    if declared_format not in (None, SESSION_FORMAT):
+        raise SessionFormatError(
+            f"Unsupported session format {declared_format!r}; "
+            f"expected {SESSION_FORMAT!r}."
+        )
+
+    version = source.get("format_version", 1)
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise SessionFormatError("Session format_version must be an integer.")
+    if version > SESSION_FORMAT_VERSION:
+        raise SessionFormatError(
+            f"Session format version {version} is newer than supported version "
+            f"{SESSION_FORMAT_VERSION}."
+        )
+    if version < 1:
+        raise SessionFormatError(f"Unsupported session format version {version}.")
+    if version == SESSION_FORMAT_VERSION:
+        return _canonicalize_v2(source)
+    return _migrate_v1(source)
 
 
 def session_from_spectra(
@@ -77,44 +194,284 @@ def session_from_spectra(
     device_registry: DeviceRegistry | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> FluxForgeSession:
-    """Create a session from spectra and optional workflow metadata."""
+    """Create a new canonical session from spectra and workflow metadata."""
 
     return FluxForgeSession(
         spectra=list(spectra),
         active_spectrum_index=active_spectrum_index,
-        source_files=[str(Path(path)) for path in source_files],
-        recent_files=[str(Path(path)) for path in recent_files],
+        source_files=source_files,
+        recent_files=recent_files,
         device_snapshot=(
             device_registry.snapshot() if device_registry is not None else []
         ),
-        metadata=dict(metadata or {}),
+        metadata=metadata,
     )
 
 
 def write_ffs_session(path: str | Path, session: FluxForgeSession) -> dict[str, Any]:
-    """Write a `.ffs` session file."""
+    """Atomically write a canonical v2 ``.ffs`` session file."""
 
-    path = Path(path)
-    if path.suffix.lower() != ".ffs":
+    target = Path(path)
+    if target.suffix.lower() != ".ffs":
         raise ValueError("FluxForge sessions must use the `.ffs` extension.")
+    if not isinstance(session, FluxForgeSession):
+        raise TypeError("session must be a FluxForgeSession instance.")
     payload = session.to_dict()
-    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    atomic_write_json(target, payload)
     return payload
 
 
 def read_ffs_session(path: str | Path) -> FluxForgeSession:
-    """Read a `.ffs` session file."""
+    """Read and validate a v1, unversioned, or v2 ``.ffs`` session file."""
 
-    path = Path(path)
-    payload = json.loads(path.read_text(encoding="utf-8"))
-    if payload.get("format") != "fluxforge_session":
-        raise ValueError(f"{path} is not a FluxForge session file.")
-    return FluxForgeSession.from_dict(payload)
+    import json
+
+    source = Path(path)
+    try:
+        payload = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise SessionFormatError(
+            f"Could not read FluxForge session {source}: {exc}"
+        ) from exc
+    try:
+        return FluxForgeSession.from_dict(payload)
+    except (TypeError, ValueError) as exc:
+        if isinstance(exc, SessionFormatError):
+            raise
+        raise SessionFormatError(f"Invalid FluxForge session {source}: {exc}") from exc
+
+
+def _canonicalize_v2(payload: dict[str, Any]) -> dict[str, Any]:
+    unknown = sorted(set(payload).difference(_V2_FIELDS))
+    if unknown:
+        raise SessionFormatError(
+            "Version 2 session contains unknown top-level fields: " + ", ".join(unknown)
+        )
+    if payload.get("format") != SESSION_FORMAT:
+        raise SessionFormatError(
+            f"Version 2 session format must be {SESSION_FORMAT!r}."
+        )
+    if not isinstance(payload.get("document"), Mapping):
+        raise SessionFormatError("Version 2 session document must be an object.")
+    try:
+        document = WorkspaceDocument.from_dict(payload["document"])
+        document.validate()
+    except (KeyError, TypeError, ValueError) as exc:
+        raise SessionFormatError(
+            f"Version 2 session document is invalid: {exc}"
+        ) from exc
+    recent_files = _string_list(payload.get("recent_files"), "recent_files")
+    device_snapshot = _mapping_list(payload.get("device_snapshot"), "device_snapshot")
+    metadata = _mapping(payload.get("metadata"), "metadata")
+    created_at = _require_string(
+        payload.get("created_at"), "created_at", allow_empty=True
+    )
+    return {
+        "format": SESSION_FORMAT,
+        "format_version": SESSION_FORMAT_VERSION,
+        "document": document.to_dict(),
+        "recent_files": recent_files,
+        "device_snapshot": device_snapshot,
+        "metadata": metadata,
+        "created_at": created_at,
+    }
+
+
+def _migrate_v1(payload: dict[str, Any]) -> dict[str, Any]:
+    if "spectra" not in payload:
+        raise SessionFormatError(
+            "Legacy session payload is missing the required spectra array."
+        )
+    raw_spectra = payload.get("spectra", [])
+    if not isinstance(raw_spectra, list):
+        raise SessionFormatError("Legacy session spectra must be an array.")
+    source_files = _string_list(payload.get("source_files", []), "source_files")
+    active_index = _active_index(
+        payload.get("active_spectrum_index", 0), len(raw_spectra)
+    )
+
+    workspace_spectra: list[WorkspaceSpectrum] = []
+    for index, raw_spectrum in enumerate(raw_spectra):
+        if not isinstance(raw_spectrum, Mapping):
+            raise SessionFormatError(
+                f"Legacy spectrum at index {index} must be an object."
+            )
+        try:
+            spectrum = GammaSpectrum.from_dict(dict(raw_spectrum))
+        except (KeyError, TypeError, ValueError) as exc:
+            raise SessionFormatError(
+                f"Legacy spectrum at index {index} is invalid: {exc}"
+            ) from exc
+        spectrum_id = f"legacy-spectrum-{index + 1}"
+        source_path = source_files[index] if index < len(source_files) else None
+        label = spectrum.spectrum_id or (
+            Path(source_path).name if source_path else f"Spectrum {index + 1}"
+        )
+        workspace_spectra.append(
+            WorkspaceSpectrum(
+                spectrum_id=spectrum_id,
+                spectrum=spectrum,
+                label=label,
+                source_path=source_path or None,
+                provenance={"migrated_from_session_version": 1},
+            )
+        )
+
+    unknown = {
+        str(key): deepcopy(value)
+        for key, value in payload.items()
+        if key not in _V1_FIELDS
+    }
+    extensions: dict[str, Any] = {}
+    if unknown:
+        extensions["legacy_unknown_top_level"] = unknown
+    if len(source_files) > len(workspace_spectra):
+        extensions["legacy_unmatched_source_files"] = source_files[
+            len(workspace_spectra) :
+        ]
+
+    active_id = (
+        workspace_spectra[active_index].spectrum_id if workspace_spectra else None
+    )
+    roles = (
+        (SpectrumRoleAssignment(role="foreground", spectrum_ids=(active_id,)),)
+        if active_id is not None
+        else ()
+    )
+    legacy_created_at = _require_string(
+        payload.get("created_at", ""), "created_at", allow_empty=True
+    )
+    document_timestamp = legacy_created_at or "1970-01-01T00:00:00+00:00"
+    document = WorkspaceDocument(
+        document_id="legacy-session",
+        title=str(_mapping(payload.get("metadata", {}), "metadata").get("title", "")),
+        created_at=document_timestamp,
+        updated_at=document_timestamp,
+        spectra=tuple(workspace_spectra),
+        spectrum_roles=roles,
+        active_spectrum_id=active_id,
+        provenance={"migrated_from_session_version": 1},
+        extensions=extensions,
+    )
+    document.validate()
+    return {
+        "format": SESSION_FORMAT,
+        "format_version": SESSION_FORMAT_VERSION,
+        "document": document.to_dict(),
+        "recent_files": _string_list(payload.get("recent_files", []), "recent_files"),
+        "device_snapshot": _mapping_list(
+            payload.get("device_snapshot", []), "device_snapshot"
+        ),
+        "metadata": _mapping(payload.get("metadata", {}), "metadata"),
+        "created_at": legacy_created_at,
+    }
+
+
+def _document_from_spectra(
+    spectra: Iterable[GammaSpectrum],
+    *,
+    active_spectrum_index: int,
+    source_files: Iterable[str | Path],
+    document_id: str,
+) -> WorkspaceDocument:
+    spectrum_values = list(spectra)
+    path_values = [str(Path(value)) for value in source_files]
+    index = _active_index(active_spectrum_index, len(spectrum_values))
+    records = tuple(
+        WorkspaceSpectrum(
+            spectrum_id=f"spectrum-{position + 1}",
+            spectrum=spectrum,
+            label=spectrum.spectrum_id
+            or (Path(path_values[position]).name if position < len(path_values) else "")
+            or f"Spectrum {position + 1}",
+            source_path=(
+                path_values[position]
+                if position < len(path_values) and path_values[position]
+                else None
+            ),
+        )
+        for position, spectrum in enumerate(spectrum_values)
+    )
+    active_id = records[index].spectrum_id if records else None
+    roles = (
+        (SpectrumRoleAssignment(role="foreground", spectrum_ids=(active_id,)),)
+        if active_id is not None
+        else ()
+    )
+    extensions: dict[str, Any] = {}
+    if len(path_values) > len(records):
+        extensions["unmatched_source_files"] = path_values[len(records) :]
+    return WorkspaceDocument(
+        document_id=document_id,
+        spectra=records,
+        spectrum_roles=roles,
+        active_spectrum_id=active_id,
+        extensions=extensions,
+    )
+
+
+def _active_index(value: Any, spectrum_count: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise SessionFormatError("active_spectrum_index must be an integer.")
+    if spectrum_count == 0:
+        if value != 0:
+            raise SessionFormatError(
+                "An empty session must use active_spectrum_index 0."
+            )
+        return 0
+    if value < 0 or value >= spectrum_count:
+        raise SessionFormatError(
+            f"active_spectrum_index {value} is outside 0..{spectrum_count - 1}."
+        )
+    return value
+
+
+def _mapping(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SessionFormatError(f"{name} must be an object.")
+    return deepcopy(dict(value))
+
+
+def _mapping_list(value: Any, name: str) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise SessionFormatError(f"{name} must be an array.")
+    result: list[dict[str, Any]] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise SessionFormatError(f"{name}[{index}] must be an object.")
+        result.append(deepcopy(dict(item)))
+    return result
+
+
+def _string_list(value: Any, name: str) -> list[str]:
+    if not isinstance(value, list):
+        raise SessionFormatError(f"{name} must be an array.")
+    result: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            raise SessionFormatError(f"{name}[{index}] must be a string.")
+        result.append(item)
+    return result
+
+
+def _require_string(value: Any, name: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise SessionFormatError(f"{name} must be a string.")
+    if not allow_empty and not value:
+        raise SessionFormatError(f"{name} must not be empty.")
+    return value
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
 
 
 __all__ = [
     "FluxForgeSession",
+    "SESSION_FORMAT",
     "SESSION_FORMAT_VERSION",
+    "SessionFormatError",
+    "migrate_session_payload",
     "read_ffs_session",
     "session_from_spectra",
     "write_ffs_session",

--- a/src/fluxforge/resources/schemas/workspace_document_v2.schema.json
+++ b/src/fluxforge/resources/schemas/workspace_document_v2.schema.json
@@ -1,0 +1,356 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fluxforge.dev/schemas/workspace_document_v2.schema.json",
+  "title": "FluxForge WorkspaceDocument v2",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema", "schema_version", "document_id", "title", "created_at",
+    "updated_at", "spectra", "spectrum_roles", "active_spectrum_id",
+    "rois", "peaks", "detector_profiles", "fit_diagnostics", "viewports",
+    "pinned_nuclides", "nuclide_tags", "plot_settings", "workflow_state",
+    "provenance", "extensions"
+  ],
+  "properties": {
+    "schema": {"const": "fluxforge.workspace_document.v2"},
+    "schema_version": {"const": 2},
+    "document_id": {"$ref": "#/$defs/nonEmptyString"},
+    "title": {"type": "string"},
+    "created_at": {"$ref": "#/$defs/nonEmptyString"},
+    "updated_at": {"$ref": "#/$defs/nonEmptyString"},
+    "spectra": {"type": "array", "items": {"$ref": "#/$defs/workspaceSpectrum"}},
+    "spectrum_roles": {"type": "array", "items": {"$ref": "#/$defs/spectrumRole"}},
+    "active_spectrum_id": {"$ref": "#/$defs/nullableString"},
+    "rois": {"type": "array", "items": {"$ref": "#/$defs/analysisROI"}},
+    "peaks": {"type": "array", "items": {"$ref": "#/$defs/peakModel"}},
+    "detector_profiles": {"type": "array", "items": {"$ref": "#/$defs/detectorProfile"}},
+    "fit_diagnostics": {"type": "array", "items": {"$ref": "#/$defs/fitDiagnostics"}},
+    "viewports": {"type": "array", "items": {"$ref": "#/$defs/canvasViewport"}},
+    "pinned_nuclides": {
+      "type": "array", "uniqueItems": true,
+      "items": {"$ref": "#/$defs/nonEmptyString"}
+    },
+    "nuclide_tags": {
+      "type": "object",
+      "propertyNames": {"$ref": "#/$defs/nonEmptyString"},
+      "additionalProperties": {
+        "type": "array", "uniqueItems": true,
+        "items": {"$ref": "#/$defs/nonEmptyString"}
+      }
+    },
+    "plot_settings": {"$ref": "#/$defs/jsonObject"},
+    "workflow_state": {"$ref": "#/$defs/jsonObject"},
+    "provenance": {"$ref": "#/$defs/jsonObject"},
+    "extensions": {"$ref": "#/$defs/jsonObject"}
+  },
+  "$defs": {
+    "nonEmptyString": {"type": "string", "minLength": 1, "pattern": "\\S"},
+    "nullableString": {"type": ["string", "null"]},
+    "finiteNumber": {"type": "number"},
+    "nonNegativeNumber": {"type": "number", "minimum": 0},
+    "jsonObject": {"type": "object"},
+    "numberArray": {"type": "array", "items": {"$ref": "#/$defs/finiteNumber"}},
+    "nonNegativeNumberArray": {"type": "array", "items": {"$ref": "#/$defs/nonNegativeNumber"}},
+    "pair": {
+      "type": "array", "minItems": 2, "maxItems": 2,
+      "items": {"$ref": "#/$defs/finiteNumber"}
+    },
+    "nullablePair": {
+      "anyOf": [{"$ref": "#/$defs/pair"}, {"type": "null"}]
+    },
+    "matrix": {
+      "type": "array",
+      "items": {"type": "array", "items": {"$ref": "#/$defs/finiteNumber"}}
+    },
+    "gammaSpectrum": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "counts", "counts_uncertainty", "channels", "energies", "live_time",
+        "real_time", "start_time", "spectrum_id", "detector_id", "calibration",
+        "source_type", "device_id", "device_label", "gps", "metadata"
+      ],
+      "properties": {
+        "counts": {"$ref": "#/$defs/nonNegativeNumberArray"},
+        "counts_uncertainty": {
+          "anyOf": [{"$ref": "#/$defs/nonNegativeNumberArray"}, {"type": "null"}]
+        },
+        "channels": {"$ref": "#/$defs/numberArray"},
+        "energies": {"anyOf": [{"$ref": "#/$defs/numberArray"}, {"type": "null"}]},
+        "live_time": {"$ref": "#/$defs/nonNegativeNumber"},
+        "real_time": {"$ref": "#/$defs/nonNegativeNumber"},
+        "start_time": {"$ref": "#/$defs/nullableString"},
+        "spectrum_id": {"type": "string"},
+        "detector_id": {"type": "string"},
+        "calibration": {"$ref": "#/$defs/jsonObject"},
+        "source_type": {"type": "string"},
+        "device_id": {"type": "string"},
+        "device_label": {"type": "string"},
+        "gps": {"$ref": "#/$defs/jsonObject"},
+        "metadata": {"$ref": "#/$defs/jsonObject"}
+      }
+    },
+    "workspaceSpectrum": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "spectrum_id", "label", "source_path", "source_hash",
+        "detector_profile_id", "spectrum", "provenance", "extensions"
+      ],
+      "properties": {
+        "spectrum_id": {"$ref": "#/$defs/nonEmptyString"},
+        "label": {"type": "string"},
+        "source_path": {"$ref": "#/$defs/nullableString"},
+        "source_hash": {"$ref": "#/$defs/nullableString"},
+        "detector_profile_id": {"$ref": "#/$defs/nullableString"},
+        "spectrum": {"$ref": "#/$defs/gammaSpectrum"},
+        "provenance": {"$ref": "#/$defs/jsonObject"},
+        "extensions": {"$ref": "#/$defs/jsonObject"}
+      }
+    },
+    "spectrumRole": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "spectrum_ids"],
+      "properties": {
+        "role": {"$ref": "#/$defs/nonEmptyString"},
+        "spectrum_ids": {
+          "type": "array", "minItems": 1, "uniqueItems": true,
+          "items": {"$ref": "#/$defs/nonEmptyString"}
+        }
+      }
+    },
+    "analysisROI": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "roi_id", "spectrum_id", "signal_range", "left_background_range",
+        "right_background_range", "associated_peak_ids", "fit_revision", "label", "color"
+      ],
+      "properties": {
+        "roi_id": {"$ref": "#/$defs/nonEmptyString"},
+        "spectrum_id": {"$ref": "#/$defs/nonEmptyString"},
+        "signal_range": {"$ref": "#/$defs/pair"},
+        "left_background_range": {"$ref": "#/$defs/pair"},
+        "right_background_range": {"$ref": "#/$defs/pair"},
+        "associated_peak_ids": {
+          "type": "array", "uniqueItems": true,
+          "items": {"$ref": "#/$defs/nonEmptyString"}
+        },
+        "fit_revision": {"type": "integer", "minimum": 0},
+        "label": {"type": "string"},
+        "color": {"$ref": "#/$defs/nonEmptyString"}
+      }
+    },
+    "peakComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "component_id", "shape", "centroid", "area", "amplitude", "fwhm",
+        "uncertainty", "parameters", "provenance"
+      ],
+      "properties": {
+        "component_id": {"$ref": "#/$defs/nonEmptyString"},
+        "shape": {"$ref": "#/$defs/nonEmptyString"},
+        "centroid": {"$ref": "#/$defs/finiteNumber"},
+        "area": {"$ref": "#/$defs/nonNegativeNumber"},
+        "amplitude": {"$ref": "#/$defs/nonNegativeNumber"},
+        "fwhm": {"$ref": "#/$defs/nonNegativeNumber"},
+        "uncertainty": {"$ref": "#/$defs/nonNegativeNumber"},
+        "parameters": {"$ref": "#/$defs/jsonObject"},
+        "provenance": {"$ref": "#/$defs/jsonObject"}
+      }
+    },
+    "nuclideAssignment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["nuclide", "line_energy_keV", "library_id", "confidence", "manual", "provenance"],
+      "properties": {
+        "nuclide": {"$ref": "#/$defs/nonEmptyString"},
+        "line_energy_keV": {"$ref": "#/$defs/nonNegativeNumber"},
+        "library_id": {"type": "string"},
+        "confidence": {
+          "anyOf": [{"type": "number", "minimum": 0, "maximum": 1}, {"type": "null"}]
+        },
+        "manual": {"type": "boolean"},
+        "provenance": {"$ref": "#/$defs/jsonObject"}
+      }
+    },
+    "peakModel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "peak_id", "spectrum_id", "roi_id", "centroid_channel", "centroid_energy_keV",
+        "shape", "components", "assignments", "tags", "status", "manual_overrides",
+        "provenance", "net_counts", "significance", "fit_quality", "candidate_nuclides",
+        "reference_lines_keV", "normalized_residuals", "residual_channels"
+      ],
+      "properties": {
+        "peak_id": {"$ref": "#/$defs/nonEmptyString"},
+        "spectrum_id": {"$ref": "#/$defs/nonEmptyString"},
+        "roi_id": {"$ref": "#/$defs/nullableString"},
+        "centroid_channel": {"$ref": "#/$defs/nonNegativeNumber"},
+        "centroid_energy_keV": {"$ref": "#/$defs/nonNegativeNumber"},
+        "shape": {"$ref": "#/$defs/nonEmptyString"},
+        "components": {"type": "array", "items": {"$ref": "#/$defs/peakComponent"}},
+        "assignments": {"type": "array", "items": {"$ref": "#/$defs/nuclideAssignment"}},
+        "tags": {"type": "array", "items": {"$ref": "#/$defs/nonEmptyString"}},
+        "status": {"$ref": "#/$defs/nonEmptyString"},
+        "manual_overrides": {"$ref": "#/$defs/jsonObject"},
+        "provenance": {"$ref": "#/$defs/jsonObject"},
+        "net_counts": {"$ref": "#/$defs/finiteNumber"},
+        "significance": {"$ref": "#/$defs/nonNegativeNumber"},
+        "fit_quality": {"$ref": "#/$defs/nonNegativeNumber"},
+        "candidate_nuclides": {"type": "array", "items": {"$ref": "#/$defs/nonEmptyString"}},
+        "reference_lines_keV": {"$ref": "#/$defs/numberArray"},
+        "normalized_residuals": {"$ref": "#/$defs/numberArray"},
+        "residual_channels": {"$ref": "#/$defs/numberArray"}
+      }
+    },
+    "calibrationModel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "model_key", "coefficients", "calibration_points", "deviation_pairs",
+        "covariance", "valid_range", "provenance"
+      ],
+      "properties": {
+        "model_key": {"$ref": "#/$defs/nonEmptyString"},
+        "coefficients": {
+          "type": "array", "minItems": 1,
+          "items": {"$ref": "#/$defs/finiteNumber"}
+        },
+        "calibration_points": {"type": "array", "items": {"$ref": "#/$defs/pair"}},
+        "deviation_pairs": {"type": "array", "items": {"$ref": "#/$defs/pair"}},
+        "covariance": {"$ref": "#/$defs/matrix"},
+        "valid_range": {"$ref": "#/$defs/nullablePair"},
+        "provenance": {"$ref": "#/$defs/jsonObject"}
+      }
+    },
+    "efficiencyModelState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model_key", "parameters", "points", "covariance", "uncertainty_model"],
+      "properties": {
+        "model_key": {"$ref": "#/$defs/nonEmptyString"},
+        "parameters": {"$ref": "#/$defs/jsonObject"},
+        "points": {"type": "array", "items": {"$ref": "#/$defs/jsonObject"}},
+        "covariance": {"$ref": "#/$defs/matrix"},
+        "uncertainty_model": {"$ref": "#/$defs/jsonObject"}
+      }
+    },
+    "detectorGeometry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "crystal_diameter_cm", "crystal_length_cm", "dead_layer_um", "window_material",
+        "window_thickness_um", "distance_cm", "angle_deg", "metadata"
+      ],
+      "properties": {
+        "crystal_diameter_cm": {"anyOf": [{"$ref": "#/$defs/nonNegativeNumber"}, {"type": "null"}]},
+        "crystal_length_cm": {"anyOf": [{"$ref": "#/$defs/nonNegativeNumber"}, {"type": "null"}]},
+        "dead_layer_um": {"anyOf": [{"$ref": "#/$defs/nonNegativeNumber"}, {"type": "null"}]},
+        "window_material": {"$ref": "#/$defs/nullableString"},
+        "window_thickness_um": {"anyOf": [{"$ref": "#/$defs/nonNegativeNumber"}, {"type": "null"}]},
+        "distance_cm": {"anyOf": [{"$ref": "#/$defs/nonNegativeNumber"}, {"type": "null"}]},
+        "angle_deg": {"anyOf": [{"$ref": "#/$defs/finiteNumber"}, {"type": "null"}]},
+        "metadata": {"$ref": "#/$defs/jsonObject"}
+      }
+    },
+    "correctionSettings": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "attenuation_enabled", "self_shielding_enabled", "summing_enabled",
+        "dead_time_enabled", "pileup_enabled", "geometry_enabled", "parameters"
+      ],
+      "properties": {
+        "attenuation_enabled": {"type": "boolean"},
+        "self_shielding_enabled": {"type": "boolean"},
+        "summing_enabled": {"type": "boolean"},
+        "dead_time_enabled": {"type": "boolean"},
+        "pileup_enabled": {"type": "boolean"},
+        "geometry_enabled": {"type": "boolean"},
+        "parameters": {"$ref": "#/$defs/jsonObject"}
+      }
+    },
+    "detectorProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "detector_profile_id", "detector_id", "energy_calibration", "fwhm_calibration",
+        "efficiency_model", "geometry", "uncertainty", "covariance", "corrections",
+        "provenance", "extensions"
+      ],
+      "properties": {
+        "detector_profile_id": {"$ref": "#/$defs/nonEmptyString"},
+        "detector_id": {"type": "string"},
+        "energy_calibration": {
+          "anyOf": [{"$ref": "#/$defs/calibrationModel"}, {"type": "null"}]
+        },
+        "fwhm_calibration": {
+          "anyOf": [{"$ref": "#/$defs/calibrationModel"}, {"type": "null"}]
+        },
+        "efficiency_model": {
+          "anyOf": [{"$ref": "#/$defs/efficiencyModelState"}, {"type": "null"}]
+        },
+        "geometry": {"$ref": "#/$defs/detectorGeometry"},
+        "uncertainty": {"$ref": "#/$defs/jsonObject"},
+        "covariance": {"$ref": "#/$defs/matrix"},
+        "corrections": {"$ref": "#/$defs/correctionSettings"},
+        "provenance": {"$ref": "#/$defs/jsonObject"},
+        "extensions": {"$ref": "#/$defs/jsonObject"}
+      }
+    },
+    "fitDiagnostics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "diagnostic_id", "spectrum_id", "roi_id", "peak_id", "fit_revision", "status",
+        "x", "observed", "model", "uncertainty", "normalized_residuals",
+        "goodness_of_fit", "warning_flags", "method", "provenance"
+      ],
+      "properties": {
+        "diagnostic_id": {"$ref": "#/$defs/nonEmptyString"},
+        "spectrum_id": {"$ref": "#/$defs/nonEmptyString"},
+        "roi_id": {"$ref": "#/$defs/nullableString"},
+        "peak_id": {"$ref": "#/$defs/nullableString"},
+        "fit_revision": {"type": "integer", "minimum": 0},
+        "status": {"enum": ["valid", "invalid"]},
+        "x": {"$ref": "#/$defs/numberArray"},
+        "observed": {"$ref": "#/$defs/numberArray"},
+        "model": {"$ref": "#/$defs/numberArray"},
+        "uncertainty": {"$ref": "#/$defs/nonNegativeNumberArray"},
+        "normalized_residuals": {"$ref": "#/$defs/numberArray"},
+        "goodness_of_fit": {"$ref": "#/$defs/jsonObject"},
+        "warning_flags": {"type": "array", "items": {"$ref": "#/$defs/nonEmptyString"}},
+        "method": {"type": "string"},
+        "provenance": {"$ref": "#/$defs/jsonObject"}
+      }
+    },
+    "canvasViewport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "viewport_id", "spectrum_id", "x_range", "y_range", "x_unit", "y_unit",
+        "log_x", "log_y", "overlays", "residual_mode", "selected_roi_id",
+        "crosshair_enabled", "labels_visible"
+      ],
+      "properties": {
+        "viewport_id": {"$ref": "#/$defs/nonEmptyString"},
+        "spectrum_id": {"$ref": "#/$defs/nullableString"},
+        "x_range": {"$ref": "#/$defs/nullablePair"},
+        "y_range": {"$ref": "#/$defs/nullablePair"},
+        "x_unit": {"$ref": "#/$defs/nonEmptyString"},
+        "y_unit": {"$ref": "#/$defs/nonEmptyString"},
+        "log_x": {"type": "boolean"},
+        "log_y": {"type": "boolean"},
+        "overlays": {"type": "array", "items": {"$ref": "#/$defs/nonEmptyString"}},
+        "residual_mode": {"enum": ["off", "compact", "full"]},
+        "selected_roi_id": {"$ref": "#/$defs/nullableString"},
+        "crosshair_enabled": {"type": "boolean"},
+        "labels_visible": {"type": "boolean"}
+      }
+    }
+  }
+}

--- a/tests/test_analysis_workspace_qt.py
+++ b/tests/test_analysis_workspace_qt.py
@@ -19,10 +19,15 @@ from fluxforge.core.analysis_workspace import (  # noqa: E402
     subtract_background_counts,
 )
 from fluxforge.gui.backends import PYQTGRAPH_AVAILABLE  # noqa: E402
-from fluxforge.gui.dialogs.auto_peak_review_dialog import AutoPeakReviewDialog  # noqa: E402
+from fluxforge.gui.dialogs.auto_peak_review_dialog import (
+    AutoPeakReviewDialog,
+)  # noqa: E402
 from fluxforge.gui.main_window import FluxForgeMainWindow  # noqa: E402
 from fluxforge.gui.mode_manager import GUIMode, ModeManager, ModeState  # noqa: E402
-from fluxforge.gui.nuclide_search import GammaLineMatchResult, NuclideSearchController  # noqa: E402
+from fluxforge.gui.nuclide_search import (
+    GammaLineMatchResult,
+    NuclideSearchController,
+)  # noqa: E402
 from fluxforge.gui.panels.modern_shell import (  # noqa: E402
     build_demo_background_spectrum,
     build_demo_overlay_spectrum,
@@ -98,11 +103,14 @@ def _make_efficiency_points():
         ),
     )
 
+
 def _seed_phase6_real_workspace(window: FluxForgeMainWindow) -> dict[str, str]:
     review = load_phase6_real_activity_review(DEFAULT_PHASE6_SAMPLE_ID)
     results = load_phase6_real_activity_results(DEFAULT_PHASE6_SAMPLE_ID)
     window.analysis_workspace.set_activity_results(results)
-    window.bottom_dock.widget().activity_results_panel._last_activity_review = review  # noqa: SLF001
+    window.bottom_dock.widget().activity_results_panel._last_activity_review = (
+        review  # noqa: SLF001
+    )
     return load_phase6_real_optimization_grids(DEFAULT_PHASE6_SAMPLE_ID)
 
 
@@ -142,15 +150,24 @@ def test_analysis_core_helpers_cover_workspace_surfaces():
 def test_efficiency_models_and_activity_results_are_available():
     fits = {
         model_key: fit_efficiency_model(_make_efficiency_points(), model_key=model_key)
-        for model_key in ("log_poly_2", "log_poly_3", "gray_functional", "semi_empirical_hpge")
+        for model_key in (
+            "log_poly_2",
+            "log_poly_3",
+            "gray_functional",
+            "semi_empirical_hpge",
+        )
     }
 
     for fit in fits.values():
         assert fit.points_used == 5
-        efficiency = np.asarray(fit.curve.efficiency([661.657]), dtype=float).reshape(-1)[0]
+        efficiency = np.asarray(fit.curve.efficiency([661.657]), dtype=float).reshape(
+            -1
+        )[0]
         assert 0.0 < efficiency < 1.0
 
-    matched = bayesian_match_peak_candidates(detect_peak_candidates(build_demo_spectrum()))
+    matched = bayesian_match_peak_candidates(
+        detect_peak_candidates(build_demo_spectrum())
+    )
     result = calculate_peak_activity(
         matched[1],
         build_demo_spectrum(),
@@ -188,7 +205,13 @@ def test_line_match_browser_and_gamma_phenomena_estimates_are_available():
 
     phenomena = estimate_spectral_phenomena(1332.492)
     kinds = {item.kind for item in phenomena}
-    assert {"compton_edge", "backscatter", "single_escape", "double_escape", "annihilation"} <= kinds
+    assert {
+        "compton_edge",
+        "backscatter",
+        "single_escape",
+        "double_escape",
+        "annihilation",
+    } <= kinds
     assert all(item.energy_keV > 0.0 for item in phenomena)
 
 
@@ -241,7 +264,10 @@ def test_analysis_workspace_tracks_loaded_spectra_and_role_assignments():
 
 def _write_spectrum_csv(path: Path, spectrum) -> None:
     lines = ["channel,counts"]
-    for channel, count in zip(np.asarray(spectrum.channels, dtype=float), np.asarray(spectrum.counts, dtype=float)):
+    for channel, count in zip(
+        np.asarray(spectrum.channels, dtype=float),
+        np.asarray(spectrum.counts, dtype=float),
+    ):
         lines.append(f"{int(round(float(channel)))},{float(count):.6f}")
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
@@ -250,11 +276,14 @@ def _write_spectrum_csv(path: Path, spectrum) -> None:
     not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
     reason="Qt analysis workspace dependencies are unavailable.",
 )
-def test_main_window_peak_workflow_supports_undo_pin_tag_and_selection_sync(monkeypatch):
+def test_main_window_peak_workflow_supports_undo_pin_tag_and_selection_sync(
+    monkeypatch,
+):
     _qapp()
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.show()
     _qapp().processEvents()
@@ -294,7 +323,9 @@ def test_main_window_peak_workflow_supports_undo_pin_tag_and_selection_sync(monk
     assert "Co60" in window.analysis_workspace.state.pinned_nuclides
     assert len(window.analysis_workspace.state.cascade_sum_lines_keV) >= 1
 
-    monkeypatch.setattr(QInputDialog, "getText", lambda *args, **kwargs: ("qa-check", True))
+    monkeypatch.setattr(
+        QInputDialog, "getText", lambda *args, **kwargs: ("qa-check", True)
+    )
     QTest.mouseClick(peak_panel.tag_button, Qt.LeftButton)
     _qapp().processEvents()
     assert "qa-check" in peak_panel.table.item(co60_row, 5).text()
@@ -318,6 +349,7 @@ def test_peak_table_follows_selection_bus_peak_energy_updates():
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.show()
     _qapp().processEvents()
@@ -345,11 +377,14 @@ def test_peak_table_follows_selection_bus_peak_energy_updates():
     not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
     reason="Qt analysis workspace dependencies are unavailable.",
 )
-def test_peak_panel_exposes_full_search_surface_and_method_specific_databases(monkeypatch):
+def test_peak_panel_exposes_full_search_surface_and_method_specific_databases(
+    monkeypatch,
+):
     _qapp()
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.show()
     _qapp().processEvents()
@@ -413,6 +448,7 @@ def test_inventory_timeline_panel_builds_and_exports_timeseries(tmp_path):
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.library_manager.set_gamma_identification_source("nasa_common_lab_sources")
     window.analysis_workspace.set_activity_results(
@@ -694,7 +730,10 @@ def test_masking_review_panel_runs_and_exports_tables(tmp_path):
     assert result is not None
     assert panel.line_table.rowCount() > 0
     assert panel.isotope_table.rowCount() > 0
-    assert "alternate-line" in panel.summary.text().lower() or "recommendation" in panel.summary.text().lower()
+    assert (
+        "alternate-line" in panel.summary.text().lower()
+        or "recommendation" in panel.summary.text().lower()
+    )
 
     lines_csv = tmp_path / "masking_lines.csv"
     isotopes_csv = tmp_path / "masking_isotopes.csv"
@@ -749,7 +788,9 @@ def test_optimization_workspace_panel_runs_and_exports_phase6_bundle(tmp_path):
     not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
     reason="Qt analysis workspace dependencies are unavailable.",
 )
-def test_optimization_workspace_panel_advanced_guard_and_second_irradiation_panel(tmp_path):
+def test_optimization_workspace_panel_advanced_guard_and_second_irradiation_panel(
+    tmp_path,
+):
     _qapp()
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
@@ -804,7 +845,9 @@ def test_optimization_workspace_panel_advanced_guard_and_second_irradiation_pane
     not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
     reason="Qt analysis workspace dependencies are unavailable.",
 )
-def test_optimization_workspace_panel_runs_ldrd_worked_example_action(monkeypatch, tmp_path):
+def test_optimization_workspace_panel_runs_ldrd_worked_example_action(
+    monkeypatch, tmp_path
+):
     _qapp()
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
@@ -874,7 +917,9 @@ def test_astm_mode_locks_peak_identification_databases_to_standard_sources():
     assert sidebar.gamma_source_combo.currentData() == "decay_2012"
     assert sidebar.gamma_source_combo.isEnabled() is False
     assert sidebar.calibration_source_combo.count() == 1
-    assert sidebar.calibration_source_combo.currentData() == "calibration_standard_sources"
+    assert (
+        sidebar.calibration_source_combo.currentData() == "calibration_standard_sources"
+    )
     assert sidebar.calibration_source_combo.isEnabled() is False
     window.close()
 
@@ -907,7 +952,9 @@ def test_astm_mode_peak_matching_workflows_use_locked_gamma_source(monkeypatch):
     peak_panel = window.bottom_dock.widget().peak_table_panel
     captured: dict[str, str] = {}
 
-    def _fake_bayesian_match(peaks_arg, *, source_id="fluxforge_bundled_gamma", custom_path=None):
+    def _fake_bayesian_match(
+        peaks_arg, *, source_id="fluxforge_bundled_gamma", custom_path=None
+    ):
         del custom_path
         captured["bayesian_source_id"] = str(source_id)
         return tuple(peaks_arg)
@@ -970,7 +1017,9 @@ def test_astm_mode_reference_overlays_use_locked_gamma_source(monkeypatch):
     peak_panel = window.bottom_dock.widget().peak_table_panel
     captured: dict[str, str] = {}
 
-    def _fake_cascade_lines(pinned, *, source_id="fluxforge_bundled_gamma", custom_path=None):
+    def _fake_cascade_lines(
+        pinned, *, source_id="fluxforge_bundled_gamma", custom_path=None
+    ):
         del pinned, custom_path
         captured["source_id"] = str(source_id)
         return (2505.72,)
@@ -992,6 +1041,7 @@ def _prepare_reassignable_peak_assignment(monkeypatch):
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.show()
     _qapp().processEvents()
@@ -1029,13 +1079,17 @@ def _prepare_reassignable_peak_assignment(monkeypatch):
             min_intensity: float = 0.0,
         ):
             del tolerance_keV, min_intensity
-            token = "".join(character for character in query.lower() if character.isalnum())
+            token = "".join(
+                character for character in query.lower() if character.isalnum()
+            )
             matches = [
                 GammaLineMatchResult(
                     nuclide=primary_nuclide,
                     display_name=primary_nuclide,
                     line_energy_keV=float(original_peak.energy_keV),
-                    delta_keV=round(float(original_peak.energy_keV) - float(energy_keV), 3),
+                    delta_keV=round(
+                        float(original_peak.energy_keV) - float(energy_keV), 3
+                    ),
                     intensity=0.9,
                     half_life_s=1.0,
                 ),
@@ -1052,12 +1106,21 @@ def _prepare_reassignable_peak_assignment(monkeypatch):
                 matches = [
                     match
                     for match in matches
-                    if token in "".join(character for character in f"{match.nuclide} {match.display_name}".lower() if character.isalnum())
+                    if token
+                    in "".join(
+                        character
+                        for character in f"{match.nuclide} {match.display_name}".lower()
+                        if character.isalnum()
+                    )
                 ]
             return matches[:limit]
 
         def _fake_reference_lines_for_nuclide(nuclide: str, *, limit=None):
-            anchor = float(original_peak.energy_keV) if nuclide == primary_nuclide else alternate_energy
+            anchor = (
+                float(original_peak.energy_keV)
+                if nuclide == primary_nuclide
+                else alternate_energy
+            )
             lines = (round(anchor, 3), round(anchor + 31.0, 3), round(anchor + 63.0, 3))
             if limit is None:
                 return lines
@@ -1089,10 +1152,17 @@ def _prepare_reassignable_peak_assignment(monkeypatch):
             peak_panel.peak_id_matches.setCurrentRow(alternate_row)
             peak_panel._match_selection_changed()
             _qapp().processEvents()
-            return window, peak_panel, original_peak, peak_panel._current_match_results[alternate_row]
+            return (
+                window,
+                peak_panel,
+                original_peak,
+                peak_panel._current_match_results[alternate_row],
+            )
 
     window.close()
-    pytest.fail("Expected at least one reassignable peak in the demo analysis workspace.")
+    pytest.fail(
+        "Expected at least one reassignable peak in the demo analysis workspace."
+    )
 
 
 @pytest.mark.skipif(
@@ -1100,7 +1170,9 @@ def _prepare_reassignable_peak_assignment(monkeypatch):
     reason="Qt analysis workspace dependencies are unavailable.",
 )
 def test_peak_id_browser_supports_manual_isotope_reassignment(monkeypatch):
-    window, peak_panel, original_peak, reassigned = _prepare_reassignable_peak_assignment(monkeypatch)
+    window, peak_panel, original_peak, reassigned = (
+        _prepare_reassignable_peak_assignment(monkeypatch)
+    )
 
     assert peak_panel.peak_id_energy.value() == pytest.approx(
         original_peak.energy_keV,
@@ -1115,7 +1187,10 @@ def test_peak_id_browser_supports_manual_isotope_reassignment(monkeypatch):
     assert updated_peak is not None
     assert updated_peak.status == "manual"
     assert updated_peak.nuclide == reassigned.nuclide
-    assert updated_peak.nuclide != original_peak.nuclide or peak_panel.peak_id_tolerance.value() > 2.0
+    assert (
+        updated_peak.nuclide != original_peak.nuclide
+        or peak_panel.peak_id_tolerance.value() > 2.0
+    )
     window.close()
 
 
@@ -1124,7 +1199,9 @@ def test_peak_id_browser_supports_manual_isotope_reassignment(monkeypatch):
     reason="Qt analysis workspace dependencies are unavailable.",
 )
 def test_peak_id_browser_supports_clearing_manual_assignment(monkeypatch):
-    window, peak_panel, _original_peak, _reassigned = _prepare_reassignable_peak_assignment(monkeypatch)
+    window, peak_panel, _original_peak, _reassigned = (
+        _prepare_reassignable_peak_assignment(monkeypatch)
+    )
 
     peak_panel._assign_selected_isotope()
     _qapp().processEvents()
@@ -1196,6 +1273,7 @@ def test_peak_id_browser_use_selected_peak_button_restores_peak_centroid(monkeyp
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.show()
     _qapp().processEvents()
@@ -1349,6 +1427,7 @@ def test_main_window_activity_background_and_survey_map_workflows(monkeypatch):
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.show()
     _qapp().processEvents()
@@ -1405,6 +1484,7 @@ def test_main_window_activity_review_exports_csv_and_plots(monkeypatch, tmp_path
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.show()
     _qapp().processEvents()
@@ -1447,11 +1527,14 @@ def test_main_window_activity_review_exports_csv_and_plots(monkeypatch, tmp_path
     not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
     reason="Qt analysis workspace dependencies are unavailable.",
 )
-def test_main_window_activity_unit_selector_rescales_activity_review_plot(monkeypatch, tmp_path):
+def test_main_window_activity_unit_selector_rescales_activity_review_plot(
+    monkeypatch, tmp_path
+):
     _qapp()
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.show()
     _qapp().processEvents()
@@ -1511,6 +1594,7 @@ def test_main_window_inventory_panel_activity_unit_selector_updates_headers_and_
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.library_manager.set_gamma_identification_source("nasa_common_lab_sources")
     window.analysis_workspace.set_activity_results(
@@ -1585,12 +1669,18 @@ def test_main_window_sidebar_registers_and_removes_user_library(monkeypatch, tmp
     _qapp().processEvents()
 
     assert sidebar.gamma_source_combo.findData("user_gamma_lab_ref") >= 0
-    assert window.library_manager.state.gamma_identification_source_id == "user_gamma_lab_ref"
+    assert (
+        window.library_manager.state.gamma_identification_source_id
+        == "user_gamma_lab_ref"
+    )
 
     QTest.mouseClick(sidebar.remove_registered_gamma_button, Qt.LeftButton)
     _qapp().processEvents()
 
-    assert window.library_manager.state.gamma_identification_source_id == "fluxforge_bundled_gamma"
+    assert (
+        window.library_manager.state.gamma_identification_source_id
+        == "fluxforge_bundled_gamma"
+    )
     window.close()
 
 
@@ -1598,7 +1688,9 @@ def test_main_window_sidebar_registers_and_removes_user_library(monkeypatch, tmp
     not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
     reason="Qt analysis workspace dependencies are unavailable.",
 )
-def test_main_window_background_selector_updates_subtracted_foreground_and_overlay(tmp_path):
+def test_main_window_background_selector_updates_subtracted_foreground_and_overlay(
+    tmp_path,
+):
     _qapp()
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
@@ -1656,7 +1748,9 @@ def test_main_window_background_selector_updates_subtracted_foreground_and_overl
     assert "overlay.csv" in status
 
     assigned_roles = {
-        sidebar.files.topLevelItem(index).text(0): sidebar.files.topLevelItem(index).text(1)
+        sidebar.files.topLevelItem(index)
+        .text(0): sidebar.files.topLevelItem(index)
+        .text(1)
         for index in range(sidebar.files.topLevelItemCount())
     }
     assert "Foreground" in assigned_roles["sample.csv"]
@@ -1674,6 +1768,7 @@ def test_roi_tools_panel_supports_mouse_driven_roi_analysis_and_statistics(monke
     window = FluxForgeMainWindow(
         mode_manager=ModeManager(),
         selection_bus=SelectionBus(),
+        load_example=True,
     )
     window.show()
     _qapp().processEvents()

--- a/tests/test_atomic_session_save.py
+++ b/tests/test_atomic_session_save.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from fluxforge.io import atomic
+
+
+def _temporary_files(directory: Path, target_name: str) -> list[Path]:
+    return list(directory.glob(f".{target_name}.*.tmp"))
+
+
+def test_atomic_write_json_replaces_once_with_valid_utf8_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "workspace.json"
+    target.write_bytes(b'{"old": true}\n')
+    replacements: list[tuple[Path, Path]] = []
+    real_replace = atomic.os.replace
+
+    def recording_replace(source: Path, destination: Path) -> None:
+        replacements.append((Path(source), Path(destination)))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(atomic.os, "replace", recording_replace)
+
+    result = atomic.atomic_write_json(
+        target,
+        {"name": "UWNR γ analysis", "values": [1, 2, 3]},
+        sort_keys=True,
+    )
+
+    assert result == target
+    assert json.loads(target.read_text(encoding="utf-8")) == {
+        "name": "UWNR γ analysis",
+        "values": [1, 2, 3],
+    }
+    assert len(replacements) == 1
+    assert replacements[0][0].parent == target.parent
+    assert replacements[0][1] == target
+    assert not _temporary_files(tmp_path, target.name)
+
+
+def test_serialization_failure_occurs_before_any_filesystem_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "workspace.json"
+    original = b"original bytes\r\n"
+    target.write_bytes(original)
+    temporary_creation_attempted = False
+
+    def unexpected_mkstemp(*args: object, **kwargs: object) -> tuple[int, str]:
+        nonlocal temporary_creation_attempted
+        temporary_creation_attempted = True
+        raise AssertionError("serialization must precede temporary-file creation")
+
+    monkeypatch.setattr(atomic.tempfile, "mkstemp", unexpected_mkstemp)
+
+    with pytest.raises(ValueError, match="Out of range float values"):
+        atomic.atomic_write_json(target, {"not_json": float("nan")})
+
+    assert not temporary_creation_attempted
+    assert target.read_bytes() == original
+
+
+def test_injected_write_failure_preserves_original_and_cleans_temp(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "workspace.json"
+    original = b"existing workspace bytes\n"
+    target.write_bytes(original)
+
+    def fail_write(stream: object, serialized: str) -> None:
+        stream.write(serialized[:5])
+        raise OSError("simulated disk-full write failure")
+
+    monkeypatch.setattr(atomic, "_write_serialized", fail_write)
+
+    with pytest.raises(atomic.AtomicWriteError) as error:
+        atomic.atomic_write_json(target, {"replacement": True})
+
+    assert error.value.phase == "write"
+    assert error.value.replacement_completed is False
+    assert "original file remains unchanged" in str(error.value)
+    assert target.read_bytes() == original
+    assert not _temporary_files(tmp_path, target.name)
+
+
+def test_injected_replace_failure_is_clear_and_preserves_original(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "workspace.json"
+    original = b"byte-identical original\x00content"
+    target.write_bytes(original)
+
+    def fail_replace(source: Path, destination: Path) -> None:
+        raise PermissionError("simulated sharing violation")
+
+    monkeypatch.setattr(atomic.os, "replace", fail_replace)
+
+    with pytest.raises(atomic.AtomicWriteError) as error:
+        atomic.atomic_write_json(target, {"replacement": True})
+
+    assert error.value.phase == "replace"
+    assert error.value.replacement_completed is False
+    assert "original file remains unchanged" in str(error.value)
+    assert "OneDrive" in str(error.value)
+    assert "Windows file lock" in str(error.value)
+    assert target.read_bytes() == original
+    assert not _temporary_files(tmp_path, target.name)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="parent fsync is POSIX-specific")
+def test_parent_directory_sync_failure_reports_that_replace_completed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "workspace.json"
+    target.write_text('{"old": true}\n', encoding="utf-8")
+
+    def fail_directory_sync(directory: Path) -> None:
+        raise OSError("simulated directory fsync failure")
+
+    monkeypatch.setattr(atomic, "_fsync_parent_directory", fail_directory_sync)
+
+    with pytest.raises(atomic.AtomicWriteError) as error:
+        atomic.atomic_write_json(target, {"new": True})
+
+    assert error.value.phase == "directory-sync"
+    assert error.value.replacement_completed is True
+    assert json.loads(target.read_text(encoding="utf-8")) == {"new": True}
+    assert not _temporary_files(tmp_path, target.name)

--- a/tests/test_calibration_workspace_qt.py
+++ b/tests/test_calibration_workspace_qt.py
@@ -576,15 +576,21 @@ def test_calibration_dialog_supports_preserve_slots_fine_tune_and_nasa_seed():
     not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
     reason="Qt calibration workspace dependencies are unavailable.",
 )
-def test_apply_workspace_results_persists_calibration_workspace_state_to_spectrum():
+def test_apply_workspace_results_emits_new_calibrated_spectrum_without_mutation():
     _qapp()
     spectrum = build_demo_spectrum()
+    original_calibration = dict(spectrum.calibration)
+    original_counts = spectrum.counts
+    applied = []
     bus = SelectionBus()
     dialog = CalibrationWorkspaceDialog(
         spectrum=spectrum,
         mode_manager=ModeManager(),
         selection_bus=bus,
         library_manager=DataLibraryManager(),
+        on_apply=lambda updated, energy_fit, fwhm_fit: applied.append(
+            (updated, energy_fit, fwhm_fit)
+        ),
     )
     dialog.show()
     _qapp().processEvents()
@@ -606,12 +612,18 @@ def test_apply_workspace_results_persists_calibration_workspace_state_to_spectru
 
     dialog._apply_workspace_results()
 
-    assert spectrum.calibration["energy"] == pytest.approx(
+    assert len(applied) == 1
+    updated_spectrum, applied_energy_fit, _applied_fwhm_fit = applied[0]
+    assert updated_spectrum is not spectrum
+    assert updated_spectrum.counts is original_counts
+    assert spectrum.calibration == original_calibration
+    assert updated_spectrum.calibration["energy"] == pytest.approx(
         dialog._energy_fit.coefficients
     )
-    assert spectrum.calibration["deviation_pairs"]
+    assert applied_energy_fit is dialog._energy_fit
+    assert updated_spectrum.calibration["deviation_pairs"]
     assert bus.state.roi_bounds_keV is not None
-    assert spectrum.energies is not None
+    assert updated_spectrum.energies is not None
     dialog.close()
 
 

--- a/tests/test_canvas_intents.py
+++ b/tests/test_canvas_intents.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+
+from fluxforge.gui.canvas_intents import CanvasIntent, CanvasIntentKind
+
+
+@pytest.mark.parametrize(
+    "intent",
+    (
+        CanvasIntent(
+            CanvasIntentKind.CREATE_ROI,
+            spectrum_id="spectrum-1",
+            bounds=(100.0, 120.0),
+            left_background=(90.0, 98.0),
+            right_background=(122.0, 130.0),
+        ),
+        CanvasIntent(
+            CanvasIntentKind.MOVE_ROI,
+            spectrum_id="spectrum-1",
+            roi_id="roi-1",
+            bounds=(101.0, 121.0),
+            drag_token="drag-7",
+        ),
+        CanvasIntent(
+            CanvasIntentKind.ADD_PEAK,
+            spectrum_id="spectrum-1",
+            position=1173.2,
+        ),
+        CanvasIntent(
+            CanvasIntentKind.MERGE_PEAKS,
+            spectrum_id="spectrum-1",
+            component_ids=("component-a", "component-b"),
+        ),
+        CanvasIntent(
+            CanvasIntentKind.ASSIGN_NUCLIDE,
+            spectrum_id="spectrum-1",
+            peak_id="peak-1",
+            nuclide="Co60",
+        ),
+        CanvasIntent(CanvasIntentKind.PIN_NUCLIDE, nuclide="Co60"),
+        CanvasIntent(
+            CanvasIntentKind.ASSIGN_SPECTRUM_ROLE,
+            spectrum_id="spectrum-1",
+            role="foreground",
+        ),
+        CanvasIntent(
+            CanvasIntentKind.CHANGE_VIEWPORT,
+            spectrum_id="spectrum-1",
+            viewport_id="spectrum-main",
+            x_range=(100.0, 1500.0),
+            y_range=(0.0, 10000.0),
+        ),
+        CanvasIntent(
+            CanvasIntentKind.SET_LOG_SCALE,
+            spectrum_id="spectrum-1",
+            enabled=True,
+        ),
+    ),
+)
+def test_canvas_intents_round_trip_without_qt(intent: CanvasIntent) -> None:
+    assert CanvasIntent.from_dict(intent.to_dict()) == intent
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        {"kind": CanvasIntentKind.CREATE_ROI, "spectrum_id": "s", "bounds": (2, 1)},
+        {"kind": CanvasIntentKind.MOVE_PEAK, "spectrum_id": "s", "peak_id": "p"},
+        {
+            "kind": CanvasIntentKind.MERGE_PEAKS,
+            "spectrum_id": "s",
+            "component_ids": ("a",),
+        },
+        {"kind": CanvasIntentKind.ASSIGN_NUCLIDE, "spectrum_id": "s", "peak_id": "p"},
+        {
+            "kind": CanvasIntentKind.CHANGE_VIEWPORT,
+            "spectrum_id": "s",
+            "viewport_id": "v",
+        },
+        {"kind": CanvasIntentKind.SET_LOG_SCALE, "spectrum_id": "s"},
+    ),
+)
+def test_canvas_intents_reject_incomplete_or_nonphysical_payloads(kwargs) -> None:
+    with pytest.raises(ValueError):
+        CanvasIntent(**kwargs)
+
+
+def test_canvas_intent_rejects_future_schema_versions() -> None:
+    with pytest.raises(ValueError, match="Unsupported"):
+        CanvasIntent.from_dict(
+            {
+                "schema": "fluxforge.canvas_intent.v2",
+                "version": 2,
+                "kind": "nuclide.pin",
+                "nuclide": "Co60",
+            }
+        )
+
+
+def test_canvas_intent_rejects_string_boolean_values() -> None:
+    with pytest.raises(ValueError, match="enabled must be a boolean"):
+        CanvasIntent.from_dict(
+            {
+                "schema": "fluxforge.canvas_intent.v1",
+                "version": 1,
+                "kind": "viewport.log_scale",
+                "spectrum_id": "spectrum-1",
+                "enabled": "false",
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    "change, message",
+    [
+        ({"version": "1"}, "version must be an integer"),
+        ({"temporary": True}, "unknown fields"),
+        ({"position": True}, "finite number"),
+    ],
+)
+def test_canvas_intent_parser_is_strict(change, message) -> None:
+    payload = CanvasIntent(
+        CanvasIntentKind.ADD_PEAK,
+        spectrum_id="spectrum-1",
+        position=12.0,
+    ).to_dict()
+    payload.update(change)
+    with pytest.raises(ValueError, match=message):
+        CanvasIntent.from_dict(payload)

--- a/tests/test_production_gui_mode.py
+++ b/tests/test_production_gui_mode.py
@@ -189,7 +189,7 @@ def test_astm_review_enables_only_after_data_load_and_uses_workspace_values(tmp_
     not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
     reason="Qt spectrum renderer dependencies are unavailable.",
 )
-def test_polluted_active_workflow_cannot_restore_spectrum_path_until_load(tmp_path):
+def test_workflow_templates_never_persist_or_restore_spectrum_paths(tmp_path):
     app = _qapp()
     settings = MemorySettings()
     spectrum_path = (
@@ -216,6 +216,9 @@ def test_polluted_active_workflow_cannot_restore_spectrum_path_until_load(tmp_pa
     )
     first.close()
 
+    saved = settings.value("gui/workflow_presets")
+    assert str(spectrum_path) not in str(saved)
+
     second = FluxForgeMainWindow(
         mode_manager=ModeManager(settings=settings),
         selection_bus=SelectionBus(),
@@ -234,11 +237,8 @@ def test_polluted_active_workflow_cannot_restore_spectrum_path_until_load(tmp_pa
     second.load_workflow_button.click()
     app.processEvents()
 
-    assert second.analysis_workspace.spectrum() is not None
-    assert len(second.analysis_workspace.state.loaded_spectra) == 1
-    assert second.analysis_workspace.state.loaded_spectra[0].source_path == str(
-        spectrum_path
-    )
+    assert second.analysis_workspace.spectrum() is None
+    assert second.analysis_workspace.state.loaded_spectra == ()
     second.close()
 
 

--- a/tests/test_pyqtgraph_viewport.py
+++ b/tests/test_pyqtgraph_viewport.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+
+import pytest
+
+from fluxforge.core.analysis_workspace import PeakCandidate
+from fluxforge.gui import QT_AVAILABLE, SelectionBus
+from fluxforge.gui.backends import PYQTGRAPH_AVAILABLE, PyQtGraphSpectrumCanvas
+from fluxforge.gui.qt_compat import QApplication
+from fluxforge.gui.spectrum_canvas import ReferenceLine, SpectrumTrace
+
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+pytestmark = pytest.mark.skipif(
+    not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
+    reason="Qt spectrum renderer dependencies are unavailable.",
+)
+
+
+def _qapp() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def test_pyqtgraph_viewport_round_trip_restores_supported_display_state() -> None:
+    app = _qapp()
+    selection_bus = SelectionBus()
+    canvas = PyQtGraphSpectrumCanvas(selection_bus=selection_bus)
+    canvas.resize(900, 600)
+    canvas.show()
+    canvas.set_traces(
+        (
+            SpectrumTrace(
+                label="Foreground",
+                counts=tuple(float(index + 1) for index in range(1000)),
+                channels=tuple(float(index) for index in range(1000)),
+                x_axis_label="Energy (keV)",
+            ),
+        )
+    )
+    canvas.set_annotation_lines((ReferenceLine(energy_keV=661.657, label="Cs-137"),))
+    canvas.set_peak_residuals(
+        (
+            PeakCandidate(
+                peak_id="peak-1",
+                channel=662.0,
+                energy_keV=661.657,
+                significance=12.0,
+                roi_bounds_keV=(650.0, 675.0),
+                net_counts=500.0,
+                fit_quality=1.1,
+                normalized_residuals=(-0.4, 0.2, 0.7),
+                residual_channels=(660.0, 661.0, 662.0),
+            ),
+        ),
+        visible=True,
+    )
+    canvas.set_residual_mode("full")
+    canvas.set_log_scale(True)
+    canvas.set_peak_labels_visible(False)
+    selection_bus.publish_roi(650.0, 675.0)
+    canvas.roi_button.setChecked(True)
+    canvas.set_crosshair_enabled(True)
+    canvas.plot_item.setXRange(600.0, 725.0, padding=0.0)
+    canvas.plot_item.setYRange(0.0, 3.0, padding=0.0)
+    app.processEvents()
+
+    expected = canvas.viewport_state(
+        viewport_id="primary-spectrum",
+        spectrum_id="spectrum-1",
+        selected_roi_id="roi-1",
+    )
+    assert expected.overlays == ("roi",)
+    assert expected.residual_mode == "full"
+    assert expected.crosshair_enabled is True
+    assert expected.labels_visible is False
+
+    canvas.set_log_scale(False)
+    canvas.set_peak_labels_visible(True)
+    canvas.roi_button.setChecked(False)
+    canvas.set_residual_mode("off")
+    canvas.set_crosshair_enabled(False)
+    canvas.plot_item.setXRange(0.0, 100.0, padding=0.0)
+    canvas.plot_item.setYRange(0.0, 1000.0, padding=0.0)
+    app.processEvents()
+
+    canvas.apply_viewport_state(expected)
+    app.processEvents()
+    restored = canvas.viewport_state(
+        viewport_id="primary-spectrum",
+        spectrum_id="spectrum-1",
+        selected_roi_id="roi-1",
+    )
+
+    assert restored.viewport_id == expected.viewport_id
+    assert restored.spectrum_id == expected.spectrum_id
+    assert restored.x_range == pytest.approx(expected.x_range)
+    assert restored.y_range == pytest.approx(expected.y_range)
+    assert restored.x_unit == expected.x_unit
+    assert restored.y_unit == expected.y_unit
+    assert restored.log_x == expected.log_x
+    assert restored.log_y == expected.log_y
+    assert restored.overlays == expected.overlays
+    assert restored.residual_mode == expected.residual_mode
+    assert restored.selected_roi_id == expected.selected_roi_id
+    assert restored.crosshair_enabled == expected.crosshair_enabled
+    assert restored.labels_visible == expected.labels_visible
+    assert canvas._roi_region.isVisible()
+    assert canvas.residual_row.isVisible()
+    assert canvas._crosshair_vertical.isVisible()
+    assert canvas._crosshair_horizontal.isVisible()
+    assert not canvas._annotation_label_items
+
+    canvas.close()
+
+
+def test_pyqtgraph_viewport_restore_hides_optional_layers() -> None:
+    app = _qapp()
+    canvas = PyQtGraphSpectrumCanvas(selection_bus=SelectionBus())
+    canvas.show()
+    canvas.set_spectrum((1.0, 3.0, 2.0))
+    canvas.set_peak_residuals(
+        (
+            PeakCandidate(
+                peak_id="peak-1",
+                channel=1.0,
+                energy_keV=1.0,
+                significance=3.0,
+                roi_bounds_keV=(0.5, 1.5),
+                net_counts=2.0,
+                fit_quality=1.0,
+                normalized_residuals=(0.1,),
+                residual_channels=(1.0,),
+            ),
+        ),
+        visible=True,
+    )
+    canvas.roi_button.setChecked(True)
+    canvas.set_crosshair_enabled(True)
+    app.processEvents()
+
+    hidden = replace(
+        canvas.viewport_state(),
+        overlays=(),
+        residual_mode="off",
+        crosshair_enabled=False,
+        labels_visible=False,
+    )
+    canvas.apply_viewport_state(hidden)
+    app.processEvents()
+
+    assert not canvas._roi_region.isVisible()
+    assert not canvas.residual_row.isVisible()
+    assert not canvas._crosshair_vertical.isVisible()
+    assert not canvas._crosshair_horizontal.isVisible()
+    canvas.close()

--- a/tests/test_session_v2_migration.py
+++ b/tests/test_session_v2_migration.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from fluxforge.core.workspace_document import WorkspaceDocument
+from fluxforge.io import session as session_module
+from fluxforge.io.session import (
+    SESSION_FORMAT_VERSION,
+    FluxForgeSession,
+    SessionFormatError,
+    migrate_session_payload,
+    read_ffs_session,
+    session_from_spectra,
+    write_ffs_session,
+)
+from fluxforge.io.spe import GammaSpectrum
+
+
+def _spectrum_payload(name: str, offset: float = 0.0) -> dict[str, object]:
+    return GammaSpectrum(
+        counts=np.array([2.0 + offset, 5.0 + offset, 9.0 + offset]),
+        live_time=120.0,
+        real_time=125.0,
+        spectrum_id=name,
+        detector_id="uwrn-hpge",
+        calibration={
+            "energy": [0.25, 0.5],
+            "fwhm": [0.8, 0.04],
+            "efficiency": {"model": "log-polynomial", "coefficients": [-2.0]},
+        },
+        source_type="hal",
+        device_id="mca-1",
+        device_label="UWNR MCA",
+        gps={"latitude": 43.072, "longitude": -89.412},
+        metadata={"sample": "RAFM"},
+    ).to_dict()
+
+
+def _legacy_payload(*, versioned: bool = True) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "format": "fluxforge_session",
+        "created_at": "2026-07-22T12:34:56+00:00",
+        "active_spectrum_index": 1,
+        "source_files": ["raw/first.ASC", "raw/second.ASC", "raw/unmatched.ASC"],
+        "recent_files": ["recent/a.n42"],
+        "device_snapshot": [
+            {
+                "source_type": "hal",
+                "device_id": "mca-1",
+                "state": "ready",
+                "telemetry": {"temperature_c": 19.5},
+            }
+        ],
+        "metadata": {"campaign": "UWNR", "title": "RAFM activation"},
+        "spectra": [_spectrum_payload("first"), _spectrum_payload("second", 1.0)],
+        "site_extension": {"operator": "test-user"},
+    }
+    if versioned:
+        payload["format_version"] = 1
+    return payload
+
+
+@pytest.mark.parametrize("versioned", [False, True])
+def test_v1_and_unversioned_payloads_migrate_without_data_loss(
+    versioned: bool,
+) -> None:
+    legacy = _legacy_payload(versioned=versioned)
+    original = deepcopy(legacy)
+
+    migrated = migrate_session_payload(legacy)
+
+    assert legacy == original
+    assert migrated["format"] == "fluxforge_session"
+    assert migrated["format_version"] == SESSION_FORMAT_VERSION
+    assert migrated["created_at"] == legacy["created_at"]
+    assert migrated["recent_files"] == legacy["recent_files"]
+    assert migrated["device_snapshot"] == legacy["device_snapshot"]
+    assert migrated["metadata"] == legacy["metadata"]
+
+    document = WorkspaceDocument.from_dict(migrated["document"])
+    assert [item.spectrum_id for item in document.spectra] == [
+        "legacy-spectrum-1",
+        "legacy-spectrum-2",
+    ]
+    assert document.active_spectrum_id == "legacy-spectrum-2"
+    assert document.spectrum_roles[0].role == "foreground"
+    assert document.spectrum_roles[0].spectrum_ids == ("legacy-spectrum-2",)
+    assert [item.source_path for item in document.spectra] == [
+        "raw/first.ASC",
+        "raw/second.ASC",
+    ]
+    restored = document.spectra[1].spectrum
+    assert restored.calibration == legacy["spectra"][1]["calibration"]
+    assert restored.gps == legacy["spectra"][1]["gps"]
+    assert restored.source_type == "hal"
+    assert restored.device_id == "mca-1"
+    assert document.extensions["legacy_unknown_top_level"] == {
+        "site_extension": {"operator": "test-user"}
+    }
+    assert tuple(document.extensions["legacy_unmatched_source_files"]) == (
+        "raw/unmatched.ASC",
+    )
+
+
+def test_migration_is_idempotent_and_v2_is_canonical() -> None:
+    legacy = _legacy_payload()
+    migrated = migrate_session_payload(legacy)
+
+    assert migrate_session_payload(legacy) == migrated
+    assert migrate_session_payload(migrated) == migrated
+    session = FluxForgeSession.from_dict(migrated)
+    assert session.source_files == [
+        "raw/first.ASC",
+        "raw/second.ASC",
+        "raw/unmatched.ASC",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"format": "other", "format_version": 1}, "Unsupported session format"),
+        ({"format": "fluxforge_session", "format_version": "2"}, "integer"),
+        ({"format": "fluxforge_session", "format_version": 99}, "newer"),
+        ({"format": "fluxforge_session", "format_version": 0}, "Unsupported"),
+        ({}, "missing the required spectra"),
+        (
+            {"format": "fluxforge_session", "format_version": 1},
+            "missing the required spectra",
+        ),
+        (
+            {
+                "format": "fluxforge_session",
+                "format_version": 2,
+                "document": {},
+                "recent_files": [],
+                "device_snapshot": [],
+                "metadata": {},
+                "created_at": "",
+                "unexpected": True,
+            },
+            "unknown top-level",
+        ),
+    ],
+)
+def test_malformed_or_future_versions_fail_explicitly(
+    payload: dict[str, object], message: str
+) -> None:
+    with pytest.raises(SessionFormatError, match=message):
+        migrate_session_payload(payload)
+
+
+@pytest.mark.parametrize("index", [-1, 2, 7])
+def test_invalid_active_index_fails_for_nonempty_legacy_session(index: int) -> None:
+    payload = _legacy_payload()
+    payload["active_spectrum_index"] = index
+
+    with pytest.raises(SessionFormatError, match="active_spectrum_index"):
+        migrate_session_payload(payload)
+
+
+def test_only_index_zero_is_valid_for_empty_legacy_session() -> None:
+    empty = {
+        "format": "fluxforge_session",
+        "format_version": 1,
+        "spectra": [],
+        "active_spectrum_index": 0,
+    }
+    assert migrate_session_payload(empty)["document"]["active_spectrum_id"] is None
+
+    empty["active_spectrum_index"] = 1
+    with pytest.raises(SessionFormatError, match="empty session"):
+        migrate_session_payload(empty)
+
+
+def test_new_session_facade_writes_only_v2_and_round_trips(tmp_path: Path) -> None:
+    spectrum = GammaSpectrum(
+        counts=np.array([4.0, 8.0, 15.0]),
+        calibration={"energy": [0.0, 0.5]},
+        spectrum_id="sample",
+        source_type="hal",
+        device_id="mock-mca",
+        gps={"latitude": 43.07, "longitude": -89.4},
+    )
+    session = session_from_spectra(
+        [spectrum],
+        source_files=["sample.ASC"],
+        recent_files=["recent.ASC"],
+        metadata={"campaign": "UWNR"},
+    )
+
+    assert session.spectra == [spectrum]
+    assert session.active_spectrum_index == 0
+    assert session.source_files == ["sample.ASC"]
+
+    target = tmp_path / "analysis.ffs"
+    payload = write_ffs_session(target, session)
+    on_disk = json.loads(target.read_text(encoding="utf-8"))
+    assert payload == on_disk
+    assert set(on_disk) == {
+        "format",
+        "format_version",
+        "document",
+        "recent_files",
+        "device_snapshot",
+        "metadata",
+        "created_at",
+    }
+    assert "active_spectrum_index" not in on_disk
+    assert "spectra" not in on_disk
+
+    restored = read_ffs_session(target)
+    assert restored.document.to_dict() == session.document.to_dict()
+    assert restored.spectra[0].gps["latitude"] == 43.07
+    assert restored.source_files == ["sample.ASC"]
+    assert restored.recent_files == ["recent.ASC"]
+
+
+def test_write_uses_atomic_json_helper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[Path, dict[str, object]]] = []
+
+    def record_atomic(path: Path, payload: dict[str, object]) -> Path:
+        calls.append((Path(path), deepcopy(payload)))
+        return Path(path)
+
+    monkeypatch.setattr(session_module, "atomic_write_json", record_atomic)
+    session = FluxForgeSession()
+    target = tmp_path / "empty.ffs"
+
+    payload = write_ffs_session(target, session)
+
+    assert calls == [(target, payload)]
+    assert payload["format_version"] == 2
+
+
+def test_read_wraps_invalid_json_with_session_context(tmp_path: Path) -> None:
+    target = tmp_path / "broken.ffs"
+    target.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(SessionFormatError, match="Could not read FluxForge session"):
+        read_ffs_session(target)

--- a/tests/test_workspace_controller_v2.py
+++ b/tests/test_workspace_controller_v2.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from fluxforge.core.analysis_workspace import (
+    ActivityCalculationResult,
+    PeakCandidate,
+    ROIAnalysisResult,
+    SurveyPoint,
+)
+from fluxforge.core.workspace_document import (
+    AnalysisROI,
+    CalibrationModel,
+    CanvasViewport,
+    DetectorGeometry,
+    DetectorProfile,
+    PeakModel,
+    SpectrumRoleAssignment,
+    WorkspaceDocument,
+    WorkspaceSpectrum,
+    WorkspaceValidationError,
+)
+from fluxforge.gui.analysis_workspace import (
+    AnalysisWorkspaceController,
+    AnalysisWorkspaceState,
+    LoadedSpectrumRecord,
+    SpectrumSlot,
+)
+from fluxforge.io.flux_wire import EfficiencyCalibration
+from fluxforge.io.spe import GammaSpectrum
+
+
+def _spectrum(spectrum_id: str = "sample") -> GammaSpectrum:
+    return GammaSpectrum(
+        counts=np.asarray([2.0, 5.0, 9.0, 4.0]),
+        channels=np.arange(4),
+        energies=np.asarray([100.0, 101.0, 102.0, 103.0]),
+        live_time=10.0,
+        real_time=11.0,
+        spectrum_id=spectrum_id,
+    )
+
+
+def _candidate(
+    peak_id: str = "peak-1", *, nuclide: str | None = "Cs-137"
+) -> PeakCandidate:
+    return PeakCandidate(
+        peak_id=peak_id,
+        channel=2.0,
+        energy_keV=102.0,
+        significance=6.5,
+        roi_bounds_keV=(100.5, 103.5),
+        net_counts=13.0,
+        fit_quality=1.2,
+        nuclide=nuclide,
+        candidate_nuclides=("Cs-137", "Ba-137m"),
+        reference_lines_keV=(661.657,),
+        tags=("reviewed",),
+    )
+
+
+def _peak(spectrum_id: str = "sample", peak_id: str = "peak-1") -> PeakModel:
+    return PeakModel(
+        peak_id=peak_id,
+        spectrum_id=spectrum_id,
+        roi_id=None,
+        centroid_channel=2.0,
+        centroid_energy_keV=102.0,
+        net_counts=13.0,
+        significance=6.5,
+        fit_quality=1.2,
+        manual_overrides={"roi_bounds_keV": [100.5, 103.5]},
+    )
+
+
+def _document() -> WorkspaceDocument:
+    spectrum = _spectrum()
+    peak = _peak()
+    roi = AnalysisROI(
+        roi_id="roi-1",
+        spectrum_id="sample",
+        signal_range=(100.5, 103.5),
+        left_background_range=(98.0, 100.0),
+        right_background_range=(104.0, 106.0),
+        associated_peak_ids=("peak-1",),
+    )
+    return WorkspaceDocument(
+        document_id="controller-test",
+        spectra=(
+            WorkspaceSpectrum(
+                spectrum_id="sample",
+                spectrum=spectrum,
+                label="UWNR sample",
+                source_path="C:/data/sample.asc",
+                extensions={"slot_label": "Foreground"},
+            ),
+        ),
+        spectrum_roles=(
+            SpectrumRoleAssignment(role="foreground", spectrum_ids=("sample",)),
+        ),
+        active_spectrum_id="sample",
+        rois=(roi,),
+        peaks=(peak,),
+        detector_profiles=(
+            DetectorProfile(
+                detector_profile_id="hpge-1",
+                detector_id="South",
+                geometry=DetectorGeometry(distance_cm=25.0),
+            ),
+        ),
+        viewports=(
+            CanvasViewport(
+                viewport_id="spectrum",
+                spectrum_id="sample",
+                x_range=(100.0, 104.0),
+                selected_roi_id="roi-1",
+            ),
+        ),
+        pinned_nuclides=("Cs-137",),
+        provenance={"campaign": "UWNR"},
+        extensions={"future_contract": {"retained": True}},
+    )
+
+
+def test_legacy_state_is_adapted_to_canonical_document_without_copying_arrays():
+    spectrum = _spectrum()
+    state = AnalysisWorkspaceState(
+        spectra=(SpectrumSlot("foreground", "Foreground", spectrum),),
+        loaded_spectra=(
+            LoadedSpectrumRecord(
+                "sample", "UWNR sample", spectrum, "C:/data/sample.asc"
+            ),
+        ),
+        active_spectrum_key="foreground",
+        peaks=(_candidate(),),
+        pinned_nuclides=("Cs-137",),
+    )
+
+    controller = AnalysisWorkspaceController(state)
+
+    assert controller.document.active_spectrum_id == "foreground"
+    assert controller.document.spectrum_roles == (
+        SpectrumRoleAssignment(role="foreground", spectrum_ids=("foreground",)),
+    )
+    canonical = controller.document.spectrum_by_id("foreground")
+    assert canonical is not None
+    assert canonical.spectrum is spectrum
+    assert canonical.spectrum.counts is spectrum.counts
+    model = controller.document.peak_by_id("foreground", "peak-1")
+    assert model is not None
+    assert model.assignments[0].nuclide == "Cs-137"
+    assert model.manual_overrides["roi_bounds_keV"] == (100.5, 103.5)
+
+
+def test_source_key_maps_slot_role_to_registered_spectrum_identity():
+    spectrum = _spectrum()
+    controller = AnalysisWorkspaceController(
+        AnalysisWorkspaceState(
+            spectra=(
+                SpectrumSlot(
+                    "foreground",
+                    "Foreground",
+                    spectrum,
+                    source_key="sample",
+                    source_label="UWNR sample",
+                ),
+            ),
+            loaded_spectra=(LoadedSpectrumRecord("sample", "UWNR sample", spectrum),),
+        )
+    )
+
+    assert controller.document.spectrum_roles[0].spectrum_ids == ("sample",)
+    assert controller.document.active_spectrum_id == "sample"
+    assert (
+        controller.document.spectrum_by_id("sample").spectrum.counts is spectrum.counts
+    )
+
+
+def test_document_constructor_and_set_document_rebuild_compatibility_projection():
+    document = _document()
+    controller = AnalysisWorkspaceController(document)
+    state_events = []
+    document_events = []
+    controller.subscribe(state_events.append)
+    controller.subscribe_document(document_events.append)
+
+    replacement = replace(
+        document, title="Restored session", pinned_nuclides=("Co-60",)
+    )
+    returned = controller.set_document(replacement)
+
+    assert returned is replacement
+    assert controller.document is replacement
+    assert controller.state.active_spectrum_key == "foreground"
+    assert controller.state.loaded_spectra[0].source_path == "C:/data/sample.asc"
+    assert (
+        controller.state.spectra[0].spectrum.counts
+        is document.spectra[0].spectrum.counts
+    )
+    assert controller.state.peaks[0].roi_bounds_keV == (100.5, 103.5)
+    assert controller.state.pinned_nuclides == ("Co-60",)
+    assert state_events == [controller.state]
+    assert document_events == [replacement]
+
+
+def test_legacy_mutation_preserves_unrelated_document_leaves_and_array_identity():
+    document = _document()
+    secondary = WorkspaceSpectrum(
+        spectrum_id="secondary",
+        spectrum=_spectrum("secondary"),
+        label="Repeat count",
+    )
+    document = replace(
+        document,
+        spectra=document.spectra + (secondary,),
+        spectrum_roles=document.spectrum_roles
+        + (
+            SpectrumRoleAssignment(
+                role="comparison", spectrum_ids=("sample", "secondary")
+            ),
+        ),
+    )
+    counts = document.spectra[0].spectrum.counts
+    controller = AnalysisWorkspaceController(document)
+
+    controller.set_peak_search_method("second_derivative")
+
+    assert controller.document.rois is document.rois
+    assert controller.document.detector_profiles is document.detector_profiles
+    assert controller.document.viewports is document.viewports
+    assert controller.document.provenance == {"campaign": "UWNR"}
+    assert controller.document.extensions["future_contract"]["retained"] is True
+    assert controller.document.spectrum_roles[-1].spectrum_ids == (
+        "sample",
+        "secondary",
+    )
+    assert controller.document.spectra[0].spectrum.counts is counts
+    assert (
+        controller.document.workflow_state["analysis_workspace_v1"][
+            "peak_search_method"
+        ]
+        == "second_derivative"
+    )
+
+
+def test_inventory_edit_preserves_multi_spectrum_and_unprojected_roles():
+    document = _document()
+    secondary = WorkspaceSpectrum(
+        spectrum_id="secondary",
+        spectrum=_spectrum("secondary"),
+        label="Repeat count",
+    )
+    document = replace(
+        document,
+        spectra=document.spectra + (secondary,),
+        spectrum_roles=document.spectrum_roles
+        + (
+            SpectrumRoleAssignment(
+                role="comparison", spectrum_ids=("sample", "secondary")
+            ),
+            SpectrumRoleAssignment(role="archive", spectrum_ids=("secondary",)),
+        ),
+    )
+    controller = AnalysisWorkspaceController(document)
+
+    controller.register_loaded_spectrum(_spectrum("new"), label="New count", key="new")
+
+    roles = {
+        item.role: item.spectrum_ids for item in controller.document.spectrum_roles
+    }
+    assert roles["comparison"] == ("sample", "secondary")
+    assert roles["archive"] == ("secondary",)
+
+
+def test_legacy_workflow_dtos_and_detector_configuration_round_trip_in_document():
+    spectrum = _spectrum()
+    activity = ActivityCalculationResult(
+        nuclide="Cs-137",
+        line_energy_keV=661.657,
+        activity_bq=120.0,
+        uncertainty_bq=4.0,
+        age_corrected_activity_bq=121.0,
+        mda_bq=2.0,
+        half_life_s=1.0e9,
+        source_age_s=60.0,
+        chain_summary="direct",
+    )
+    roi = ROIAnalysisResult(
+        label="Cs-137",
+        roi_bounds_keV=(650.0, 670.0),
+        gross_counts=100.0,
+        gross_counts_uncertainty=10.0,
+        background_counts=20.0,
+        background_counts_uncertainty=4.0,
+        net_counts=80.0,
+        net_counts_uncertainty=10.77,
+        centroid_keV=661.6,
+        centroid_uncertainty_keV=0.1,
+        significance=7.4,
+        background_method="sideband",
+        peak_search_method="mariscotti",
+        sideband_bounds_keV=((640.0, 648.0), (672.0, 680.0)),
+        notes=("accepted",),
+    )
+    controller = AnalysisWorkspaceController(
+        AnalysisWorkspaceState(
+            spectra=(SpectrumSlot("foreground", "Foreground", spectrum),),
+            activity_results=(activity,),
+            roi_analysis=roi,
+            survey_points=(SurveyPoint("A", 46.7, -92.1, "foreground"),),
+            detector_efficiency=EfficiencyCalibration(
+                detector_id="South", source_distance_cm=25.0
+            ),
+        )
+    )
+
+    restored = AnalysisWorkspaceController(
+        WorkspaceDocument.from_dict(controller.document.to_dict())
+    ).state
+
+    assert restored.activity_results == (activity,)
+    assert restored.roi_analysis == roi
+    assert restored.survey_points[0].latitude == pytest.approx(46.7)
+    assert restored.detector_efficiency.detector_id == "South"
+    assert restored.detector_efficiency.source_distance_cm == pytest.approx(25.0)
+
+
+def test_peak_and_roi_leaf_edits_cleanup_only_dependent_references():
+    controller = AnalysisWorkspaceController(_document())
+    added = replace(_peak(peak_id="peak-2"), centroid_channel=2.5)
+    controller.upsert_peak_model(added)
+    assert controller.document.peak_by_id("sample", "peak-2") is added
+
+    controller.delete_peak_model("sample", "peak-1")
+    assert controller.document.peak_by_id("sample", "peak-1") is None
+    assert controller.document.roi_by_id("roi-1").associated_peak_ids == ()
+    assert controller.document.detector_profiles[0].detector_id == "South"
+
+    controller.delete_roi("roi-1")
+    assert controller.document.roi_by_id("roi-1") is None
+    assert controller.document.viewport_by_id("spectrum").selected_roi_id is None
+
+
+def test_role_detector_viewport_and_pinned_leaf_edits_are_canonical():
+    controller = AnalysisWorkspaceController(_document())
+    profile = replace(
+        controller.document.detector_profiles[0],
+        geometry=DetectorGeometry(distance_cm=12.5),
+    )
+    viewport = replace(controller.document.viewports[0], x_range=(101.0, 103.0))
+
+    controller.assign_spectrum_role("background", "sample")
+    controller.upsert_detector_profile(profile)
+    controller.upsert_viewport(viewport)
+    controller.set_pinned_nuclides(("Co-60", "Co-60", "Cs-137"))
+
+    assert controller.document.spectrum_roles[-1].role == "background"
+    assert (
+        controller.document.detector_profile_by_id("hpge-1").geometry.distance_cm
+        == 12.5
+    )
+    assert controller.document.viewport_by_id("spectrum").x_range == (101.0, 103.0)
+    assert controller.document.pinned_nuclides == ("Co-60", "Cs-137")
+    assert controller.state.pinned_nuclides == ("Co-60", "Cs-137")
+
+
+def test_apply_calibration_copies_container_reuses_count_arrays_and_updates_profile_leaf():
+    controller = AnalysisWorkspaceController(_document())
+    original = controller.document.spectrum_by_id("sample").spectrum
+    calibration = CalibrationModel(
+        model_key="linear",
+        coefficients=(0.5, 2.0),
+        deviation_pairs=((102.5, 0.25),),
+    )
+
+    controller.apply_calibration("sample", calibration)
+
+    calibrated_record = controller.document.spectrum_by_id("sample")
+    calibrated = calibrated_record.spectrum
+    assert calibrated is not original
+    assert calibrated.counts is original.counts
+    assert calibrated.counts_uncertainty is original.counts_uncertainty
+    assert calibrated.channels is original.channels
+    assert original.calibration == {}
+    assert np.array_equal(original.energies, np.asarray([100.0, 101.0, 102.0, 103.0]))
+    assert calibrated.calibration["energy"] == [0.5, 2.0]
+    assert calibrated_record.detector_profile_id == "sample-detector"
+    assert (
+        controller.document.detector_profile_by_id("sample-detector").energy_calibration
+        is calibration
+    )
+    assert calibrated.energies.shape == original.channels.shape
+
+    controller.apply_calibration("sample", None)
+    cleared = controller.document.spectrum_by_id("sample").spectrum
+    assert cleared is not calibrated
+    assert cleared.counts is original.counts
+    assert cleared.energies is None
+    assert calibrated.energies is not None
+    assert (
+        controller.document.detector_profile_by_id("sample-detector").energy_calibration
+        is None
+    )
+
+
+def test_set_document_rejects_invalid_reference_without_changing_controller():
+    original = _document()
+    controller = AnalysisWorkspaceController(original)
+    invalid = replace(original, active_spectrum_id="missing")
+
+    with pytest.raises(WorkspaceValidationError, match="active_spectrum_id"):
+        controller.set_document(invalid)
+
+    assert controller.document is original

--- a/tests/test_workspace_document_v2.py
+++ b/tests/test_workspace_document_v2.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from dataclasses import replace
+from importlib.resources import files
+
+import numpy as np
+import pytest
+
+from fluxforge.core import WorkspaceDocument as LazyWorkspaceDocument
+from fluxforge.core.workspace_document import (
+    WORKSPACE_DOCUMENT_SCHEMA,
+    AnalysisROI,
+    CalibrationModel,
+    CanvasViewport,
+    CorrectionSettings,
+    DetectorGeometry,
+    DetectorProfile,
+    EfficiencyModelState,
+    FitDiagnostics,
+    NuclideAssignment,
+    PeakComponent,
+    PeakModel,
+    SpectrumRoleAssignment,
+    WorkspaceDocument,
+    WorkspaceSpectrum,
+    WorkspaceValidationError,
+)
+from fluxforge.io.spe import GammaSpectrum
+
+
+def _spectrum() -> GammaSpectrum:
+    return GammaSpectrum(
+        counts=np.asarray([0.0, 4.0, 9.0, 1.0]),
+        channels=np.arange(4),
+        live_time=10.0,
+        real_time=12.0,
+        spectrum_id="detector-native-id",
+        detector_id="HPGe-1",
+        calibration={"energy": [0.0, 1.5]},
+        metadata={"operator": "UWNR"},
+    )
+
+
+def _rich_document() -> WorkspaceDocument:
+    calibration = CalibrationModel(
+        model_key="polynomial",
+        coefficients=(0.0, 1.5),
+        # A channel/energy pair is data, not an increasing mathematical range.
+        calibration_points=((2.0, 1.0), (3.0, 4.5)),
+        deviation_pairs=((100.0, -0.04),),
+        covariance=((0.04, 0.0), (0.0, 0.0001)),
+        valid_range=(0.0, 3000.0),
+    )
+    profile = DetectorProfile(
+        detector_profile_id="profile-1",
+        detector_id="HPGe-1",
+        energy_calibration=calibration,
+        fwhm_calibration=CalibrationModel(
+            model_key="sqrt-polynomial", coefficients=(0.8, 0.001)
+        ),
+        efficiency_model=EfficiencyModelState(
+            model_key="log-polynomial",
+            parameters={"coefficients": [-3.1, -0.7]},
+            points=({"energy_keV": 661.657, "efficiency": 0.012},),
+            covariance=((0.01, 0.0), (0.0, 0.02)),
+            uncertainty_model={"relative_percent": 2.5},
+        ),
+        geometry=DetectorGeometry(
+            crystal_diameter_cm=6.0,
+            crystal_length_cm=6.5,
+            dead_layer_um=0.7,
+            window_material="aluminum",
+            window_thickness_um=500.0,
+            distance_cm=12.0,
+        ),
+        corrections=CorrectionSettings(
+            attenuation_enabled=True,
+            self_shielding_enabled=True,
+            summing_enabled=False,
+        ),
+        uncertainty={"geometry_relative": 0.01},
+        covariance=((0.04,),),
+    )
+    component = PeakComponent(
+        component_id="component-1",
+        shape="gaussian-tail",
+        centroid=2.0,
+        area=12.0,
+        amplitude=7.0,
+        fwhm=1.2,
+        uncertainty=1.0,
+        parameters={"tail": 0.03},
+    )
+    assignment = NuclideAssignment(
+        nuclide="Cs-137",
+        line_energy_keV=661.657,
+        library_id="fixture-lib@1",
+        confidence=0.95,
+        manual=True,
+    )
+    peak = PeakModel(
+        peak_id="peak-1",
+        spectrum_id="spectrum-1",
+        roi_id="roi-1",
+        centroid_channel=2.0,
+        centroid_energy_keV=3.0,
+        components=(component,),
+        assignments=(assignment,),
+        tags=("reviewed",),
+        status="accepted",
+        net_counts=10.0,
+        significance=3.2,
+        fit_quality=1.1,
+        normalized_residuals=(-0.2, 0.1),
+        residual_channels=(1.0, 2.0),
+    )
+    roi = AnalysisROI(
+        roi_id="roi-1",
+        spectrum_id="spectrum-1",
+        signal_range=(1.0, 2.5),
+        left_background_range=(0.0, 1.0),
+        right_background_range=(2.5, 3.5),
+        associated_peak_ids=("peak-1",),
+        fit_revision=4,
+        label="661.7 keV review",
+    )
+    diagnostics = FitDiagnostics(
+        diagnostic_id="diagnostic-1",
+        spectrum_id="spectrum-1",
+        roi_id="roi-1",
+        peak_id="peak-1",
+        fit_revision=4,
+        status="valid",
+        x=(1.0, 2.0),
+        observed=(4.0, 9.0),
+        model=(4.2, 8.7),
+        uncertainty=(2.0, 3.0),
+        normalized_residuals=(-0.1, 0.1),
+        goodness_of_fit={"chi_squared": 0.02},
+        method="poisson-likelihood",
+    )
+    return WorkspaceDocument(
+        document_id="uwrn-analysis",
+        title="UWNR HPGe analysis",
+        created_at="2026-07-22T20:00:00+00:00",
+        updated_at="2026-07-22T20:01:00+00:00",
+        spectra=(
+            WorkspaceSpectrum(
+                spectrum_id="spectrum-1",
+                spectrum=_spectrum(),
+                label="UWNR foreground",
+                source_path="fixture.spe",
+                detector_profile_id="profile-1",
+                provenance={"sha256": "abc"},
+            ),
+        ),
+        spectrum_roles=(
+            SpectrumRoleAssignment(role="foreground", spectrum_ids=("spectrum-1",)),
+        ),
+        active_spectrum_id="spectrum-1",
+        rois=(roi,),
+        peaks=(peak,),
+        detector_profiles=(profile,),
+        fit_diagnostics=(diagnostics,),
+        viewports=(
+            CanvasViewport(
+                viewport_id="primary-spectrum",
+                spectrum_id="spectrum-1",
+                x_range=(0.5, 3.5),
+                y_range=(0.1, 12.0),
+                log_y=True,
+                overlays=("fits", "roi-bounds"),
+                residual_mode="compact",
+                selected_roi_id="roi-1",
+                crosshair_enabled=True,
+            ),
+        ),
+        pinned_nuclides=("Cs-137",),
+        nuclide_tags={"Cs-137": ("benchmark",)},
+        plot_settings={"theme": "dark"},
+        workflow_state={"analysis_mode": "expert"},
+        provenance={"application": "FluxForge"},
+        extensions={"plugin.example": {"value": 2}},
+    )
+
+
+def test_workspace_document_v2_rich_json_round_trip() -> None:
+    document = _rich_document()
+    payload = document.to_dict()
+    encoded = json.dumps(payload, allow_nan=False)
+    restored = WorkspaceDocument.from_dict(json.loads(encoded))
+
+    assert restored.to_dict() == payload
+    assert restored.schema == WORKSPACE_DOCUMENT_SCHEMA
+    assert restored.spectra[0].spectrum.counts.tolist() == [0.0, 4.0, 9.0, 1.0]
+    assert restored.detector_profiles[0].efficiency_model is not None
+    assert restored.viewports[0].selected_roi_id == "roi-1"
+
+
+def test_empty_workspace_round_trip_is_valid() -> None:
+    document = WorkspaceDocument(
+        document_id="empty",
+        created_at="2026-07-22T20:00:00+00:00",
+        updated_at="2026-07-22T20:00:00+00:00",
+    )
+    assert (
+        WorkspaceDocument.from_dict(document.to_dict()).to_dict() == document.to_dict()
+    )
+
+
+def test_core_lazy_export_does_not_create_io_import_cycle() -> None:
+    assert LazyWorkspaceDocument is WorkspaceDocument
+    assert _spectrum().counts.shape == (4,)
+
+
+def test_schema_resource_is_packaged_and_matches_domain_version() -> None:
+    resource = files("fluxforge").joinpath(
+        "resources/schemas/workspace_document_v2.schema.json"
+    )
+    schema = json.loads(resource.read_text(encoding="utf-8"))
+    assert schema["properties"]["schema"]["const"] == WORKSPACE_DOCUMENT_SCHEMA
+    assert schema["properties"]["schema_version"]["const"] == 2
+    assert schema["additionalProperties"] is False
+
+
+def _schema_payload() -> tuple[dict, dict]:
+    resource = files("fluxforge").joinpath(
+        "resources/schemas/workspace_document_v2.schema.json"
+    )
+    return (
+        json.loads(resource.read_text(encoding="utf-8")),
+        _rich_document().to_dict(),
+    )
+
+
+def _set_path(payload: dict, path: tuple[object, ...], value: object) -> dict:
+    malformed = deepcopy(payload)
+    target: object = malformed
+    for key in path[:-1]:
+        target = target[key]  # type: ignore[index]
+    target[path[-1]] = value  # type: ignore[index]
+    return malformed
+
+
+@pytest.mark.parametrize(
+    "path,value,expected_path",
+    [
+        (("title",), 12, "document.title"),
+        (("pinned_nuclides", 0), 137, "document.pinned_nuclides"),
+        (("nuclide_tags", "Cs-137", 0), False, "document.nuclide_tags.Cs-137"),
+        (("spectra", 0, "label"), ["foreground"], "spectrum.label"),
+        (
+            ("spectra", 0, "spectrum", "detector_id"),
+            7,
+            "spectrum.spectrum.detector_id",
+        ),
+        (("rois", 0, "associated_peak_ids", 0), 1, "roi.associated_peak_ids"),
+        (("peaks", 0, "shape"), 2, "peak.shape"),
+        (("peaks", 0, "tags", 0), {"tag": "reviewed"}, "peak.tags"),
+        (("peaks", 0, "status"), True, "peak.status"),
+        (
+            ("peaks", 0, "assignments", 0, "library_id"),
+            3,
+            "assignment.library_id",
+        ),
+        (
+            ("detector_profiles", 0, "detector_id"),
+            ["HPGe-1"],
+            "detector_profile.detector_id",
+        ),
+        (
+            ("fit_diagnostics", 0, "warning_flags"),
+            ["review", 3],
+            "fit_diagnostics.warning_flags",
+        ),
+        (("fit_diagnostics", 0, "method"), 4, "fit_diagnostics.method"),
+        (("viewports", 0, "x_unit"), 1, "viewport.x_unit"),
+        (("viewports", 0, "overlays", 0), False, "viewport.overlays"),
+    ],
+)
+def test_from_dict_rejects_non_strings_in_typed_string_fields(
+    path, value, expected_path
+) -> None:
+    payload = _set_path(_rich_document().to_dict(), path, value)
+    with pytest.raises(WorkspaceValidationError, match=expected_path):
+        WorkspaceDocument.from_dict(payload)
+
+
+def test_external_json_schema_accepts_complete_canonical_document() -> None:
+    jsonschema = pytest.importorskip("jsonschema")
+    schema, payload = _schema_payload()
+    validator = jsonschema.Draft202012Validator(schema)
+    validator.check_schema(schema)
+    validator.validate(payload)
+
+
+@pytest.mark.parametrize(
+    "path,value",
+    [
+        (("pinned_nuclides", 0), 137),
+        (("nuclide_tags", "Cs-137", 0), False),
+        (("spectra", 0, "spectrum", "detector_id"), 7),
+        (("peaks", 0, "tags", 0), {"tag": "reviewed"}),
+        (("detector_profiles", 0, "detector_id"), ["HPGe-1"]),
+        (("fit_diagnostics", 0, "warning_flags"), ["review", 3]),
+        (("viewports", 0, "overlays", 0), False),
+        (("detector_profiles", 0, "unexpected"), "not allowed"),
+    ],
+)
+def test_external_json_schema_rejects_malformed_domain_objects(path, value) -> None:
+    schema, payload = _schema_payload()
+    malformed = _set_path(payload, path, value)
+    jsonschema = pytest.importorskip("jsonschema")
+    validator = jsonschema.Draft202012Validator(schema)
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate(malformed)
+
+
+def test_every_domain_object_definition_rejects_unknown_properties() -> None:
+    schema, _ = _schema_payload()
+    domain_definitions = {
+        "gammaSpectrum",
+        "workspaceSpectrum",
+        "spectrumRole",
+        "analysisROI",
+        "peakComponent",
+        "nuclideAssignment",
+        "peakModel",
+        "calibrationModel",
+        "efficiencyModelState",
+        "detectorGeometry",
+        "correctionSettings",
+        "detectorProfile",
+        "fitDiagnostics",
+        "canvasViewport",
+    }
+    assert all(
+        schema["$defs"][name]["additionalProperties"] is False
+        for name in domain_definitions
+    )
+
+
+@pytest.mark.parametrize(
+    "mutator, expected_path",
+    [
+        (
+            lambda doc: replace(doc, active_spectrum_id="missing"),
+            "active_spectrum_id",
+        ),
+        (
+            lambda doc: replace(
+                doc,
+                spectra=(doc.spectra[0], doc.spectra[0]),
+            ),
+            "spectra\\[1\\].spectrum_id",
+        ),
+        (
+            lambda doc: replace(
+                doc,
+                detector_profiles=(
+                    replace(
+                        doc.detector_profiles[0], covariance=((1.0, 2.0), (2.0, 1.0))
+                    ),
+                ),
+            ),
+            "positive semidefinite",
+        ),
+        (
+            lambda doc: replace(
+                doc,
+                rois=(replace(doc.rois[0], right_background_range=(2.0, 3.0)),),
+            ),
+            "right_background_range",
+        ),
+        (
+            lambda doc: replace(
+                doc,
+                fit_diagnostics=(
+                    replace(doc.fit_diagnostics[0], normalized_residuals=(0.1,)),
+                ),
+            ),
+            "equal non-empty",
+        ),
+    ],
+)
+def test_nonphysical_or_dangling_state_fails_clearly(mutator, expected_path) -> None:
+    with pytest.raises(WorkspaceValidationError, match=expected_path):
+        mutator(_rich_document()).validate()
+
+
+def test_negative_net_peak_area_is_preserved_for_review() -> None:
+    document = _rich_document()
+    negative_peak = replace(document.peaks[0], net_counts=-2.0, status="invalid")
+    reviewed = replace(document, peaks=(negative_peak,))
+
+    assert WorkspaceDocument.from_dict(reviewed.to_dict()).peaks[0].net_counts == -2.0
+
+
+def test_nonfinite_extension_fails_before_json_write() -> None:
+    with pytest.raises(WorkspaceValidationError, match="extensions.result"):
+        replace(_rich_document(), extensions={"result": float("nan")}).to_dict()
+
+
+@pytest.mark.parametrize(
+    "value, type_name",
+    [
+        (np.asarray([1.0]), "ndarray"),
+        (object(), "object"),
+    ],
+)
+def test_non_json_extension_values_fail_with_field_path(value, type_name) -> None:
+    with pytest.raises(
+        WorkspaceValidationError,
+        match=rf"extensions.result.*not {type_name}",
+    ):
+        replace(_rich_document(), extensions={"result": value}).to_dict()
+
+
+def test_invalid_schema_and_lossy_integer_are_rejected() -> None:
+    payload = _rich_document().to_dict()
+    payload["schema_version"] = 2.0
+    with pytest.raises(WorkspaceValidationError, match="schema_version.*integer"):
+        WorkspaceDocument.from_dict(payload)
+
+    payload = _rich_document().to_dict()
+    payload["rois"][0]["fit_revision"] = "4"
+    with pytest.raises(WorkspaceValidationError, match="roi.fit_revision.*integer"):
+        WorkspaceDocument.from_dict(payload)
+
+
+def test_unknown_document_fields_are_rejected() -> None:
+    payload = _rich_document().to_dict()
+    payload["temporary_gui_note"] = "do not persist"
+    with pytest.raises(WorkspaceValidationError, match="unknown fields"):
+        WorkspaceDocument.from_dict(payload)

--- a/tests/test_workspace_session_qt.py
+++ b/tests/test_workspace_session_qt.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from fluxforge.core.workspace_document import (
+    AnalysisROI,
+    CalibrationModel,
+    CanvasViewport,
+    DetectorProfile,
+    EfficiencyModelState,
+    WorkspaceDocument,
+)
+from fluxforge.gui import QT_AVAILABLE, FluxForgeMainWindow, ModeManager, SelectionBus
+from fluxforge.gui.backends import PYQTGRAPH_AVAILABLE
+from fluxforge.gui.qt_compat import QApplication
+from fluxforge.io import FluxForgeSession, read_ffs_session, write_ffs_session
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+class MemorySettings:
+    def __init__(self) -> None:
+        self.values = {}
+
+    def value(self, key, default=None):
+        return self.values.get(key, default)
+
+    def setValue(self, key, value) -> None:
+        self.values[key] = value
+
+    def sync(self) -> None:
+        return None
+
+
+def _qapp():
+    return QApplication.instance() or QApplication([])
+
+
+def _window(*, load_example: bool = False) -> FluxForgeMainWindow:
+    return FluxForgeMainWindow(
+        mode_manager=ModeManager(settings=MemorySettings()),
+        selection_bus=SelectionBus(),
+        settings=MemorySettings(),
+        load_example=load_example,
+    )
+
+
+pytestmark = pytest.mark.skipif(
+    not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
+    reason="Qt spectrum renderer dependencies are unavailable.",
+)
+
+
+def test_session_actions_have_stable_ids_and_shortcuts() -> None:
+    _qapp()
+    window = _window()
+    try:
+        save = window.findChild(object, "SaveSessionAction")
+        save_as = window.findChild(object, "SaveSessionAsAction")
+        assert save is not None and save.shortcut().toString() == "Ctrl+S"
+        assert save_as is not None and save_as.shortcut().toString() == "Ctrl+Shift+S"
+    finally:
+        window.close()
+
+
+def test_save_and_open_session_replaces_complete_workspace(tmp_path: Path) -> None:
+    app = _qapp()
+    window = _window(load_example=True)
+    window.show()
+    app.processEvents()
+    try:
+        spectrum_id = window.analysis_workspace.document.active_spectrum_id
+        assert spectrum_id is not None
+        roi = AnalysisROI(
+            roi_id="saved-roi",
+            spectrum_id=spectrum_id,
+            signal_range=(400.0, 700.0),
+            left_background_range=(300.0, 400.0),
+            right_background_range=(700.0, 800.0),
+            label="review",
+        )
+        profile = DetectorProfile(
+            detector_profile_id="saved-detector",
+            energy_calibration=CalibrationModel(
+                model_key="polynomial", coefficients=(0.1, 0.5)
+            ),
+            efficiency_model=EfficiencyModelState(
+                model_key="log-polynomial",
+                parameters={"coefficients": [-2.0, -0.6]},
+                covariance=((0.01, 0.0), (0.0, 0.02)),
+            ),
+        )
+        window.analysis_workspace.upsert_roi(roi)
+        window.analysis_workspace.upsert_detector_profile(profile)
+        window.analysis_workspace.upsert_viewport(
+            CanvasViewport(
+                viewport_id="primary-spectrum",
+                spectrum_id=spectrum_id,
+                x_range=(250.0, 850.0),
+                y_range=(0.1, 200.0),
+                log_y=True,
+                residual_mode="compact",
+                selected_roi_id="saved-roi",
+                labels_visible=False,
+            )
+        )
+        window.central_tabs.apply_viewport_state(
+            window.analysis_workspace.document.viewport_by_id("primary-spectrum")
+        )
+        app.processEvents()
+
+        target = tmp_path / "complete.ffs"
+        assert window.save_session(target)
+        persisted = read_ffs_session(target).document
+        assert persisted.roi_by_id("saved-roi") == roi
+        assert persisted.detector_profile_by_id("saved-detector") == profile
+        assert persisted.viewport_by_id("primary-spectrum").log_y is True
+
+        window.analysis_workspace.set_document(
+            WorkspaceDocument(
+                document_id="temporary",
+                created_at="2026-07-22T00:00:00+00:00",
+                updated_at="2026-07-22T00:00:00+00:00",
+            )
+        )
+        window.open_path(target)
+        app.processEvents()
+
+        loaded = window.analysis_workspace.document
+        loaded_payload = loaded.to_dict()
+        persisted_payload = persisted.to_dict()
+        loaded_payload.pop("updated_at")
+        persisted_payload.pop("updated_at")
+        assert loaded_payload == persisted_payload
+        assert window._session_path == target.resolve()
+        assert window._document_dirty is False
+        assert window.undo_stack.isClean()
+        assert window.selection_bus.state.roi_bounds_keV == pytest.approx(
+            roi.signal_range
+        )
+        restored_view = window.central_tabs.viewport_state()
+        assert restored_view.x_range == pytest.approx((250.0, 850.0))
+        assert restored_view.log_y is True
+        assert restored_view.labels_visible is False
+    finally:
+        window.close()
+
+
+def test_opening_second_session_does_not_append_first_session(tmp_path: Path) -> None:
+    _qapp()
+    populated_path = tmp_path / "populated.ffs"
+    empty_path = tmp_path / "empty.ffs"
+    source = _window(load_example=True)
+    try:
+        assert source.save_session(populated_path)
+    finally:
+        source.close()
+
+    empty_document = WorkspaceDocument(
+        document_id="empty",
+        created_at="2026-07-22T00:00:00+00:00",
+        updated_at="2026-07-22T00:00:00+00:00",
+    )
+    write_ffs_session(empty_path, FluxForgeSession(document=empty_document))
+
+    window = _window()
+    try:
+        window.open_path(populated_path)
+        assert window.analysis_workspace.document.spectra
+        window.open_path(empty_path)
+        assert window.analysis_workspace.document.document_id == "empty"
+        assert window.analysis_workspace.document.spectra == ()
+        assert window.analysis_workspace.state.loaded_spectra == ()
+        assert window.analysis_workspace.state.spectra == ()
+    finally:
+        window.close()
+
+
+def test_gui_open_and_resave_preserves_session_envelope(tmp_path: Path) -> None:
+    _qapp()
+    source_path = tmp_path / "source.ffs"
+    target_path = tmp_path / "resaved.ffs"
+    embedded_recent = [tmp_path / "first.asc", tmp_path / "second.asc"]
+    original = FluxForgeSession(
+        document=WorkspaceDocument(
+            document_id="envelope-test",
+            created_at="2026-07-20T10:00:00+00:00",
+            updated_at="2026-07-20T10:00:00+00:00",
+        ),
+        recent_files=embedded_recent,
+        device_snapshot=[
+            {
+                "device_id": "sim-mca-1",
+                "telemetry": {"dead_time_fraction": 0.012},
+            }
+        ],
+        metadata={"campaign": "UWNR", "operator": "fixture"},
+        created_at="2026-07-20T09:55:00+00:00",
+    )
+    write_ffs_session(source_path, original)
+
+    window = _window()
+    try:
+        window.open_path(source_path)
+        assert window.save_session(target_path)
+
+        resaved = read_ffs_session(target_path)
+        assert resaved.device_snapshot == original.device_snapshot
+        assert resaved.metadata == original.metadata
+        assert resaved.created_at == original.created_at
+        assert str(source_path) in resaved.recent_files
+        assert str(target_path) in resaved.recent_files
+        assert all(str(item) in resaved.recent_files for item in embedded_recent)
+
+        window._load_example_workspace()
+        assert window._session_device_snapshot == []
+        assert window._session_metadata == {}
+        assert window._session_created_at is None
+        assert window._session_recent_files == ()
+    finally:
+        window.close()
+
+
+def test_main_window_calibration_apply_and_undo_are_non_mutating() -> None:
+    _qapp()
+    window = _window(load_example=True)
+    try:
+        spectrum_id = window.analysis_workspace.document.active_spectrum_id
+        before_record = window.analysis_workspace.document.spectrum_by_id(spectrum_id)
+        before_spectrum = before_record.spectrum
+        before_counts = before_spectrum.counts
+        before_energies = np.asarray(before_spectrum.energies, dtype=float).copy()
+        before_coefficients = tuple(before_spectrum.calibration["energy"])
+        before_payload = window.analysis_workspace.document.to_dict()
+        before_payload.pop("updated_at")
+        fit = SimpleNamespace(
+            order=1,
+            coefficients=(0.5, 2.0),
+            deviation_pairs=(),
+            chi_squared=0.2,
+            reduced_chi_squared=0.1,
+            rms_keV=0.03,
+        )
+
+        window._apply_calibration_workspace_result(before_spectrum, fit, None)
+        applied_record = window.analysis_workspace.document.spectrum_by_id(spectrum_id)
+        applied_spectrum = applied_record.spectrum
+        assert applied_spectrum is not before_spectrum
+        assert applied_spectrum.counts is before_counts
+        assert before_spectrum.calibration["energy"] == list(before_coefficients)
+        assert np.array_equal(before_spectrum.energies, before_energies)
+        assert applied_spectrum.calibration["energy"] == [0.5, 2.0]
+        assert applied_record.detector_profile_id is not None
+
+        window.undo_stack.undo()
+        restored = window.analysis_workspace.document.spectrum_by_id(
+            spectrum_id
+        ).spectrum
+        assert restored.counts is before_counts
+        assert restored.calibration["energy"] == list(before_coefficients)
+        assert np.array_equal(restored.energies, before_energies)
+        restored_payload = window.analysis_workspace.document.to_dict()
+        restored_payload.pop("updated_at")
+        assert restored_payload == before_payload
+
+        window.undo_stack.redo()
+        redone = window.analysis_workspace.document.spectrum_by_id(spectrum_id).spectrum
+        assert redone.calibration["energy"] == [0.5, 2.0]
+    finally:
+        window.close()

--- a/tests/test_workspace_undo.py
+++ b/tests/test_workspace_undo.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtGui import QUndoStack
+
+from fluxforge.core.workspace_document import (
+    AnalysisROI,
+    CalibrationModel,
+    CanvasViewport,
+    DetectorProfile,
+    FitDiagnostics,
+    NuclideAssignment,
+    PeakModel,
+    WorkspaceDocument,
+    WorkspaceSpectrum,
+)
+from fluxforge.gui.analysis_workspace import (
+    AnalysisWorkspaceController,
+    AnalysisWorkspaceState,
+)
+from fluxforge.gui.workspace_undo import (
+    ApplyCalibrationCommand,
+    AssignSpectrumRoleCommand,
+    DeletePeakCommand,
+    DeleteROICommand,
+    MoveROIBoundsCommand,
+    ReplacePeakSetCommand,
+    TogglePinnedNuclideCommand,
+    UpdateCanvasViewportCommand,
+    UpdateDetectorProfileCommand,
+    UpdatePeakAssignmentCommand,
+    UpdatePeakCommand,
+    UpsertROICommand,
+)
+from fluxforge.io.spe import GammaSpectrum
+
+
+class FakeLeafController:
+    def __init__(self) -> None:
+        self.peaks: dict[str, tuple[PeakModel, ...]] = {}
+        self.rois: dict[str, AnalysisROI] = {}
+        self.roles: dict[str, tuple[str, ...]] = {}
+        self.profiles: dict[str, DetectorProfile] = {}
+        self.viewports: dict[str, CanvasViewport] = {}
+        self.diagnostics: dict[str, FitDiagnostics] = {}
+        self.pinned: tuple[str, ...] = ()
+        self.calibrations: dict[str, CalibrationModel | DetectorProfile | None] = {}
+
+    def replace_peak_models(self, peaks, *, spectrum_id=None):
+        assert spectrum_id is not None
+        self.peaks[spectrum_id] = tuple(peaks)
+
+    def replace_all_peak_models(self, peaks):
+        grouped: dict[str, list[PeakModel]] = {}
+        for peak in peaks:
+            grouped.setdefault(peak.spectrum_id, []).append(peak)
+        self.peaks = {key: tuple(values) for key, values in grouped.items()}
+
+    def upsert_peak_model(self, peak, *, index=None):
+        items = list(self.peaks.get(peak.spectrum_id, ()))
+        for index, current in enumerate(items):
+            if current.peak_id == peak.peak_id:
+                items[index] = peak
+                break
+        else:
+            if index is None:
+                items.append(peak)
+            else:
+                items.insert(max(0, min(index, len(items))), peak)
+        self.peaks[peak.spectrum_id] = tuple(items)
+
+    def delete_peak_model(self, spectrum_id, peak_id):
+        self.peaks[spectrum_id] = tuple(
+            peak for peak in self.peaks.get(spectrum_id, ()) if peak.peak_id != peak_id
+        )
+
+    def upsert_roi(self, roi, *, index=None):
+        if index is None or roi.roi_id in self.rois:
+            self.rois[roi.roi_id] = roi
+            return
+        items = list(self.rois.items())
+        items.insert(max(0, min(index, len(items))), (roi.roi_id, roi))
+        self.rois = dict(items)
+
+    def delete_roi(self, roi_id):
+        self.rois.pop(roi_id, None)
+
+    def upsert_fit_diagnostic(self, diagnostic):
+        self.diagnostics[diagnostic.diagnostic_id] = diagnostic
+
+    def assign_spectrum_role(self, role, spectrum_ids):
+        resolved = tuple(spectrum_ids or ())
+        if resolved:
+            self.roles[role] = resolved
+        else:
+            self.roles.pop(role, None)
+
+    def upsert_detector_profile(self, profile):
+        self.profiles[profile.detector_profile_id] = profile
+
+    def delete_detector_profile(self, profile_id):
+        self.profiles.pop(profile_id, None)
+
+    def upsert_viewport(self, viewport):
+        self.viewports[viewport.viewport_id] = viewport
+
+    def delete_viewport(self, viewport_id):
+        self.viewports.pop(viewport_id, None)
+
+    def set_pinned_nuclides(self, pinned_nuclides):
+        self.pinned = tuple(pinned_nuclides)
+
+    def apply_calibration(self, spectrum_id, calibration_state):
+        self.calibrations[spectrum_id] = calibration_state
+
+
+def _peak(peak_id: str = "peak-1", centroid: float = 10.0) -> PeakModel:
+    return PeakModel(
+        peak_id=peak_id,
+        spectrum_id="spec-1",
+        roi_id=None,
+        centroid_channel=centroid,
+        centroid_energy_keV=centroid * 2.0,
+    )
+
+
+def _roi(signal=(9.0, 11.0)) -> AnalysisROI:
+    return AnalysisROI(
+        roi_id="roi-1",
+        spectrum_id="spec-1",
+        signal_range=signal,
+        left_background_range=(6.0, 8.0),
+        right_background_range=(12.0, 14.0),
+    )
+
+
+def _linked_document() -> WorkspaceDocument:
+    spectrum = GammaSpectrum(
+        counts=np.asarray([3.0, 8.0, 4.0]),
+        channels=np.arange(3),
+        energies=np.asarray([9.0, 10.0, 11.0]),
+        live_time=10.0,
+        real_time=11.0,
+        spectrum_id="spec-1",
+    )
+    peak = replace(_peak(), roi_id="roi-1")
+    roi = replace(_roi(), associated_peak_ids=("peak-1",))
+    diagnostic = FitDiagnostics(
+        diagnostic_id="diag-1",
+        spectrum_id="spec-1",
+        roi_id="roi-1",
+        peak_id="peak-1",
+        fit_revision=1,
+        status="valid",
+        x=(9.0, 10.0, 11.0),
+        observed=(3.0, 8.0, 4.0),
+        model=(3.2, 7.6, 4.1),
+        uncertainty=(1.0, 1.0, 1.0),
+        normalized_residuals=(-0.2, 0.4, -0.1),
+    )
+    return WorkspaceDocument(
+        spectra=(
+            WorkspaceSpectrum(
+                spectrum_id="spec-1",
+                spectrum=spectrum,
+                label="Linked test",
+            ),
+        ),
+        active_spectrum_id="spec-1",
+        rois=(roi,),
+        peaks=(peak,),
+        fit_diagnostics=(diagnostic,),
+        viewports=(
+            CanvasViewport(
+                viewport_id="main",
+                spectrum_id="spec-1",
+                selected_roi_id="roi-1",
+            ),
+        ),
+    )
+
+
+def _semantic_payload(document: WorkspaceDocument) -> dict:
+    payload = document.to_dict()
+    payload.pop("updated_at", None)
+    return payload
+
+
+def _ordered_linked_document() -> WorkspaceDocument:
+    base = _linked_document()
+    secondary_spectrum = GammaSpectrum(
+        counts=np.asarray([1.0, 2.0, 1.0]),
+        channels=np.arange(3),
+        energies=np.asarray([9.0, 10.0, 11.0]),
+        live_time=10.0,
+        real_time=10.0,
+        spectrum_id="spec-2",
+    )
+    interleaved = PeakModel(
+        peak_id="other-peak",
+        spectrum_id="spec-2",
+        roi_id=None,
+        centroid_channel=1.0,
+        centroid_energy_keV=10.0,
+    )
+    second_roi = replace(
+        _roi((20.0, 22.0)),
+        roi_id="roi-2",
+        left_background_range=(17.0, 19.0),
+        right_background_range=(23.0, 25.0),
+        associated_peak_ids=("peak-2",),
+    )
+    second_peak = replace(
+        _peak("peak-2", 21.0),
+        roi_id="roi-2",
+        centroid_energy_keV=21.0,
+    )
+    return replace(
+        base,
+        spectra=base.spectra
+        + (
+            WorkspaceSpectrum(
+                spectrum_id="spec-2",
+                spectrum=secondary_spectrum,
+                label="Interleaved spectrum",
+            ),
+        ),
+        rois=(base.rois[0], second_roi),
+        peaks=(base.peaks[0], interleaved, second_peak),
+    )
+
+
+@pytest.mark.parametrize("operation", ["delete_peak", "replace_peaks", "delete_roi"])
+def test_destructive_focused_commands_restore_all_dependent_leaves(operation):
+    original = _linked_document()
+    controller = AnalysisWorkspaceController(original)
+
+    if operation == "delete_peak":
+        command = DeletePeakCommand(controller, peak=original.peaks[0])
+    elif operation == "replace_peaks":
+        command = ReplacePeakSetCommand(
+            controller,
+            spectrum_id="spec-1",
+            before=original.peaks,
+            after=(),
+        )
+    else:
+        command = DeleteROICommand(controller, roi=original.rois[0])
+
+    command.redo()
+    assert _semantic_payload(controller.document) != _semantic_payload(original)
+    command.undo()
+
+    assert _semantic_payload(controller.document) == _semantic_payload(original)
+
+
+@pytest.mark.parametrize("operation", ["delete_peak", "replace_peaks", "delete_roi"])
+def test_destructive_undo_restores_global_leaf_order(operation):
+    original = _ordered_linked_document()
+    controller = AnalysisWorkspaceController(original)
+
+    if operation == "delete_peak":
+        command = DeletePeakCommand(controller, peak=original.peaks[0])
+    elif operation == "replace_peaks":
+        spectrum_peaks = tuple(
+            item for item in original.peaks if item.spectrum_id == "spec-1"
+        )
+        command = ReplacePeakSetCommand(
+            controller,
+            spectrum_id="spec-1",
+            before=spectrum_peaks,
+            after=(spectrum_peaks[1],),
+        )
+    else:
+        command = DeleteROICommand(controller, roi=original.rois[0])
+
+    command.redo()
+    command.undo()
+
+    assert _semantic_payload(controller.document) == _semantic_payload(original)
+
+
+def test_peak_commands_redo_and_undo_only_target_peak_leaves():
+    controller = FakeLeafController()
+    peak_before = _peak()
+    peak_after = _peak(centroid=10.5)
+    second = _peak("peak-2", 20.0)
+
+    replace_set = ReplacePeakSetCommand(
+        controller,
+        spectrum_id="spec-1",
+        before=(peak_before,),
+        after=(peak_after, second),
+    )
+    replace_set.redo()
+    assert controller.peaks["spec-1"] == (peak_after, second)
+    replace_set.undo()
+    assert controller.peaks["spec-1"] == (peak_before,)
+
+    update = UpdatePeakCommand(controller, before=peak_before, after=peak_after)
+    update.redo()
+    assert controller.peaks["spec-1"] == (peak_after,)
+    update.undo()
+    assert controller.peaks["spec-1"] == (peak_before,)
+
+    add = UpdatePeakCommand(controller, before=None, after=second)
+    add.redo()
+    assert second in controller.peaks["spec-1"]
+    add.undo()
+    assert second not in controller.peaks["spec-1"]
+
+    delete = DeletePeakCommand(controller, peak=peak_before)
+    delete.redo()
+    assert controller.peaks["spec-1"] == ()
+    delete.undo()
+    assert controller.peaks["spec-1"] == (peak_before,)
+
+
+def test_assignment_pin_roi_role_profile_viewport_and_calibration_commands():
+    controller = FakeLeafController()
+    peak_before = _peak()
+    assignment = NuclideAssignment(nuclide="Cs-137", line_energy_keV=661.657)
+    peak_after = replace(peak_before, assignments=(assignment,), tags=("reference",))
+    assignment_command = UpdatePeakAssignmentCommand(
+        controller, before=peak_before, after=peak_after
+    )
+    assignment_command.redo()
+    assert controller.peaks["spec-1"] == (peak_after,)
+    assignment_command.undo()
+    assert controller.peaks["spec-1"] == (peak_before,)
+
+    pin = TogglePinnedNuclideCommand(
+        controller, before=("Co-60",), after=("Co-60", "Cs-137")
+    )
+    pin.redo()
+    assert controller.pinned == ("Co-60", "Cs-137")
+    pin.undo()
+    assert controller.pinned == ("Co-60",)
+
+    roi = _roi()
+    upsert_roi = UpsertROICommand(controller, before=None, after=roi)
+    upsert_roi.redo()
+    assert controller.rois == {"roi-1": roi}
+    upsert_roi.undo()
+    assert controller.rois == {}
+    controller.upsert_roi(roi)
+    delete_roi = DeleteROICommand(controller, roi=roi)
+    delete_roi.redo()
+    assert controller.rois == {}
+    delete_roi.undo()
+    assert controller.rois == {"roi-1": roi}
+
+    role = AssignSpectrumRoleCommand(
+        controller,
+        role="foreground",
+        before=("old-spec",),
+        after=("spec-1",),
+    )
+    role.redo()
+    assert controller.roles["foreground"] == ("spec-1",)
+    role.undo()
+    assert controller.roles["foreground"] == ("old-spec",)
+
+    profile = DetectorProfile(detector_profile_id="hpge-1", detector_id="HPGe")
+    profile_command = UpdateDetectorProfileCommand(
+        controller, before=None, after=profile
+    )
+    profile_command.redo()
+    assert controller.profiles == {"hpge-1": profile}
+    profile_command.undo()
+    assert controller.profiles == {}
+
+    viewport = CanvasViewport(
+        viewport_id="main", spectrum_id="spec-1", x_range=(5.0, 25.0)
+    )
+    viewport_command = UpdateCanvasViewportCommand(
+        controller, before=None, after=viewport
+    )
+    viewport_command.redo()
+    assert controller.viewports == {"main": viewport}
+    viewport_command.undo()
+    assert controller.viewports == {}
+
+    old_calibration = CalibrationModel(model_key="linear", coefficients=(0.0, 1.0))
+    new_calibration = CalibrationModel(model_key="linear", coefficients=(0.1, 1.01))
+    calibration_command = ApplyCalibrationCommand(
+        controller,
+        spectrum_id="spec-1",
+        before=old_calibration,
+        after=new_calibration,
+    )
+    calibration_command.redo()
+    assert controller.calibrations["spec-1"] is new_calibration
+    calibration_command.undo()
+    assert controller.calibrations["spec-1"] is old_calibration
+
+
+def test_roi_drag_commands_merge_only_for_same_gesture_and_identity():
+    controller = FakeLeafController()
+    first = _roi((9.0, 11.0))
+    middle = _roi((9.2, 11.2))
+    final = _roi((9.5, 11.5))
+    stack = QUndoStack()
+
+    stack.push(
+        MoveROIBoundsCommand(
+            controller, before=first, after=middle, drag_token="drag-17"
+        )
+    )
+    stack.push(
+        MoveROIBoundsCommand(
+            controller, before=middle, after=final, drag_token="drag-17"
+        )
+    )
+
+    assert stack.count() == 1
+    assert controller.rois["roi-1"] is final
+    stack.undo()
+    assert controller.rois["roi-1"] is first
+    stack.redo()
+    assert controller.rois["roi-1"] is final
+
+    stack.push(
+        MoveROIBoundsCommand(
+            controller,
+            before=final,
+            after=_roi((9.6, 11.6)),
+            drag_token="drag-18",
+        )
+    )
+    assert stack.count() == 2
+
+
+def test_commands_never_retain_documents_legacy_states_or_spectrum_arrays():
+    controller = FakeLeafController()
+    peak = _peak()
+    roi = _roi()
+    profile = DetectorProfile(detector_profile_id="hpge-1")
+    viewport = CanvasViewport(viewport_id="main", spectrum_id="spec-1")
+    calibration = CalibrationModel(model_key="linear", coefficients=(0.0, 1.0))
+    commands = (
+        ReplacePeakSetCommand(
+            controller,
+            spectrum_id="spec-1",
+            before=(),
+            after=(peak,),
+        ),
+        UpdatePeakCommand(controller, before=None, after=peak),
+        DeletePeakCommand(controller, peak=peak),
+        UpdatePeakAssignmentCommand(controller, before=peak, after=peak),
+        TogglePinnedNuclideCommand(controller, before=(), after=("Cs-137",)),
+        UpsertROICommand(controller, before=None, after=roi),
+        DeleteROICommand(controller, roi=roi),
+        MoveROIBoundsCommand(controller, before=roi, after=roi, drag_token="drag-1"),
+        AssignSpectrumRoleCommand(
+            controller, role="foreground", before=(), after=("spec-1",)
+        ),
+        UpdateDetectorProfileCommand(controller, before=None, after=profile),
+        UpdateCanvasViewportCommand(controller, before=None, after=viewport),
+        ApplyCalibrationCommand(
+            controller,
+            spectrum_id="spec-1",
+            before=None,
+            after=calibration,
+        ),
+    )
+
+    forbidden = (WorkspaceDocument, AnalysisWorkspaceState, GammaSpectrum, np.ndarray)
+    for command in commands:
+        assert not any(
+            isinstance(value, forbidden) for value in vars(command).values()
+        ), command.__class__.__name__
+
+
+def test_commands_reject_identity_changes_and_non_leaf_calibration():
+    controller = FakeLeafController()
+    with pytest.raises(ValueError, match="same peak"):
+        UpdatePeakCommand(controller, before=_peak(), after=_peak("other"))
+    with pytest.raises(ValueError, match="same ROI"):
+        MoveROIBoundsCommand(
+            controller,
+            before=_roi(),
+            after=replace(_roi(), roi_id="other"),
+            drag_token="drag",
+        )
+    with pytest.raises(TypeError, match="CalibrationModel"):
+        ApplyCalibrationCommand(
+            controller,
+            spectrum_id="spec-1",
+            before=None,
+            after=np.arange(4.0),  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary
- introduce validated `WorkspaceDocument v2` models for spectra, roles, ROIs, peaks, detector profiles, fit diagnostics, and viewports
- add strict v1→v2 session migration, atomic crash-safe `.ffs` saves, and full GUI session-envelope preservation
- make the canonical document the GUI source of truth with focused, exact undo/redo and renderer-independent canvas intents
- restore all persisted viewport state, including overlays, residual mode, labels, log state, and crosshair
- package the complete closed JSON schema and document the session format

## Validation
- independent branch gate: PASS, no remaining blockers
- Windows foundation: 100 passed, 10 expected skips
- Linux foundation: 101 passed, 9 expected skips
- Windows production/modern GUI: 51 passed
- Windows calibration: 25 passed
- exact controller/undo/session regression set: 26 passed
- Black, compileall, JSON parsing, import-order smoke tests, and git diff check passed

Expected skips are the optional external `jsonschema` engine (not installed in the audited environments) and one POSIX-only parent-directory fsync case on Windows. The packaged schema was also checked with a bounded local validator during the independent gate review.