### PR TITLE
GUI: canonical bGamma direct spectrum manipulation

### DIFF
--- a/.github/project-management/full_parity_ledger.json
+++ b/.github/project-management/full_parity_ledger.json
@@ -81,11 +81,11 @@
       "notes": "Initial executable workflow cases exist; same-input end-to-end competitor and UWNR golden suites remain open."
     },
     {
-      "id": "3.24", "title": "Direct-manipulation spectrum canvas", "roadmap": "Phase 3B", "status": "prototype",
+      "id": "3.24", "title": "Direct-manipulation spectrum canvas", "roadmap": "Phase 3B", "status": "implemented",
       "source_urls": ["fluxforge-roadmap", "interspec", "peakeasy", "hyperlab"],
-      "backend": "prototype", "cli": "not-applicable", "gui": "prototype", "fixture": "planned", "test": "prototype",
-      "evidence": ["src/fluxforge/gui/spectrum_canvas.py", "src/fluxforge/gui/backends/pyqtgraph_backend.py", "src/fluxforge/gui/canvas_intents.py", "src/fluxforge/gui/workspace_undo.py", "tests/test_canvas_intents.py", "tests/test_workspace_undo.py", "tests/test_analysis_workspace_qt.py"],
-      "notes": "Renderer-independent intents, focused undo commands, and persisted viewports are implemented with Windows/Linux tests. Direct peak/ROI/sideband mouse manipulation and native desktop automation remain for gui/02, so this stays prototype."
+      "backend": "implemented", "cli": "not-applicable", "gui": "implemented", "fixture": "not-applicable", "test": "implemented",
+      "evidence": ["src/fluxforge/gui/spectrum_canvas.py", "src/fluxforge/gui/backends/pyqtgraph_backend.py", "src/fluxforge/gui/canvas_intents.py", "src/fluxforge/gui/canvas_controller.py", "src/fluxforge/gui/workspace_undo.py", "tests/test_pyqtgraph_direct_interactions.py", "tests/test_bgamma_canvas_integration_qt.py", "tests/test_canvas_intent_dispatcher.py", "tests/test_workspace_undo.py", "docs/BRANCH02_DIRECT_MANIPULATION_EVIDENCE.md"],
+      "notes": "Shift-drag ROI creation, signal and sideband handles, exact peak selection and centroid dragging, context actions, spectrum roles, table/plot synchronization, focused undo/redo, viewport persistence, and stale-analysis invalidation are implemented. Real Qt mouse tests pass on Windows and Linux/X11; final release-level Wayland, scaling, and accessibility coverage remains tracked by 3.27."
     },
     {
       "id": "3.25", "title": "Modern Qt parity workspaces", "roadmap": "Phase 3B", "status": "prototype",
@@ -316,32 +316,32 @@
       "notes": "Mini residual rendering exists; complete modes, linked ranges, per-channel severity, and persisted mode defaults remain open."
     },
     {
-      "id": "BG.4", "title": "Direct ROI, sideband, and peak manipulation with undo", "roadmap": "bGamma carryover", "status": "prototype",
+      "id": "BG.4", "title": "Direct ROI, sideband, and peak manipulation with undo", "roadmap": "bGamma carryover", "status": "implemented",
       "source_urls": ["fluxforge-roadmap", "interspec", "hyperlab"],
-      "backend": "prototype", "cli": "not-applicable", "gui": "prototype", "fixture": "planned", "test": "prototype",
-      "evidence": ["src/fluxforge/gui/backends/pyqtgraph_backend.py", "src/fluxforge/gui/analysis_workspace.py", "tests/test_analysis_workspace_qt.py"],
-      "notes": "Some direct manipulation and undo infrastructure exists; the complete renderer-independent intent/command contract and native mouse evidence remain open."
+      "backend": "implemented", "cli": "not-applicable", "gui": "implemented", "fixture": "not-applicable", "test": "implemented",
+      "evidence": ["src/fluxforge/gui/backends/pyqtgraph_backend.py", "src/fluxforge/gui/canvas_controller.py", "src/fluxforge/gui/analysis_workspace.py", "tests/test_pyqtgraph_direct_interactions.py", "tests/test_bgamma_canvas_integration_qt.py", "docs/BRANCH02_DIRECT_MANIPULATION_EVIDENCE.md"],
+      "notes": "Canonical ROI signal/sideband and peak-centroid edits are emitted as renderer-independent intents, committed once per completed drag, persisted in WorkspaceDocument v2, and covered by exact undo/redo and native Windows/Linux mouse tests."
     },
     {
-      "id": "BG.5", "title": "Context actions, assignments, pins, tags, overlap edits, and spectrum roles", "roadmap": "bGamma carryover", "status": "prototype",
+      "id": "BG.5", "title": "Context actions, assignments, pins, tags, overlap edits, and spectrum roles", "roadmap": "bGamma carryover", "status": "implemented",
       "source_urls": ["fluxforge-roadmap", "interspec", "hyperlab"],
-      "backend": "prototype", "cli": "not-applicable", "gui": "prototype", "fixture": "scaffolded", "test": "prototype",
-      "evidence": ["src/fluxforge/gui/panels/modern_shell.py", "src/fluxforge/gui/analysis_workspace.py", "tests/test_analysis_workspace_qt.py"],
-      "notes": "Several actions exist; complete context-menu reachability, overlap split/merge, persistence, and undo coverage remain open."
+      "backend": "implemented", "cli": "not-applicable", "gui": "implemented", "fixture": "not-applicable", "test": "implemented",
+      "evidence": ["src/fluxforge/gui/backends/pyqtgraph_backend.py", "src/fluxforge/gui/canvas_controller.py", "src/fluxforge/gui/analysis_workspace.py", "tests/test_pyqtgraph_direct_interactions.py", "tests/test_canvas_intent_dispatcher.py"],
+      "notes": "The spectrum context menu exposes stable-ID add/select/move/delete, assignment, pin, tag, component add/split/merge, ROI, viewport, crosshair, export, and foreground/background/secondary role actions with persistence and focused undo coverage."
     },
     {
-      "id": "BG.6", "title": "Graph-table synchronization and plot-driven edits", "roadmap": "bGamma carryover", "status": "prototype",
+      "id": "BG.6", "title": "Graph-table synchronization and plot-driven edits", "roadmap": "bGamma carryover", "status": "implemented",
       "source_urls": ["fluxforge-roadmap", "interspec", "peakeasy"],
-      "backend": "prototype", "cli": "not-applicable", "gui": "prototype", "fixture": "prototype", "test": "prototype",
-      "evidence": ["src/fluxforge/gui/selection_bus.py", "src/fluxforge/gui/panels/modern_shell.py", "tests/test_analysis_workspace_qt.py"],
-      "notes": "Selection synchronization exists; persisted ROI ownership and complete bidirectional edit propagation remain open."
+      "backend": "implemented", "cli": "not-applicable", "gui": "implemented", "fixture": "not-applicable", "test": "implemented",
+      "evidence": ["src/fluxforge/gui/selection_bus.py", "src/fluxforge/gui/panels/modern_shell.py", "src/fluxforge/gui/panels/modern_shell_center.py", "tests/test_bgamma_canvas_integration_qt.py"],
+      "notes": "Exact spectrum, ROI, and peak IDs drive bidirectional table/plot selection, including duplicate-energy peaks; table selection zooms to the canonical ROI, plot edits refresh tables and clear stale derived results, and save/reload preserves the edits."
     },
     {
       "id": "BG.7", "title": "Canvas navigation, crosshair, export, and keyboard access", "roadmap": "bGamma carryover", "status": "prototype",
       "source_urls": ["fluxforge-roadmap", "interspec", "peakeasy"],
       "backend": "not-applicable", "cli": "not-applicable", "gui": "prototype", "fixture": "planned", "test": "prototype",
       "evidence": ["src/fluxforge/gui/spectrum_canvas.py", "src/fluxforge/gui/backends/pyqtgraph_backend.py", "tests/test_modern_gui_shell.py"],
-      "notes": "Zoom, pan, reset, and export foundations exist; all scientific plots still require consistent crosshair, keyboard, scaling, and native evidence."
+      "notes": "The primary spectrum canvas now has zoom, pan, reset, crosshair/readout, persisted viewport state, and an export action with native Windows/Linux interaction evidence. This carryover remains prototype until the same navigation and keyboard contract is applied to every scientific plot."
     },
     {
       "id": "BG.8", "title": "Self-contained analytical reports with plot diagnostics", "roadmap": "bGamma carryover", "status": "prototype",

--- a/.github/project-management/gui_action_catalog.json
+++ b/.github/project-management/gui_action_catalog.json
@@ -45,6 +45,11 @@
       "object_names": ["ToggleLogScaleAction", "TogglePeakLabelsAction"]
     },
     {
+      "surface": "renderer.direct-manipulation-context",
+      "test_ids": ["tests/test_pyqtgraph_direct_interactions.py"],
+      "object_names": ["CanvasContextAddComponentAction", "CanvasContextAddPeakAction", "CanvasContextAssignNuclideAction", "CanvasContextBackgroundRoleAction", "CanvasContextClearNuclideAction", "CanvasContextCreateRoiAction", "CanvasContextCrosshairAction", "CanvasContextDeletePeakAction", "CanvasContextDeleteRoiAction", "CanvasContextForegroundRoleAction", "CanvasContextMergePeaksAction", "CanvasContextMovePeakAction", "CanvasContextPinNuclideAction", "CanvasContextResetViewAction", "CanvasContextSecondaryRoleAction", "CanvasContextSelectPeakAction", "CanvasContextSelectRoiAction", "CanvasContextSplitPeakAction", "CanvasContextTagNuclideAction", "CanvasContextTagPeakAction", "CanvasContextUnpinNuclideAction", "OpenCanvasContextSpectrumRoleMenuAction", "OpenSpectrumContextMenuAction"]
+    },
+    {
       "surface": "main-window.undo",
       "test_ids": ["tests/test_analysis_workspace_qt.py"],
       "object_names": ["RedoAction", "UndoAction"]
@@ -114,7 +119,7 @@
     {
       "surface": "spectrum-canvas",
       "test_ids": ["tests/test_analysis_workspace_qt.py", "tests/test_modern_gui_shell.py"],
-      "object_names": ["SpectrumClearRoiButton", "SpectrumResetViewButton", "SpectrumSelectRoiButton", "SpectrumZoomInButton", "SpectrumZoomOutButton"]
+      "object_names": ["SpectrumClearRoiButton", "SpectrumCrosshairButton", "SpectrumResetViewButton", "SpectrumSelectRoiButton", "SpectrumZoomInButton", "SpectrumZoomOutButton"]
     },
     {
       "surface": "roi-tools",
@@ -162,6 +167,15 @@
   "renderer_intents": [
     {"action_id": "canvas.spectrum.wheel_zoom", "test_ids": ["tests/test_analysis_workspace_qt.py"]},
     {"action_id": "canvas.spectrum.drag_pan", "test_ids": ["tests/test_analysis_workspace_qt.py"]},
-    {"action_id": "canvas.spectrum.roi_handles", "test_ids": ["tests/test_analysis_workspace_qt.py"]}
+    {"action_id": "canvas.spectrum.shift_drag_roi", "test_ids": ["tests/test_pyqtgraph_direct_interactions.py"]},
+    {"action_id": "canvas.spectrum.roi_handles", "test_ids": ["tests/test_pyqtgraph_direct_interactions.py"]},
+    {"action_id": "canvas.spectrum.background_handles", "test_ids": ["tests/test_pyqtgraph_direct_interactions.py"]},
+    {"action_id": "canvas.spectrum.peak_exact_select", "test_ids": ["tests/test_pyqtgraph_direct_interactions.py", "tests/test_bgamma_canvas_integration_qt.py"]},
+    {"action_id": "canvas.spectrum.peak_centroid_drag", "test_ids": ["tests/test_pyqtgraph_direct_interactions.py"]},
+    {"action_id": "canvas.spectrum.table_exact_zoom", "test_ids": ["tests/test_bgamma_canvas_integration_qt.py"]},
+    {"action_id": "canvas.spectrum.context_peak_roi", "test_ids": ["tests/test_pyqtgraph_direct_interactions.py"]},
+    {"action_id": "canvas.spectrum.context_roles", "test_ids": ["tests/test_pyqtgraph_direct_interactions.py"]},
+    {"action_id": "canvas.spectrum.crosshair", "test_ids": ["tests/test_pyqtgraph_direct_interactions.py"]},
+    {"action_id": "canvas.spectrum.export", "test_ids": ["tests/test_pyqtgraph_direct_interactions.py"]}
   ]
 }

--- a/README.md
+++ b/README.md
@@ -134,10 +134,15 @@ Recommended first interactions:
 
 1. Use **File > Open Spectrum** to load the foreground `.ASC` file.
 2. Use the mouse wheel to zoom and left-drag to pan the calibrated energy axis.
-3. Click **Select ROI**, then drag either boundary on the main canvas.
-4. Open **ROI Tools** to choose the background model and run the bounded analysis.
-5. Click **Reset View** to return to the full spectrum or **Clear ROI** to remove the boundaries.
-6. Use the spectrum tabs and background controls to compare foreground, background, and overlay spectra.
+3. Hold **Shift** and drag to create a signal ROI with two background sidebands;
+   drag a region to revise it and use **Ctrl+Z** to undo the completed edit.
+4. Right-click a peak or ROI for exact-ID peak, assignment, overlap, pin/tag,
+   ROI, and spectrum-role actions.
+5. Select a peak-table row to zoom and highlight its exact ROI; use the
+   crosshair for energy/count readout.
+6. Open **ROI Tools** to choose the background model and run the bounded analysis.
+7. Click **Reset View** to return to the full spectrum or **Clear ROI** to remove the boundaries.
+8. Use the spectrum tabs and background controls to compare foreground, background, and overlay spectra.
 
 If you prefer the direct GUI entrypoint, `fluxforge-gui --project-dir .`
 launches the same Qt application when the `native-gui` extra is installed.

--- a/docs/BRANCH02_DIRECT_MANIPULATION_EVIDENCE.md
+++ b/docs/BRANCH02_DIRECT_MANIPULATION_EVIDENCE.md
@@ -1,0 +1,70 @@
+# Branch 02: Direct-Manipulation Evidence
+
+Branch: `gui/02-bgamma-direct-manipulation`
+
+Integration base: `optimization-workflows` at `761ffdf8cb2437f5a0f86b027ca1d31c6eec409f`
+
+Validated: 2026-07-22
+
+## Implemented behavior
+
+- Shift-drag creates a canonical ROI with signal and left/right background ranges.
+- Signal and sideband handles update the selected `AnalysisROI` once when a drag finishes.
+- Peak markers select by stable peak ID, including peaks with identical centroid energy.
+- The selected centroid is draggable; one focused undo command is committed per drag.
+- Context actions cover peak add/select/move/delete, nuclide assignment and clearing,
+  pin/unpin, tags, component add/split/merge, ROI create/select/delete, spectrum roles,
+  reset, crosshair, and export.
+- Peak-table selection highlights and zooms to the exact canonical ROI; plot selection
+  selects the exact table row.
+- Scientific edits invalidate stale ROI/activity results and show an explicit
+  re-analysis-required state.
+- ROI, peak, assignment, role, viewport, and workflow-state changes persist in
+  `WorkspaceDocument v2` sessions and participate in focused undo/redo.
+
+## Automated evidence
+
+Windows 11, Python 3.12.10, PySide6 6.11.1:
+
+- Offscreen direct-manipulation, workspace-state, and session slice: 68 passed.
+- Native `QT_QPA_PLATFORM=windows`: 15 passed (9 renderer interactions plus
+  6 shell integration workflows).
+- `tests/test_production_gui_mode.py`: 9 passed.
+- `tests/test_modern_gui_shell.py`: 23 passed.
+
+The native pytest runs returned exit code 0, but PySide6 emitted a post-summary
+Windows COM teardown diagnostic. A standalone native `QApplication` and the
+installed GUI launcher both exited cleanly. The diagnostic is recorded as a test
+harness limitation and remains part of final clean-install qualification.
+
+Linux WSLg/X11, Python 3.13.5:
+
+- Native `QT_QPA_PLATFORM=xcb` direct/integration suite on the final source:
+  15 passed (9 renderer interactions plus 6 shell integration workflows).
+- Offscreen direct/state/session slice: 68 passed.
+
+An independent source audit reran 42 focused tests and found no remaining
+branch-level blockers. Direct `QT_QPA_PLATFORM=wayland` initialization was not
+available in this WSLg environment, so Wayland is not claimed as passed.
+
+The real Qt tests use `QTest` mouse press, move, release, and click events against
+the rendered PyQtGraph viewport. They assert emitted intent payloads, stable IDs,
+workspace mutations, undo/redo, persistence, table/plot synchronization, and
+debounced viewport commits rather than only counting widgets or rows.
+
+## Native desktop observation
+
+The installed Windows launcher (`fluxforge-gui.exe`) was exercised at 1866 x 1079.
+Default startup was empty; `File > Open Example` loaded foreground, background,
+and overlay spectra. The crosshair produced a live coordinate readout. The spectrum
+context menu exposed the full action set, and adding a manual peak produced a visible
+selected centroid, peak-table row, and residual row. The automatic peak-review dialog
+displayed three candidates; automated acceptance through the native accessibility
+layer was inconclusive, so acceptance of that modal is not claimed as branch evidence.
+
+## Remaining release-level gates
+
+This branch closes roadmap step 3.24 and bGamma carryovers BG.4-BG.6. BG.7 remains
+prototype until consistent navigation and keyboard behavior is applied to every
+scientific plot. Wayland, high-DPI matrices, accessibility, and visual-golden checks
+remain part of the final GUI release gate.

--- a/docs/GUI_TEST_COVERAGE_LEDGER.md
+++ b/docs/GUI_TEST_COVERAGE_LEDGER.md
@@ -34,6 +34,21 @@ Purpose: explicit inventory of FluxForge GUI parts tested so far, with evidence 
     ASC/ROI/log/background/unfolding/plot checks, and 1/1 legacy desktop driver.
   - The legacy control workflow reached activity, reaction rates, GLS unfolding,
     comparison, reports, and six plots.
+- 2026-07-22 bGamma direct-manipulation gate:
+  - Windows: 15/15 native Qt direct/integration tests (including 9 real
+    PyQtGraph mouse-interaction tests), 68/68 offscreen focused
+    interaction/state/session tests, 9/9 production-shell tests, and 23/23
+    modern-shell tests. Native pytest reports a post-summary COM teardown
+    diagnostic despite exit code 0; the standalone application exits cleanly.
+  - Linux WSLg/X11: 15/15 native direct/integration tests on the final source
+    (including 9 real renderer-interaction tests); 68/68 offscreen
+    interaction/state/session tests.
+  - Direct Wayland initialization was unavailable in this WSLg environment and
+    remains a release-level platform qualification gate.
+  - Stable-ID context actions, ROI signal/sideband handles, centroid dragging,
+    table/plot synchronization, stale-result invalidation, persistence, undo/redo,
+    crosshair, and viewport commits are covered. See
+    `docs/BRANCH02_DIRECT_MANIPULATION_EVIDENCE.md`.
 
 - Broad Qt GUI regression:
   - Command:
@@ -138,6 +153,17 @@ Purpose: explicit inventory of FluxForge GUI parts tested so far, with evidence 
   - Probe gallery:
     - `artifacts/gui_review/phase5_parity/index.html`
 
+### 2.11 Direct Spectrum Manipulation
+
+- Shift-drag ROI creation; signal and left/right sideband handle dragging; exact
+  peak selection and centroid dragging; stable-ID context actions; spectrum role
+  assignment; crosshair; zoom/pan/reset; debounced viewport persistence; exact
+  table/plot synchronization; session save/reload; and focused undo/redo.
+  - Tests: `tests/test_pyqtgraph_direct_interactions.py`,
+    `tests/test_bgamma_canvas_integration_qt.py`,
+    `tests/test_canvas_intent_dispatcher.py`, `tests/test_workspace_undo.py`
+  - Platform evidence: `docs/BRANCH02_DIRECT_MANIPULATION_EVIDENCE.md`
+
 ## 3. Browser-Lane Coverage Status
 
 - All generated GUI review galleries under `artifacts/gui_review/**/index.html` pass current Playwright checks:
@@ -154,8 +180,9 @@ The items below are tracked as direct-expansion targets to approach full GUI-par
 - Add focused panel-construction/behavior tests for:
   - `src/fluxforge/gui/panels/phase6.py` panel classes
   - `src/fluxforge/gui/panels/modern_shell.py` panel classes where only integrated coverage exists today
-- Add explicit backend-canvas coverage for:
-  - `src/fluxforge/gui/backends/pyqtgraph_backend.py` (`PyQtGraphSpectrumCanvas`)
+- Extend the direct backend-canvas contract to every remaining scientific plot,
+  including consistent keyboard navigation, high-DPI behavior, and visual-golden
+  coverage under Windows, X11, and Wayland.
 
 ## 5. Operating Rule for Future Runs
 

--- a/docs/ROADMAP_EXECUTION_STATUS.md
+++ b/docs/ROADMAP_EXECUTION_STATUS.md
@@ -183,7 +183,7 @@ following overlays were adopted additively and do not replace that map.
 | 3.21 | `pending` | `in-progress` | Fixture-manifest scaffolding now includes expanded source-linked case placeholders under `tests/spectra/reference_parity/cases/` and `tests/activation_inventory/fixtures/` (including second-irradiation planning), with contract checks in `tests/test_parity_fixture_manifests.py` and `tests/test_parity_phase3_scaffolding.py`. |
 | 3.22 | `pending` | `in-progress` | Initial algorithm-level parity scaffolding is now present via `parity_scope=algorithm` manifests plus discovery checks in `tests/test_parity_phase3_scaffolding.py`; full parser/calibration/fit/activity/dose/k0 golden comparisons remain pending. |
 | 3.23 | `pending` | `in-progress` | Initial workflow-level parity scaffolding is now present via `parity_scope=workflow` manifests (including activity/inventory and second-irradiation placeholders) plus scaffold verification tests; source-linked end-to-end golden-result suites remain pending. |
-| 3.24 | `pending` | `not-started` | Add direct-manipulation canvas parity: peak add/delete/move, ROI dragging, background handles, and overlay-role actions. |
+| 3.24 | `pending` | `complete` | Direct-manipulation canvas parity is implemented through renderer-independent intents and focused undo commands: shift-drag ROI creation, signal/sideband handles, exact peak selection and centroid dragging, peak/assignment/pin/tag/overlap/ROI/role context actions, bidirectional table/plot synchronization, stale-result invalidation, session persistence, and native Windows/Linux Qt mouse evidence. This remains sequence-pending until earlier Phase 3B gates close. |
 | 3.25 | `pending` | `in-progress` | Add dedicated Qt workspaces for ROI statistics, detection limit, dose/shielding, relative activity, file query/batch compare, reference libraries, and k0 reporting. Prototype `Line Interference / Masking`, `Irradiation Optimizer`, and `Second Irradiation` surfaces are executable and persist state, but must not be described as parity-complete or scientifically validated. |
 | 3.26 | `pending` | `complete` | GUI polish parity is now implemented via saved theme profiles (`src/fluxforge/gui/mode_manager.py` + `src/fluxforge/gui/widgets/mode_switcher.py`), stronger graph-table synchronization (`src/fluxforge/gui/backends/pyqtgraph_backend.py` + `src/fluxforge/gui/panels/modern_shell.py`), clearer launch/discovery actions (`src/fluxforge/gui/main_window.py`), and the maintainability split of the oversized shell into `modern_shell_center.py`, `modern_shell_sidebar.py`, `modern_shell_context.py`, and `modern_shell_shared.py`, with Qt coverage in `tests/test_analysis_workspace_qt.py`, `tests/test_module3_workflows_qt.py`, and `tests/test_modern_gui_shell.py`. |
 | 3.27 | `pending` | `complete` | GUI verification/release acceptance is now implemented with expanded Qt/CLI coverage (`tests/test_modern_gui_shell.py`, `tests/test_module3_workflows_qt.py`, `tests/test_cli_app.py`), native probe evidence (`tests/gui_phase327_release_probe.py` and `artifacts/gui_review/phase327_probe/index.html`), and a release-blocking checklist at `docs/PHASE3_27_RELEASE_CHECKLIST.md` plus CLI validation command `gui-acceptance-check`. |
@@ -462,11 +462,13 @@ following overlays were adopted additively and do not replace that map.
 - Phase 3.16 is now complete in the repository and formally complete in sequence.
 - Phase 3.17 is now complete in the repository and formally complete in sequence.
 - Phase 3.18 remains the active sequence gate and is not yet complete.
-- Phase 3.19 through 3.24 remain open in sequence (in-progress/planned).
+- Phase 3.19 through 3.23 remain open in sequence (in-progress/planned).
+- Phase 3.24 is implemented in-repo but remains sequence-pending until the earlier
+  open Phase 3B gates are closed.
 - Phase 3.26 and 3.27 are implemented in-repo but remain sequence-pending until the earlier open Phase 3 gates are closed.
 - The Qt shell contains substantial implemented workflows, but the full-parity
-  ledger remains authoritative for release maturity. Direct manipulation,
-  efficiency diagnostics and persistence, covariance-aware unfolding,
+  ledger remains authoritative for release maturity. Efficiency diagnostics and
+  persistence, covariance-aware unfolding,
   physics-grounded optimization, and acquisition work still include prototype,
   scaffolded, planned, or conditional-hardware gaps.
 - The roadmap's currently active offline-parity tranche is Phase 3.18 through

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -176,11 +176,17 @@ Recommended first actions:
 2. Use the foreground/background/overlay selectors to assign spectrum roles.
 3. Use the mouse wheel or **Zoom + / Zoom -** to inspect a peak-rich region;
    left-drag pans and **Reset View** restores the complete spectrum.
-4. Choose **Select ROI** and drag the displayed ROI bounds, then run the ROI
-   analysis or statistics action in the bottom workspace.
-5. Run **Auto Find Peaks**, review the proposal dialog, and use the peak table
-   for selection, isotope assignment, tags, and pinned nuclides.
-6. Choose **File > Save Session** (`Ctrl+S`) to write the complete analysis as
+4. Hold **Shift** and drag across the spectrum to create a persisted signal ROI
+   with left and right background sidebands. Drag any of the three regions to
+   revise its bounds; the complete drag is recorded as one undo step.
+5. Run **Auto Find Peaks**, review the proposals, then select a peak-table row
+   to zoom to its exact ROI. Right-click the canvas for peak add/move/delete,
+   isotope assignment, tag, pin/unpin, overlap-component, ROI, and spectrum-role
+   actions. The crosshair reports the current energy and count coordinates.
+6. Re-run any analysis marked stale after a scientific plot edit. FluxForge
+   clears prior ROI/activity results instead of allowing old results to be
+   exported against changed bounds or peaks.
+7. Choose **File > Save Session** (`Ctrl+S`) to write the complete analysis as
    a versioned `.ffs` file. **Save Session As** uses `Ctrl+Shift+S`; opening a
    session replaces the current workspace after validation.
 

--- a/docs/tutorials/1_getting_started.md
+++ b/docs/tutorials/1_getting_started.md
@@ -52,19 +52,21 @@ Recommended first interactions:
    spectra above and assign their roles in the left sidebar.
 2. Use the mouse wheel or **Zoom + / Zoom -** to inspect a photopeak region;
    left-drag pans and **Reset View** restores the full range.
-3. Choose **Select ROI** and drag the displayed ROI bounds.
+3. Hold **Shift** and drag across the plot to create a signal ROI and its two
+   background sidebands. Drag the signal or either sideband to revise it.
 4. Choose the sideband or SNIP method in the ROI tools when you want a
    background model, then run ROI analysis or ROI statistics.
 5. Run **Auto Find Peaks**, accept the reviewed proposals, and select a row to
-   synchronize the plot, peak tools, and nuclide browser.
-6. Use the peak-table controls to assign or clear an isotope, add a tag, or pin
-   a nuclide.
+   zoom and highlight its exact ROI on the plot.
+6. Right-click a peak or ROI to add, move, delete, assign, tag, pin/unpin, edit
+   overlap components, or set a spectrum role. Use **Ctrl+Z** and
+   **Ctrl+Shift+Z** to undo and redo completed edits.
 7. Choose **File > Save Session** (`Ctrl+S`) to persist spectra, roles, ROIs,
    peaks, detector state, and plot ranges in a validated `.ffs` file.
 
-Direct plot-sideband handles, centroid dragging, and peak context menus are not
-part of the current production workflow. They remain tracked direct-manipulation
-work rather than being presented as working controls.
+Scientific plot edits invalidate dependent ROI/activity output. Re-run the
+affected calculation before reporting or export; the interface never presents
+the superseded values as current.
 
 ## 3. First CLI Session
 

--- a/src/fluxforge/gui/analysis_workspace.py
+++ b/src/fluxforge/gui/analysis_workspace.py
@@ -297,7 +297,17 @@ class AnalysisWorkspaceController:
         )
 
     def select_spectrum(self, key: str) -> AnalysisWorkspaceState:
-        return self.update(active_spectrum_key=key)
+        role = next(
+            (item for item in self._document.spectrum_roles if item.role == key),
+            None,
+        )
+        spectrum_id = (
+            role.spectrum_ids[0] if role is not None and role.spectrum_ids else key
+        )
+        if self._document.spectrum_by_id(spectrum_id) is None:
+            raise KeyError(f"Unknown spectrum role or ID: {key!r}")
+        self._replace_document(active_spectrum_id=spectrum_id)
+        return self._state
 
     def replace_peaks(self, peaks: Sequence[PeakCandidate]) -> AnalysisWorkspaceState:
         selected = self._state.selected_peak_id
@@ -383,7 +393,11 @@ class AnalysisWorkspaceController:
         )
         diagnostics = tuple(
             (
-                replace(item, peak_id=None)
+                _invalid_fit_diagnostic(
+                    item,
+                    reason="peak set replaced",
+                    peak_id=None,
+                )
                 if item.spectrum_id == target
                 and item.peak_id is not None
                 and item.peak_id not in valid_peak_ids
@@ -439,7 +453,11 @@ class AnalysisWorkspaceController:
         )
         diagnostics = tuple(
             (
-                replace(item, peak_id=None)
+                _invalid_fit_diagnostic(
+                    item,
+                    reason="peak deleted",
+                    peak_id=None,
+                )
                 if item.spectrum_id == spectrum_id and item.peak_id == peak_id
                 else item
             )
@@ -469,11 +487,23 @@ class AnalysisWorkspaceController:
     def delete_roi(self, roi_id: str) -> WorkspaceDocument:
         rois = tuple(item for item in self._document.rois if item.roi_id != roi_id)
         peaks = tuple(
-            replace(item, roi_id=None) if item.roi_id == roi_id else item
+            (
+                _invalid_peak_model_fit(item, reason="ROI deleted", roi_id=None)
+                if item.roi_id == roi_id
+                else item
+            )
             for item in self._document.peaks
         )
         diagnostics = tuple(
-            replace(item, roi_id=None) if item.roi_id == roi_id else item
+            (
+                _invalid_fit_diagnostic(
+                    item,
+                    reason="ROI deleted",
+                    roi_id=None,
+                )
+                if item.roi_id == roi_id
+                else item
+            )
             for item in self._document.fit_diagnostics
         )
         viewports = tuple(
@@ -500,6 +530,20 @@ class AnalysisWorkspaceController:
         else:
             items.append(diagnostic)
         return self._replace_document(fit_diagnostics=tuple(items))
+
+    def set_fit_diagnostics(
+        self, diagnostics: Sequence[FitDiagnostics]
+    ) -> WorkspaceDocument:
+        """Replace canonical fit diagnostics without retaining spectrum arrays."""
+
+        return self._replace_document(fit_diagnostics=tuple(diagnostics))
+
+    def set_workflow_state(
+        self, workflow_state: Mapping[str, Any]
+    ) -> WorkspaceDocument:
+        """Replace the persisted workflow leaf without touching spectrum arrays."""
+
+        return self._replace_document(workflow_state=_json_safe(workflow_state))
 
     def assign_spectrum_role(
         self,
@@ -699,6 +743,23 @@ class AnalysisWorkspaceController:
                 deduped.append(nuclide)
         return self.update(pinned_nuclides=tuple(deduped))
 
+    def set_nuclide_tags(
+        self, nuclide_tags: Mapping[str, Sequence[str]]
+    ) -> WorkspaceDocument:
+        """Replace persisted analyst tags keyed by nuclide identifier."""
+
+        normalized: dict[str, tuple[str, ...]] = {}
+        for raw_nuclide, raw_tags in nuclide_tags.items():
+            nuclide = str(raw_nuclide).strip()
+            if not nuclide:
+                raise ValueError("nuclide tag keys must be non-empty")
+            tags = tuple(
+                dict.fromkeys(str(tag).strip() for tag in raw_tags if str(tag).strip())
+            )
+            if tags:
+                normalized[nuclide] = tags
+        return self._replace_document(nuclide_tags=normalized)
+
     def toggle_pinned_nuclide(self, nuclide: str) -> AnalysisWorkspaceState:
         current = list(self._state.pinned_nuclides)
         if nuclide in current:
@@ -759,19 +820,32 @@ class AnalysisWorkspaceController:
         self,
         results: Sequence[ActivityCalculationResult],
     ) -> AnalysisWorkspaceState:
-        return self.update(activity_results=tuple(results))
+        self.update(activity_results=tuple(results))
+        self._clear_analysis_invalidation()
+        return self.state
 
     def set_roi_analysis(
         self,
         result: ROIAnalysisResult | None,
     ) -> AnalysisWorkspaceState:
-        return self.update(roi_analysis=result)
+        self.update(roi_analysis=result)
+        self._clear_analysis_invalidation()
+        return self.state
 
     def set_roi_statistics(
         self,
         result: ROIStatisticsResult | None,
     ) -> AnalysisWorkspaceState:
-        return self.update(roi_statistics=result)
+        self.update(roi_statistics=result)
+        self._clear_analysis_invalidation()
+        return self.state
+
+    def _clear_analysis_invalidation(self) -> None:
+        workflow = dict(self._document.workflow_state)
+        if "analysis_invalidation" not in workflow:
+            return
+        workflow.pop("analysis_invalidation", None)
+        self.set_workflow_state(workflow)
 
     def set_survey_points(
         self, survey_points: Sequence[SurveyPoint]
@@ -1034,7 +1108,7 @@ class AnalysisWorkspaceController:
                 active_key = role.role
                 break
         peaks = tuple(
-            self._candidate_from_peak_model(item)
+            self._candidate_from_peak_model(item, document=document)
             for item in document.peaks
             if item.spectrum_id == document.active_spectrum_id
         )
@@ -1061,18 +1135,26 @@ class AnalysisWorkspaceController:
     ) -> PeakModel:
         assignments: tuple[NuclideAssignment, ...] = ()
         if candidate.nuclide:
-            line_energy = (
-                candidate.reference_lines_keV[0]
-                if candidate.reference_lines_keV
-                else candidate.energy_keV
-            )
-            assignments = (
-                NuclideAssignment(
-                    nuclide=candidate.nuclide,
-                    line_energy_keV=float(line_energy),
-                    manual=True,
-                ),
-            )
+            if (
+                prior is not None
+                and prior.assignments
+                and prior.assignments[0].nuclide == candidate.nuclide
+            ):
+                assignments = prior.assignments
+            else:
+                line_energy = (
+                    candidate.reference_lines_keV[0]
+                    if candidate.reference_lines_keV
+                    else candidate.energy_keV
+                )
+                assignments = (
+                    NuclideAssignment(
+                        nuclide=candidate.nuclide,
+                        line_energy_keV=float(line_energy),
+                        manual=True,
+                        provenance={"source": "legacy_peak_editor"},
+                    ),
+                )
         overrides = dict(prior.manual_overrides if prior else {})
         overrides["roi_bounds_keV"] = [
             float(candidate.roi_bounds_keV[0]),
@@ -1102,10 +1184,18 @@ class AnalysisWorkspaceController:
             residual_channels=candidate.residual_channels,
         )
 
-    @staticmethod
-    def _candidate_from_peak_model(peak: PeakModel) -> PeakCandidate:
+    def _candidate_from_peak_model(
+        self,
+        peak: PeakModel,
+        *,
+        document: WorkspaceDocument | None = None,
+    ) -> PeakCandidate:
+        source = document or self._document
+        roi = source.roi_by_id(peak.roi_id or "")
         raw_bounds = peak.manual_overrides.get("roi_bounds_keV")
-        if isinstance(raw_bounds, (list, tuple)) and len(raw_bounds) == 2:
+        if roi is not None and roi.spectrum_id == peak.spectrum_id:
+            roi_bounds = roi.signal_range
+        elif isinstance(raw_bounds, (list, tuple)) and len(raw_bounds) == 2:
             roi_bounds = (float(raw_bounds[0]), float(raw_bounds[1]))
         else:
             roi_bounds = (
@@ -1250,6 +1340,59 @@ def _loaded_records_equivalent(
         and a.spectrum is b.spectrum
         and a.source_path == b.source_path
         for a, b in zip(left, right)
+    )
+
+
+def _invalid_fit_diagnostic(
+    diagnostic: FitDiagnostics,
+    *,
+    reason: str,
+    **changes: Any,
+) -> FitDiagnostics:
+    """Return an explicit invalid state with no displayable stale residuals."""
+
+    flags = tuple(
+        dict.fromkeys((*diagnostic.warning_flags, "analysis-edit-invalidated"))
+    )
+    provenance = {
+        **dict(diagnostic.provenance),
+        "invalidated_by": reason,
+    }
+    return replace(
+        diagnostic,
+        status="invalid",
+        x=(),
+        observed=(),
+        model=(),
+        uncertainty=(),
+        normalized_residuals=(),
+        goodness_of_fit={},
+        warning_flags=flags,
+        provenance=provenance,
+        **changes,
+    )
+
+
+def _invalid_peak_model_fit(
+    peak: PeakModel,
+    *,
+    reason: str,
+    **changes: Any,
+) -> PeakModel:
+    """Return a peak leaf that cannot expose residuals from an obsolete fit."""
+
+    provenance = {
+        **dict(peak.provenance),
+        "fit_invalidated_by": reason,
+    }
+    return replace(
+        peak,
+        status="invalidated",
+        fit_quality=0.0,
+        normalized_residuals=(),
+        residual_channels=(),
+        provenance=provenance,
+        **changes,
     )
 
 

--- a/src/fluxforge/gui/backends/pyqtgraph_backend.py
+++ b/src/fluxforge/gui/backends/pyqtgraph_backend.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Sequence
+from uuid import uuid4
 
 import numpy as np
 
 from fluxforge.core.analysis_workspace import PeakCandidate
 from fluxforge.core.workspace_document import CanvasViewport
+from fluxforge.gui.canvas_intents import CanvasIntent, CanvasIntentKind
 from fluxforge.gui.qt_compat import QT_AVAILABLE, QT_IMPORT_ERROR
 from fluxforge.gui.selection_bus import SelectionBus, SelectionState
 from fluxforge.gui.spectrum_canvas import (
+    CanvasPeakOverlay,
+    CanvasROIOverlay,
     HierarchicalSpectrumBuffer,
     ReferenceLine,
     RendererCapabilities,
@@ -25,11 +30,14 @@ PYQTGRAPH_IMPORT_ERROR = QT_IMPORT_ERROR
 if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
     try:
         import pyqtgraph as pg
+        from PySide6.QtCore import QEvent, QTimer
 
         from fluxforge.gui.qt_compat import (
             QAction,
             QHBoxLayout,
+            QInputDialog,
             QLabel,
+            QMenu,
             QPushButton,
             QVBoxLayout,
             QWidget,
@@ -56,13 +64,14 @@ def pyqtgraph_backend_status() -> dict[str, object]:
     }
 
 
-def catalog_pyqtgraph_export_action(plot_widget, object_name: str) -> None:
-    """No-op unless the PyQtGraph backend is available."""
-
-    del plot_widget, object_name
-
-
 if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
+
+    @dataclass
+    class _ROIItems:
+        overlay: CanvasROIOverlay
+        signal: object
+        left_background: object
+        right_background: object
 
     def catalog_pyqtgraph_export_action(plot_widget, object_name: str) -> None:
         """Give PyQtGraph's production context-menu export action a stable ID."""
@@ -85,6 +94,20 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
             self.buffer = HierarchicalSpectrumBuffer.from_counts(())
             self._current_traces: tuple[SpectrumTrace, ...] = ()
             self._peak_candidates_by_id: dict[str, PeakCandidate] = {}
+            self._peak_overlays_by_id: dict[str, CanvasPeakOverlay] = {}
+            self._roi_items_by_id: dict[str, _ROIItems] = {}
+            self._interaction_spectrum_id: str | None = None
+            self._selected_roi_id: str | None = None
+            self._selected_peak_id: str | None = None
+            self._selected_peak_line = None
+            self._syncing_peak_line = False
+            self._syncing_analysis_overlays = False
+            self._shift_drag_active = False
+            self._shift_drag_start: float | None = None
+            self._shift_drag_preview = None
+            self._context_position = 0.0
+            self._context_peak_id: str | None = None
+            self._context_roi_id: str | None = None
             self._annotation_specs: tuple[ReferenceLine, ...] = ()
             self._reference_lines: list[object] = []
             self._annotation_label_items: list[object] = []
@@ -117,11 +140,26 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
             self.status_label.setObjectName("CanvasMeta")
             header.addWidget(self.status_label)
 
+            self.crosshair_readout = QLabel("x -- | y --", self)
+            self.crosshair_readout.setObjectName("SpectrumCrosshairReadout")
+            self.crosshair_readout.setVisible(False)
+            header.addWidget(self.crosshair_readout)
+
+            self.crosshair_button = QPushButton("Crosshair", self)
+            self.crosshair_button.setObjectName("SpectrumCrosshairButton")
+            self.crosshair_button.setCheckable(True)
+            self.crosshair_button.setToolTip(
+                "Show exact spectrum coordinates under the mouse pointer."
+            )
+            self.crosshair_button.toggled.connect(self._crosshair_button_toggled)
+            header.addWidget(self.crosshair_button)
+
             self.roi_button = QPushButton("Select ROI", self)
             self.roi_button.setObjectName("SpectrumSelectRoiButton")
             self.roi_button.setCheckable(True)
             self.roi_button.setToolTip(
-                "Show draggable ROI boundaries. Drag either handle to set the analysis limits."
+                "Show temporary analysis bounds. Shift-drag the plot to create a "
+                "persisted ROI with background sidebands."
             )
             self.roi_button.toggled.connect(self._set_roi_visible)
             header.addWidget(self.roi_button)
@@ -150,7 +188,8 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
             self.reset_view_button = QPushButton("Reset View", self)
             self.reset_view_button.setObjectName("SpectrumResetViewButton")
             self.reset_view_button.setToolTip(
-                "Fit the full spectrum. Use the mouse wheel to zoom and left-drag to pan."
+                "Fit the full spectrum. Use the mouse wheel to zoom and "
+                "left-drag to pan."
             )
             self.reset_view_button.clicked.connect(self.reset_view)
             header.addWidget(self.reset_view_button)
@@ -167,6 +206,13 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
             self.plot.setLabel("left", "Counts")
             self.plot_item = self.plot.getPlotItem()
             self.plot_item.setLogMode(x=False, y=False)
+            self._viewport_commit_timer = QTimer(self)
+            self._viewport_commit_timer.setSingleShot(True)
+            self._viewport_commit_timer.setInterval(120)
+            self._viewport_commit_timer.timeout.connect(self._commit_viewport_intent)
+            self.plot_item.getViewBox().sigRangeChangedManually.connect(
+                lambda _mask: self._schedule_viewport_commit()
+            )
             self.trace_item = self.plot_item.plot(
                 pen=pg.mkPen(color="#72d6ff", width=2),
                 fillLevel=0,
@@ -180,6 +226,20 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
             )
             self._peak_scatter.sigClicked.connect(self._peak_scatter_clicked)
             self.plot_item.addItem(self._peak_scatter)
+            self._selected_peak_line = pg.InfiniteLine(
+                angle=90,
+                movable=True,
+                pen=pg.mkPen(color="#f8fafc", width=2.5),
+                hoverPen=pg.mkPen(color="#38bdf8", width=3.0),
+                label="selected peak",
+                labelOpts={"color": "#f8fafc", "position": 0.92},
+            )
+            self._selected_peak_line.setZValue(28)
+            self._selected_peak_line.setVisible(False)
+            self._selected_peak_line.sigPositionChangeFinished.connect(
+                self._selected_peak_move_finished
+            )
+            self.plot_item.addItem(self._selected_peak_line, ignoreBounds=True)
             self._roi_region = pg.LinearRegionItem(
                 values=(0.0, 1.0),
                 orientation="vertical",
@@ -208,6 +268,8 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
                 line.setVisible(False)
                 self.plot_item.addItem(line, ignoreBounds=True)
             self.plot.scene().sigMouseMoved.connect(self._move_crosshair)
+            self.plot.viewport().setMouseTracking(True)
+            self.plot.viewport().installEventFilter(self)
             shell.addWidget(self.plot, 1)
 
             self.residual_row = QWidget(self)
@@ -244,6 +306,7 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
                     f"SpectrumResidualPlot{index + 1}",
                 )
             catalog_pyqtgraph_export_action(self.plot, "SpectrumPlot")
+            self._build_context_menu()
             self.residual_row.setVisible(False)
             shell.addWidget(self.residual_row)
 
@@ -305,7 +368,8 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
 
             visible_labels = ", ".join(trace.label for trace in traces if trace.visible)
             self.status_label.setText(
-                f"{len(values):,} channels · {len(self.buffer.levels)} LOD levels · {visible_labels}"
+                f"{len(values):,} channels · {len(self.buffer.levels)} LOD levels · "
+                f"{visible_labels}"
             )
             if self._annotation_specs:
                 self.set_annotation_lines(self._annotation_specs)
@@ -346,7 +410,8 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
                     label_item = pg.TextItem(
                         html=(
                             "<div style='font-size:10px; color:#e2e8f0; "
-                            "background:rgba(15,23,42,0.72); padding:2px 4px; border-radius:4px;'>"
+                            "background:rgba(15,23,42,0.72); padding:2px 4px; "
+                            "border-radius:4px;'>"
                             f"{marker.label}"
                             "</div>"
                         ),
@@ -378,59 +443,851 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
                 return
             if not peaks:
                 self._peak_candidates_by_id = {}
-                self._peak_scatter.setData([], [])
+                self._peak_overlays_by_id = {}
+                self._render_peak_overlays(())
                 return
             self._peak_candidates_by_id = {
                 str(peak.peak_id): peak for peak in peaks if peak.peak_id
             }
-            x_values = [
-                float(peak.energy_keV if self._x_axis_is_energy else peak.channel)
-                for peak in peaks
-            ]
-            y_values = [
-                (
-                    self._display_value(
-                        float(
-                            self.buffer.full_resolution[
-                                min(
-                                    int(round(peak.channel)),
-                                    len(self.buffer.full_resolution) - 1,
-                                )
-                            ]
+            overlays = tuple(
+                CanvasPeakOverlay(
+                    peak_id=str(peak.peak_id),
+                    spectrum_id=self._interaction_spectrum_id or "legacy-spectrum",
+                    position=float(
+                        peak.energy_keV if self._x_axis_is_energy else peak.channel
+                    ),
+                    y_value=(
+                        self._display_value(
+                            float(
+                                self.buffer.full_resolution[
+                                    min(
+                                        max(int(round(peak.channel)), 0),
+                                        len(self.buffer.full_resolution) - 1,
+                                    )
+                                ]
+                            )
                         )
-                    )
-                    if self.buffer.full_resolution
-                    else 0.0
+                        if self.buffer.full_resolution
+                        else 0.0
+                    ),
+                    nuclide=peak.nuclide,
+                    tags=tuple(peak.tags),
+                    selected=peak.peak_id == self._selected_peak_id,
                 )
                 for peak in peaks
-            ]
-            brushes = [
-                pg.mkBrush("#10b981" if peak.status == "matched" else "#f59e0b")
-                for peak in peaks
-            ]
-            self._peak_scatter.setData(
-                x=x_values,
-                y=y_values,
-                brush=brushes,
-                data=[peak.peak_id for peak in peaks],
             )
+            self._peak_overlays_by_id = {item.peak_id: item for item in overlays}
+            self._render_peak_overlays(overlays)
+
+        def set_interaction_context(self, spectrum_id: str | None) -> None:
+            self._interaction_spectrum_id = str(spectrum_id) if spectrum_id else None
+
+        def set_analysis_overlays(
+            self,
+            rois: Sequence[CanvasROIOverlay],
+            peaks: Sequence[CanvasPeakOverlay],
+            *,
+            selected_roi_id: str | None = None,
+            selected_peak_id: str | None = None,
+        ) -> None:
+            """Render exact canonical leaves without modifying the document."""
+
+            self._syncing_analysis_overlays = True
+            try:
+                self._selected_roi_id = selected_roi_id
+                self._selected_peak_id = selected_peak_id
+                if self._interaction_spectrum_id is None:
+                    identities = {
+                        item.spectrum_id for item in tuple(rois) + tuple(peaks)
+                    }
+                    if len(identities) == 1:
+                        self._interaction_spectrum_id = next(iter(identities))
+                self._replace_roi_items(tuple(rois))
+                normalized_peaks = tuple(
+                    CanvasPeakOverlay(
+                        peak_id=item.peak_id,
+                        spectrum_id=item.spectrum_id,
+                        position=item.position,
+                        y_value=item.y_value,
+                        component_ids=item.component_ids,
+                        nuclide=item.nuclide,
+                        tags=item.tags,
+                        pinned=item.pinned,
+                        selected=(
+                            item.peak_id == selected_peak_id
+                            if selected_peak_id is not None
+                            else item.selected
+                        ),
+                    )
+                    for item in peaks
+                )
+                self._peak_overlays_by_id = {
+                    item.peak_id: item for item in normalized_peaks
+                }
+                self._render_peak_overlays(normalized_peaks)
+            finally:
+                self._syncing_analysis_overlays = False
+
+        def _render_peak_overlays(self, peaks: Sequence[CanvasPeakOverlay]) -> None:
+            self._peak_overlays_by_id = {item.peak_id: item for item in peaks}
+            if not peaks:
+                self._peak_scatter.setData([], [])
+                self._selected_peak_line.setVisible(False)
+                return
+            self._peak_scatter.setData(
+                x=[float(item.position) for item in peaks],
+                y=[self._peak_y_at_position(item) for item in peaks],
+                size=[13 if item.selected else 9 for item in peaks],
+                brush=[
+                    pg.mkBrush("#38bdf8" if item.selected else "#f59e0b")
+                    for item in peaks
+                ],
+                pen=[
+                    pg.mkPen(
+                        color="#f8fafc" if item.selected else "#f59e0b",
+                        width=2.0 if item.selected else 1.25,
+                    )
+                    for item in peaks
+                ],
+                data=[item.peak_id for item in peaks],
+            )
+            selected = next((item for item in peaks if item.selected), None)
+            self._syncing_peak_line = True
+            try:
+                if selected is None:
+                    self._selected_peak_line.setVisible(False)
+                else:
+                    self._selected_peak_id = selected.peak_id
+                    self._selected_peak_line.setPos(float(selected.position))
+                    self._selected_peak_line.setVisible(True)
+            finally:
+                self._syncing_peak_line = False
+
+        def _peak_y_at_position(self, overlay: CanvasPeakOverlay) -> float:
+            if self._current_traces:
+                primary = self._current_traces[0]
+                if primary.channels and primary.counts:
+                    channels = np.asarray(primary.channels, dtype=float)
+                    index = int(np.argmin(np.abs(channels - float(overlay.position))))
+                    if 0 <= index < len(primary.counts):
+                        return self._display_value(float(primary.counts[index]))
+            return self._display_value(float(overlay.y_value))
+
+        def _replace_roi_items(self, rois: Sequence[CanvasROIOverlay]) -> None:
+            for bundle in self._roi_items_by_id.values():
+                for item in (
+                    bundle.signal,
+                    bundle.left_background,
+                    bundle.right_background,
+                ):
+                    self.plot_item.removeItem(item)
+            self._roi_items_by_id = {}
+            for overlay in rois:
+                selected = (
+                    overlay.roi_id == self._selected_roi_id
+                    if self._selected_roi_id is not None
+                    else overlay.selected
+                )
+                signal = self._analysis_region_item(
+                    overlay,
+                    "signal",
+                    overlay.signal_range,
+                    selected=selected,
+                )
+                left = self._analysis_region_item(
+                    overlay,
+                    "left",
+                    overlay.left_background_range,
+                    selected=selected,
+                )
+                right = self._analysis_region_item(
+                    overlay,
+                    "right",
+                    overlay.right_background_range,
+                    selected=selected,
+                )
+                self._roi_items_by_id[overlay.roi_id] = _ROIItems(
+                    overlay=overlay,
+                    signal=signal,
+                    left_background=left,
+                    right_background=right,
+                )
+                for item in (left, right, signal):
+                    self.plot_item.addItem(item)
+
+        def _analysis_region_item(
+            self,
+            overlay: CanvasROIOverlay,
+            part: str,
+            bounds: tuple[float, float],
+            *,
+            selected: bool,
+        ):
+            signal = part == "signal"
+            color = overlay.color if signal else "#64748b"
+            alpha = 62 if selected else 34
+            brush_color = pg.mkColor(color)
+            brush_color.setAlpha(alpha)
+            item = pg.LinearRegionItem(
+                values=tuple(float(value) for value in bounds),
+                orientation="vertical",
+                movable=True,
+                brush=pg.mkBrush(brush_color),
+                pen=pg.mkPen(
+                    color="#f8fafc" if selected else color,
+                    width=2.2 if selected else 1.2,
+                ),
+                hoverPen=pg.mkPen(color="#38bdf8", width=2.5),
+            )
+            item.setZValue(24 if signal else 22)
+            item.sigRegionChangeFinished.connect(
+                lambda _item=item, roi_id=overlay.roi_id, region_part=part: (
+                    self._analysis_region_move_finished(roi_id, region_part)
+                )
+            )
+            return item
 
         def _peak_scatter_clicked(self, _scatter, points) -> None:
-            if self.selection_bus is None or not points:
+            if not points:
                 return
             peak_id = points[0].data()
             if peak_id is None:
                 return
-            peak = self._peak_candidates_by_id.get(str(peak_id))
+            peak_id = str(peak_id)
+            overlay = self._peak_overlays_by_id.get(peak_id)
+            if overlay is not None:
+                self._selected_peak_id = peak_id
+                self._emit_for_spectrum(
+                    CanvasIntentKind.SELECT_PEAK,
+                    spectrum_id=overlay.spectrum_id,
+                    peak_id=peak_id,
+                )
+                self._render_peak_overlays(
+                    tuple(
+                        CanvasPeakOverlay(
+                            peak_id=item.peak_id,
+                            spectrum_id=item.spectrum_id,
+                            position=item.position,
+                            y_value=item.y_value,
+                            component_ids=item.component_ids,
+                            nuclide=item.nuclide,
+                            tags=item.tags,
+                            pinned=item.pinned,
+                            selected=item.peak_id == peak_id,
+                        )
+                        for item in self._peak_overlays_by_id.values()
+                    )
+                )
+            if self.selection_bus is None:
+                return
+            peak = self._peak_candidates_by_id.get(peak_id)
             if peak is None:
                 return
             self.selection_bus.publish(
                 SelectionState(
+                    spectrum_id=(
+                        overlay.spectrum_id
+                        if overlay is not None
+                        else self._interaction_spectrum_id
+                    ),
+                    peak_id=peak_id,
+                    roi_id=self.selection_bus.state.roi_id,
                     peak_energy_keV=float(peak.energy_keV),
                     roi_bounds_keV=peak.roi_bounds_keV,
                     nuclide=peak.nuclide,
                     reference_lines_keV=peak.reference_lines_keV,
                 )
+            )
+
+        def _selected_peak_move_finished(self) -> None:
+            if self._syncing_peak_line or self._selected_peak_id is None:
+                return
+            overlay = self._peak_overlays_by_id.get(self._selected_peak_id)
+            if overlay is None:
+                return
+            self._emit_for_spectrum(
+                CanvasIntentKind.MOVE_PEAK,
+                spectrum_id=overlay.spectrum_id,
+                peak_id=overlay.peak_id,
+                position=float(self._selected_peak_line.value()),
+                drag_token=f"peak-{uuid4().hex}",
+            )
+
+        def _analysis_region_move_finished(self, roi_id: str, part: str) -> None:
+            if self._syncing_analysis_overlays:
+                return
+            bundle = self._roi_items_by_id.get(roi_id)
+            if bundle is None:
+                return
+            signal = self._ordered_region(bundle.signal.getRegion())
+            left = self._ordered_region(bundle.left_background.getRegion())
+            right = self._ordered_region(bundle.right_background.getRegion())
+            if part == "signal":
+                self._emit_for_spectrum(
+                    CanvasIntentKind.MOVE_ROI,
+                    spectrum_id=bundle.overlay.spectrum_id,
+                    roi_id=roi_id,
+                    bounds=signal,
+                    left_background=left,
+                    right_background=right,
+                    drag_token=f"roi-{uuid4().hex}",
+                )
+            else:
+                self._emit_for_spectrum(
+                    CanvasIntentKind.MOVE_BACKGROUND,
+                    spectrum_id=bundle.overlay.spectrum_id,
+                    roi_id=roi_id,
+                    left_background=left,
+                    right_background=right,
+                    drag_token=f"roi-background-{uuid4().hex}",
+                )
+
+        @staticmethod
+        def _ordered_region(values) -> tuple[float, float]:
+            lower, upper = sorted((float(values[0]), float(values[1])))
+            return lower, upper
+
+        def _emit_for_spectrum(
+            self,
+            kind: CanvasIntentKind,
+            *,
+            spectrum_id: str | None = None,
+            **values,
+        ) -> None:
+            target = spectrum_id or self._interaction_spectrum_id
+            if target is None and kind not in {
+                CanvasIntentKind.PIN_NUCLIDE,
+                CanvasIntentKind.UNPIN_NUCLIDE,
+                CanvasIntentKind.TAG_NUCLIDE,
+            }:
+                return
+            self._emit_canvas_intent(
+                CanvasIntent(kind=kind, spectrum_id=target, **values)
+            )
+
+        def eventFilter(self, watched, event):  # noqa: N802 - Qt API
+            if watched is self.plot.viewport():
+                event_type = event.type()
+                if event_type == QEvent.MouseButtonPress:
+                    if (
+                        event.button() == pg.QtCore.Qt.LeftButton
+                        and event.modifiers() & pg.QtCore.Qt.ShiftModifier
+                        and self._interaction_spectrum_id is not None
+                    ):
+                        self._begin_shift_roi_drag(self._event_data_x(event))
+                        event.accept()
+                        return True
+                elif event_type == QEvent.MouseMove:
+                    if self._shift_drag_active:
+                        self._update_shift_roi_drag(self._event_data_x(event))
+                        event.accept()
+                        return True
+                    if self._crosshair_enabled:
+                        self._move_crosshair(self._event_scene_position(event))
+                elif event_type == QEvent.MouseButtonRelease:
+                    if self._shift_drag_active:
+                        self._finish_shift_roi_drag(self._event_data_x(event))
+                        event.accept()
+                        return True
+                    if event.button() == pg.QtCore.Qt.RightButton:
+                        self._prepare_context_menu(self._event_data_x(event))
+                        position = (
+                            event.position().toPoint()
+                            if hasattr(event, "position")
+                            else event.pos()
+                        )
+                        self.context_menu.popup(
+                            self.plot.viewport().mapToGlobal(position)
+                        )
+                        event.accept()
+                        return True
+                elif event_type == QEvent.ContextMenu:
+                    x_position = self._event_data_x(event)
+                    self._prepare_context_menu(x_position)
+                    self.context_menu.popup(event.globalPos())
+                    event.accept()
+                    return True
+            return super().eventFilter(watched, event)
+
+        def _event_data_x(self, event) -> float:
+            scene_position = self._event_scene_position(event)
+            data_position = self.plot_item.getViewBox().mapSceneToView(scene_position)
+            return float(data_position.x())
+
+        def _event_scene_position(self, event):
+            position = (
+                event.position().toPoint()
+                if hasattr(event, "position")
+                else event.pos()
+            )
+            return self.plot.mapToScene(position)
+
+        def _begin_shift_roi_drag(self, x_position: float) -> None:
+            self._shift_drag_active = True
+            self._shift_drag_start = float(x_position)
+            self._shift_drag_preview = pg.LinearRegionItem(
+                values=(float(x_position), float(x_position)),
+                orientation="vertical",
+                movable=False,
+                brush=pg.mkBrush(45, 212, 191, 72),
+                pen=pg.mkPen(color="#5eead4", width=2.0),
+            )
+            self._shift_drag_preview.setZValue(40)
+            self.plot_item.addItem(self._shift_drag_preview)
+
+        def _update_shift_roi_drag(self, x_position: float) -> None:
+            if self._shift_drag_start is None or self._shift_drag_preview is None:
+                return
+            self._shift_drag_preview.setRegion(
+                sorted((float(self._shift_drag_start), float(x_position)))
+            )
+
+        def _finish_shift_roi_drag(self, x_position: float) -> None:
+            start = self._shift_drag_start
+            preview = self._shift_drag_preview
+            self._shift_drag_active = False
+            self._shift_drag_start = None
+            self._shift_drag_preview = None
+            if preview is not None:
+                self.plot_item.removeItem(preview)
+            if start is None:
+                return
+            lower, upper = sorted((float(start), float(x_position)))
+            minimum_width = max(
+                abs(
+                    float(self.plot_item.viewRange()[0][1])
+                    - float(self.plot_item.viewRange()[0][0])
+                )
+                / max(float(self.plot.viewport().width()), 1.0),
+                1.0e-9,
+            )
+            if upper - lower < minimum_width:
+                return
+            sideband_width = upper - lower
+            self._emit_for_spectrum(
+                CanvasIntentKind.CREATE_ROI,
+                bounds=(lower, upper),
+                left_background=(lower - sideband_width, lower),
+                right_background=(upper, upper + sideband_width),
+                drag_token=f"roi-create-{uuid4().hex}",
+            )
+
+        def _build_context_menu(self) -> None:
+            self.context_menu = QMenu("Spectrum tools", self)
+            self.context_menu.setObjectName("SpectrumContextMenu")
+            self.context_menu.menuAction().setObjectName(
+                "OpenSpectrumContextMenuAction"
+            )
+            self.add_peak_action = self._menu_action(
+                "Add Peak Here", "CanvasContextAddPeakAction", self._context_add_peak
+            )
+            self.select_peak_action = self._menu_action(
+                "Select Peak",
+                "CanvasContextSelectPeakAction",
+                self._context_select_peak,
+            )
+            self.move_peak_action = self._menu_action(
+                "Move Peak Here", "CanvasContextMovePeakAction", self._context_move_peak
+            )
+            self.delete_peak_action = self._menu_action(
+                "Delete Peak",
+                "CanvasContextDeletePeakAction",
+                self._context_delete_peak,
+            )
+            self.context_menu.addSeparator()
+            self.assign_nuclide_action = self._menu_action(
+                "Assign Nuclide...",
+                "CanvasContextAssignNuclideAction",
+                self._context_assign_nuclide,
+            )
+            self.clear_nuclide_action = self._menu_action(
+                "Clear Nuclide",
+                "CanvasContextClearNuclideAction",
+                self._context_clear_nuclide,
+            )
+            self.pin_nuclide_action = self._menu_action(
+                "Pin Nuclide",
+                "CanvasContextPinNuclideAction",
+                self._context_pin_nuclide,
+            )
+            self.unpin_nuclide_action = self._menu_action(
+                "Unpin Nuclide",
+                "CanvasContextUnpinNuclideAction",
+                self._context_unpin_nuclide,
+            )
+            self.tag_peak_action = self._menu_action(
+                "Tag Peak...", "CanvasContextTagPeakAction", self._context_tag_peak
+            )
+            self.tag_nuclide_action = self._menu_action(
+                "Tag Nuclide...",
+                "CanvasContextTagNuclideAction",
+                self._context_tag_nuclide,
+            )
+            self.context_menu.addSeparator()
+            self.add_component_action = self._menu_action(
+                "Add Overlap Component Here",
+                "CanvasContextAddComponentAction",
+                self._context_add_component,
+            )
+            self.split_peak_action = self._menu_action(
+                "Split Peak Here",
+                "CanvasContextSplitPeakAction",
+                self._context_split_peak,
+            )
+            self.merge_peaks_action = self._menu_action(
+                "Merge Components",
+                "CanvasContextMergePeaksAction",
+                self._context_merge_components,
+            )
+            self.context_menu.addSeparator()
+            self.select_roi_action = self._menu_action(
+                "Select ROI", "CanvasContextSelectRoiAction", self._context_select_roi
+            )
+            self.delete_roi_action = self._menu_action(
+                "Delete ROI", "CanvasContextDeleteRoiAction", self._context_delete_roi
+            )
+            self.create_roi_action = self._menu_action(
+                "Create ROI Around Cursor",
+                "CanvasContextCreateRoiAction",
+                self._context_create_roi,
+            )
+            self.context_menu.addSeparator()
+            roles_menu = self.context_menu.addMenu("Assign Spectrum Role")
+            roles_menu.setObjectName("CanvasContextSpectrumRoleMenu")
+            roles_menu.menuAction().setObjectName(
+                "OpenCanvasContextSpectrumRoleMenuAction"
+            )
+            for label, role, object_name in (
+                ("Foreground", "foreground", "CanvasContextForegroundRoleAction"),
+                ("Background", "background", "CanvasContextBackgroundRoleAction"),
+                (
+                    "Secondary",
+                    "secondary",
+                    "CanvasContextSecondaryRoleAction",
+                ),
+            ):
+                action = QAction(label, roles_menu)
+                action.setObjectName(object_name)
+                action.triggered.connect(
+                    lambda _checked=False, value=role: self._context_assign_role(value)
+                )
+                roles_menu.addAction(action)
+            self.context_menu.addSeparator()
+            self.reset_context_action = self._menu_action(
+                "Reset View", "CanvasContextResetViewAction", self.reset_view
+            )
+            self.crosshair_action = self._menu_action(
+                "Crosshair",
+                "CanvasContextCrosshairAction",
+                self._context_crosshair_toggled,
+                checkable=True,
+            )
+            export_action = next(
+                (
+                    action
+                    for action in self.plot.scene().findChildren(QAction)
+                    if action.objectName() == "ExportSpectrumPlotAction"
+                ),
+                None,
+            )
+            if export_action is not None:
+                self.context_menu.addAction(export_action)
+
+        def _menu_action(
+            self,
+            text: str,
+            object_name: str,
+            callback,
+            *,
+            checkable: bool = False,
+        ) -> QAction:
+            action = QAction(text, self.context_menu)
+            action.setObjectName(object_name)
+            action.setCheckable(checkable)
+            if checkable:
+                action.toggled.connect(callback)
+            else:
+                action.triggered.connect(callback)
+            self.context_menu.addAction(action)
+            return action
+
+        def _prepare_context_menu(self, x_position: float) -> None:
+            self._context_position = float(x_position)
+            # PyQtGraph's export action normally receives this target from its
+            # own scene menu. FluxForge hosts the action in a stable-ID menu,
+            # so provide the same target explicitly before it can be invoked.
+            self.plot.scene().contextMenuItem = self.plot_item
+            x_range = self.plot_item.viewRange()[0]
+            tolerance = (
+                abs(float(x_range[1]) - float(x_range[0]))
+                * 14.0
+                / max(float(self.plot.viewport().width()), 1.0)
+            )
+            selected_peak = self._peak_overlays_by_id.get(
+                str(self._selected_peak_id or "")
+            )
+            nearest_peak = min(
+                self._peak_overlays_by_id.values(),
+                key=lambda item: abs(float(item.position) - self._context_position),
+                default=None,
+            )
+            if selected_peak is not None and (
+                abs(float(selected_peak.position) - self._context_position) <= tolerance
+            ):
+                self._context_peak_id = selected_peak.peak_id
+            elif nearest_peak is not None and (
+                abs(float(nearest_peak.position) - self._context_position) <= tolerance
+            ):
+                self._context_peak_id = nearest_peak.peak_id
+            else:
+                self._context_peak_id = self._selected_peak_id
+            containing_rois = [
+                bundle.overlay
+                for bundle in self._roi_items_by_id.values()
+                if any(
+                    bounds[0] <= self._context_position <= bounds[1]
+                    for bounds in (
+                        bundle.overlay.signal_range,
+                        bundle.overlay.left_background_range,
+                        bundle.overlay.right_background_range,
+                    )
+                )
+            ]
+            selected_roi = self._context_roi_overlay_for_id(self._selected_roi_id)
+            selected_contains_cursor = selected_roi is not None and any(
+                bounds[0] <= self._context_position <= bounds[1]
+                for bounds in (
+                    selected_roi.signal_range,
+                    selected_roi.left_background_range,
+                    selected_roi.right_background_range,
+                )
+            )
+            self._context_roi_id = (
+                selected_roi.roi_id
+                if selected_contains_cursor
+                else (containing_rois[0].roi_id if containing_rois else None)
+            )
+            peak = self._context_peak_overlay()
+            has_peak = peak is not None
+            for action in (
+                self.select_peak_action,
+                self.move_peak_action,
+                self.delete_peak_action,
+                self.assign_nuclide_action,
+                self.clear_nuclide_action,
+                self.tag_peak_action,
+                self.add_component_action,
+                self.split_peak_action,
+            ):
+                action.setEnabled(has_peak)
+            self.pin_nuclide_action.setEnabled(
+                bool(peak and peak.nuclide and not peak.pinned)
+            )
+            self.unpin_nuclide_action.setEnabled(
+                bool(peak and peak.nuclide and peak.pinned)
+            )
+            self.tag_nuclide_action.setEnabled(bool(peak and peak.nuclide))
+            self.tag_nuclide_action.setText(
+                "Tag Nuclide..."
+                if not peak or not peak.nuclide_tags
+                else "Tag Nuclide... [" + ", ".join(peak.nuclide_tags) + "]"
+            )
+            self.merge_peaks_action.setEnabled(
+                bool(peak and len(peak.component_ids) >= 2)
+            )
+            self.select_roi_action.setEnabled(self._context_roi_id is not None)
+            self.delete_roi_action.setEnabled(self._context_roi_id is not None)
+
+        def _context_peak_overlay(self) -> CanvasPeakOverlay | None:
+            if self._context_peak_id is None:
+                return None
+            return self._peak_overlays_by_id.get(self._context_peak_id)
+
+        def _context_roi_overlay(self) -> CanvasROIOverlay | None:
+            return self._context_roi_overlay_for_id(self._context_roi_id)
+
+        def _context_roi_overlay_for_id(
+            self, roi_id: str | None
+        ) -> CanvasROIOverlay | None:
+            if roi_id is None:
+                return None
+            bundle = self._roi_items_by_id.get(roi_id)
+            return bundle.overlay if bundle is not None else None
+
+        def _context_add_peak(self) -> None:
+            self._emit_for_spectrum(
+                CanvasIntentKind.ADD_PEAK, position=self._context_position
+            )
+
+        def _context_select_peak(self) -> None:
+            peak = self._context_peak_overlay()
+            if peak is not None:
+                self._emit_for_spectrum(
+                    CanvasIntentKind.SELECT_PEAK,
+                    spectrum_id=peak.spectrum_id,
+                    peak_id=peak.peak_id,
+                )
+
+        def _context_move_peak(self) -> None:
+            peak = self._context_peak_overlay()
+            if peak is not None:
+                self._emit_for_spectrum(
+                    CanvasIntentKind.MOVE_PEAK,
+                    spectrum_id=peak.spectrum_id,
+                    peak_id=peak.peak_id,
+                    position=self._context_position,
+                    drag_token=f"peak-menu-{uuid4().hex}",
+                )
+
+        def _context_delete_peak(self) -> None:
+            peak = self._context_peak_overlay()
+            if peak is not None:
+                self._emit_for_spectrum(
+                    CanvasIntentKind.DELETE_PEAK,
+                    spectrum_id=peak.spectrum_id,
+                    peak_id=peak.peak_id,
+                )
+
+        def _context_assign_nuclide(self) -> None:
+            peak = self._context_peak_overlay()
+            if peak is None:
+                return
+            nuclide, accepted = QInputDialog.getText(self, "Assign nuclide", "Nuclide:")
+            if accepted and str(nuclide).strip():
+                self._emit_for_spectrum(
+                    CanvasIntentKind.ASSIGN_NUCLIDE,
+                    spectrum_id=peak.spectrum_id,
+                    peak_id=peak.peak_id,
+                    nuclide=str(nuclide).strip(),
+                )
+
+        def _context_clear_nuclide(self) -> None:
+            peak = self._context_peak_overlay()
+            if peak is not None:
+                self._emit_for_spectrum(
+                    CanvasIntentKind.CLEAR_NUCLIDE,
+                    spectrum_id=peak.spectrum_id,
+                    peak_id=peak.peak_id,
+                )
+
+        def _context_pin_nuclide(self) -> None:
+            self._context_pin_state(True)
+
+        def _context_unpin_nuclide(self) -> None:
+            self._context_pin_state(False)
+
+        def _context_pin_state(self, pinned: bool) -> None:
+            peak = self._context_peak_overlay()
+            if peak is not None and peak.nuclide:
+                self._emit_for_spectrum(
+                    (
+                        CanvasIntentKind.PIN_NUCLIDE
+                        if pinned
+                        else CanvasIntentKind.UNPIN_NUCLIDE
+                    ),
+                    spectrum_id=peak.spectrum_id,
+                    nuclide=peak.nuclide,
+                )
+
+        def _context_tag_peak(self) -> None:
+            peak = self._context_peak_overlay()
+            if peak is None:
+                return
+            tag, accepted = QInputDialog.getText(self, "Tag peak", "Tag:")
+            if accepted and str(tag).strip():
+                self._emit_for_spectrum(
+                    CanvasIntentKind.TAG_PEAK,
+                    spectrum_id=peak.spectrum_id,
+                    peak_id=peak.peak_id,
+                    tag=str(tag).strip(),
+                )
+
+        def _context_tag_nuclide(self) -> None:
+            peak = self._context_peak_overlay()
+            if peak is None or not peak.nuclide:
+                return
+            tag, accepted = QInputDialog.getText(
+                self,
+                "Tag nuclide",
+                f"Tag for {peak.nuclide}:",
+            )
+            if accepted and str(tag).strip():
+                self._emit_for_spectrum(
+                    CanvasIntentKind.TAG_NUCLIDE,
+                    spectrum_id=peak.spectrum_id,
+                    nuclide=peak.nuclide,
+                    tag=str(tag).strip(),
+                )
+
+        def _context_add_component(self) -> None:
+            peak = self._context_peak_overlay()
+            if peak is not None:
+                self._emit_for_spectrum(
+                    CanvasIntentKind.ADD_COMPONENT,
+                    spectrum_id=peak.spectrum_id,
+                    peak_id=peak.peak_id,
+                    position=self._context_position,
+                )
+
+        def _context_split_peak(self) -> None:
+            peak = self._context_peak_overlay()
+            if peak is not None:
+                self._emit_for_spectrum(
+                    CanvasIntentKind.SPLIT_PEAK,
+                    spectrum_id=peak.spectrum_id,
+                    peak_id=peak.peak_id,
+                    position=self._context_position,
+                    component_ids=peak.component_ids,
+                )
+
+        def _context_merge_components(self) -> None:
+            peak = self._context_peak_overlay()
+            if peak is not None and len(peak.component_ids) >= 2:
+                self._emit_for_spectrum(
+                    CanvasIntentKind.MERGE_PEAKS,
+                    spectrum_id=peak.spectrum_id,
+                    peak_id=peak.peak_id,
+                    component_ids=peak.component_ids,
+                )
+
+        def _context_select_roi(self) -> None:
+            roi = self._context_roi_overlay()
+            if roi is not None:
+                self._emit_for_spectrum(
+                    CanvasIntentKind.SELECT_ROI,
+                    spectrum_id=roi.spectrum_id,
+                    roi_id=roi.roi_id,
+                )
+
+        def _context_delete_roi(self) -> None:
+            roi = self._context_roi_overlay()
+            if roi is not None:
+                self._emit_for_spectrum(
+                    CanvasIntentKind.DELETE_ROI,
+                    spectrum_id=roi.spectrum_id,
+                    roi_id=roi.roi_id,
+                )
+
+        def _context_create_roi(self) -> None:
+            view_range = self.plot_item.viewRange()[0]
+            width = max(abs(float(view_range[1]) - float(view_range[0])) * 0.04, 1.0e-6)
+            lower = self._context_position - width
+            upper = self._context_position + width
+            self._emit_for_spectrum(
+                CanvasIntentKind.CREATE_ROI,
+                bounds=(lower, upper),
+                left_background=(lower - 2.0 * width, lower),
+                right_background=(upper, upper + 2.0 * width),
+                drag_token=f"roi-menu-{uuid4().hex}",
+            )
+
+        def _context_assign_role(self, role: str) -> None:
+            self._emit_for_spectrum(CanvasIntentKind.ASSIGN_SPECTRUM_ROLE, role=role)
+
+        def _context_crosshair_toggled(self, enabled: bool) -> None:
+            self.set_crosshair_enabled(bool(enabled))
+            self._emit_for_spectrum(
+                CanvasIntentKind.TOGGLE_CROSSHAIR, enabled=bool(enabled)
             )
 
         def set_peak_residuals(
@@ -491,6 +1348,21 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
                 self._crosshair_horizontal.setPos((y_range[0] + y_range[1]) / 2.0)
             self._crosshair_vertical.setVisible(self._crosshair_enabled)
             self._crosshair_horizontal.setVisible(self._crosshair_enabled)
+            self.crosshair_readout.setVisible(self._crosshair_enabled)
+            self.crosshair_button.blockSignals(True)
+            self.crosshair_button.setChecked(self._crosshair_enabled)
+            self.crosshair_button.blockSignals(False)
+            if hasattr(self, "crosshair_action"):
+                self.crosshair_action.blockSignals(True)
+                self.crosshair_action.setChecked(self._crosshair_enabled)
+                self.crosshair_action.blockSignals(False)
+
+        def _crosshair_button_toggled(self, enabled: bool) -> None:
+            self.set_crosshair_enabled(enabled)
+            self._emit_for_spectrum(
+                CanvasIntentKind.TOGGLE_CROSSHAIR,
+                enabled=bool(enabled),
+            )
 
         def _move_crosshair(self, scene_position) -> None:
             if not self._crosshair_enabled:
@@ -500,8 +1372,15 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
             data_position = self.plot_item.getViewBox().mapSceneToView(scene_position)
             self._crosshair_vertical.setPos(float(data_position.x()))
             self._crosshair_horizontal.setPos(float(data_position.y()))
+            self.crosshair_readout.setText(
+                f"x {float(data_position.x()):.3f} | y {float(data_position.y()):.3f}"
+            )
 
         def clear(self) -> None:
+            self._replace_roi_items(())
+            self._peak_overlays_by_id = {}
+            self._selected_roi_id = None
+            self._selected_peak_id = None
             self.buffer = HierarchicalSpectrumBuffer.from_counts(())
             self._current_traces = ()
             self._annotation_specs = ()
@@ -514,17 +1393,66 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
             self._roi_region.setVisible(False)
             self.roi_button.setChecked(False)
 
+        def show_interaction_error(self, message: str) -> None:
+            """Surface a rejected edit next to the canvas without a modal dialog."""
+
+            detail = " ".join(str(message).split())
+            self.status_label.setText(f"Edit rejected: {detail}")
+            self.status_label.setToolTip(detail)
+
+        def reset_persisted_viewport_state(self) -> None:
+            """Restore default view controls after undo removes the viewport leaf."""
+
+            self._viewport_commit_timer.stop()
+            self.set_log_scale(False)
+            self.set_peak_labels_visible(True)
+            self.set_crosshair_enabled(False)
+            self.plot_item.enableAutoRange(x=True, y=True)
+            self.plot_item.autoRange()
+
         def reset_view(self) -> None:
             """Fit all visible traces while retaining mouse pan and wheel zoom."""
 
             self.plot_item.enableAutoRange(x=True, y=True)
             self.plot_item.autoRange()
+            self._schedule_viewport_commit()
+
+        def zoom_to_range(
+            self,
+            lower: float,
+            upper: float,
+            *,
+            padding_fraction: float = 0.12,
+        ) -> None:
+            lower = float(lower)
+            upper = float(upper)
+            if not np.isfinite(lower) or not np.isfinite(upper) or lower >= upper:
+                raise ValueError("zoom range must be finite and increasing")
+            if not np.isfinite(padding_fraction) or padding_fraction < 0.0:
+                raise ValueError("padding_fraction must be finite and non-negative")
+            padding = (upper - lower) * float(padding_fraction)
+            self.plot_item.disableAutoRange()
+            self.plot_item.setXRange(lower - padding, upper + padding, padding=0.0)
 
         def _zoom_view(self, factor: float) -> None:
             """Apply a centered zoom while keeping free mouse pan/zoom enabled."""
 
             self.plot_item.disableAutoRange()
             self.plot_item.getViewBox().scaleBy((float(factor), float(factor)))
+            self._schedule_viewport_commit()
+
+        def _schedule_viewport_commit(self) -> None:
+            if self._interaction_spectrum_id is not None:
+                self._viewport_commit_timer.start()
+
+        def _commit_viewport_intent(self) -> None:
+            x_range, y_range = self.plot_item.viewRange()
+            self._emit_for_spectrum(
+                CanvasIntentKind.CHANGE_VIEWPORT,
+                viewport_id="primary-spectrum",
+                x_range=(float(x_range[0]), float(x_range[1])),
+                y_range=(float(y_range[0]), float(y_range[1])),
+            )
 
         def _set_roi_visible(self, visible: bool) -> None:
             bounds = (
@@ -598,7 +1526,10 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
                     name
                     for name, enabled in (
                         ("peak-labels", self._peak_labels_visible),
-                        ("roi", self._roi_region.isVisible()),
+                        (
+                            "roi",
+                            self._roi_region.isVisible() or bool(self._roi_items_by_id),
+                        ),
                     )
                     if enabled
                 ),
@@ -661,7 +1592,8 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
                 fragments.append(state.nuclide)
             if state.roi_bounds_keV:
                 fragments.append(
-                    f"ROI {state.roi_bounds_keV[0]:.1f}-{state.roi_bounds_keV[1]:.1f} keV"
+                    f"ROI {state.roi_bounds_keV[0]:.1f}-"
+                    f"{state.roi_bounds_keV[1]:.1f} keV"
                 )
             if state.annotation_lines:
                 fragments.append(f"{len(state.annotation_lines)} guides")
@@ -688,6 +1620,11 @@ if PYQTGRAPH_AVAILABLE:  # pragma: no cover - optional dependency branch
             return max_value if max_value > 0.0 else 1.0
 
 else:
+
+    def catalog_pyqtgraph_export_action(plot_widget, object_name: str) -> None:
+        """No-op unless the PyQtGraph backend is available."""
+
+        del plot_widget, object_name
 
     class PyQtGraphSpectrumCanvas(
         SpectrumCanvas

--- a/src/fluxforge/gui/canvas_controller.py
+++ b/src/fluxforge/gui/canvas_controller.py
@@ -1,0 +1,858 @@
+"""Translate renderer-neutral canvas intents into focused workspace edits."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from math import sqrt
+from typing import Callable
+from uuid import uuid4
+
+import numpy as np
+
+from fluxforge.core.analysis_workspace import compute_cascade_sum_lines
+from fluxforge.core.workspace_document import (
+    AnalysisROI,
+    CanvasViewport,
+    NuclideAssignment,
+    PeakComponent,
+    PeakModel,
+)
+from fluxforge.gui.analysis_workspace import AnalysisWorkspaceController
+from fluxforge.gui.canvas_intents import CanvasIntent, CanvasIntentKind
+from fluxforge.gui.selection_bus import SelectionBus, SelectionState
+from fluxforge.gui.workspace_undo import (
+    AssignSpectrumRoleCommand,
+    DeletePeakCommand,
+    DeleteROICommand,
+    MoveROIBoundsCommand,
+    TogglePinnedNuclideCommand,
+    UpdateCanvasViewportCommand,
+    UpdateNuclideTagsCommand,
+    UpdatePeakCommand,
+    UpdateWorkflowStateCommand,
+    UpsertROICommand,
+)
+
+
+class CanvasIntentDispatcher:
+    """Apply validated canvas events without placing analysis logic in widgets."""
+
+    def __init__(
+        self,
+        workspace_controller: AnalysisWorkspaceController,
+        selection_bus: SelectionBus,
+        *,
+        undo_stack=None,
+        id_factory: Callable[[str], str] | None = None,
+    ) -> None:
+        self.workspace_controller = workspace_controller
+        self.selection_bus = selection_bus
+        self.undo_stack = undo_stack
+        self.id_factory = id_factory or (lambda prefix: f"{prefix}-{uuid4().hex[:12]}")
+
+    def handle(self, intent: CanvasIntent) -> None:
+        """Validate and apply one complete user intent."""
+
+        intent.validate()
+        handlers = {
+            CanvasIntentKind.CREATE_ROI: self._create_roi,
+            CanvasIntentKind.SELECT_ROI: self._select_roi,
+            CanvasIntentKind.DELETE_ROI: self._delete_roi,
+            CanvasIntentKind.MOVE_ROI: self._move_roi,
+            CanvasIntentKind.MOVE_BACKGROUND: self._move_background,
+            CanvasIntentKind.ADD_PEAK: self._add_peak,
+            CanvasIntentKind.SELECT_PEAK: self._select_peak,
+            CanvasIntentKind.MOVE_PEAK: self._move_peak,
+            CanvasIntentKind.DELETE_PEAK: self._delete_peak,
+            CanvasIntentKind.ADD_COMPONENT: self._add_component,
+            CanvasIntentKind.SPLIT_PEAK: self._split_peak,
+            CanvasIntentKind.MERGE_PEAKS: self._merge_components,
+            CanvasIntentKind.ASSIGN_NUCLIDE: self._assign_nuclide,
+            CanvasIntentKind.CLEAR_NUCLIDE: self._clear_nuclide,
+            CanvasIntentKind.PIN_NUCLIDE: self._pin_nuclide,
+            CanvasIntentKind.UNPIN_NUCLIDE: self._unpin_nuclide,
+            CanvasIntentKind.TAG_NUCLIDE: self._tag_nuclide,
+            CanvasIntentKind.TAG_PEAK: self._tag_peak,
+            CanvasIntentKind.ASSIGN_SPECTRUM_ROLE: self._assign_role,
+            CanvasIntentKind.CHANGE_VIEWPORT: self._change_viewport,
+            CanvasIntentKind.TOGGLE_CROSSHAIR: self._toggle_crosshair,
+            CanvasIntentKind.SET_LOG_SCALE: self._set_log_scale,
+            CanvasIntentKind.SET_LABELS_VISIBLE: self._set_labels_visible,
+        }
+        handler = handlers.get(intent.kind)
+        if handler is None:
+            raise ValueError(
+                f"Unsupported production canvas intent: {intent.kind.value}"
+            )
+        handler(intent)
+
+    def _push(self, command) -> None:
+        if self.undo_stack is None:
+            command.redo()
+        else:
+            self.undo_stack.push(command)
+
+    def _push_macro(self, description: str, commands: tuple[object, ...]) -> None:
+        if self.undo_stack is None:
+            for command in commands:
+                command.redo()
+            return
+        self.undo_stack.beginMacro(description)
+        try:
+            for command in commands:
+                self.undo_stack.push(command)
+        finally:
+            self.undo_stack.endMacro()
+
+    def _invalidation_command(self, reason: str) -> UpdateWorkflowStateCommand:
+        before = self.workspace_controller.document.workflow_state
+        after = dict(before)
+        legacy = dict(after.get("analysis_workspace_v1", {}))
+        legacy.update(
+            {
+                "activity_results": [],
+                "roi_analysis": None,
+                "roi_statistics": None,
+            }
+        )
+        after["analysis_workspace_v1"] = legacy
+        after["analysis_invalidation"] = {
+            "reason": reason,
+            "requires_reanalysis": True,
+        }
+        return UpdateWorkflowStateCommand(
+            self.workspace_controller,
+            before=before,
+            after=after,
+            description="Invalidate derived analysis",
+        )
+
+    def _push_scientific(self, command, description: str) -> None:
+        self._push_macro(
+            description,
+            (command, self._invalidation_command(description)),
+        )
+
+    def _cascade_workflow_command(
+        self, pinned_nuclides: tuple[str, ...]
+    ) -> UpdateWorkflowStateCommand:
+        before = self.workspace_controller.document.workflow_state
+        after = dict(before)
+        legacy = dict(after.get("analysis_workspace_v1", {}))
+        legacy["cascade_sum_lines_keV"] = list(
+            compute_cascade_sum_lines(pinned_nuclides)
+        )
+        after["analysis_workspace_v1"] = legacy
+        return UpdateWorkflowStateCommand(
+            self.workspace_controller,
+            before=before,
+            after=after,
+            description="Update cascade-sum overlays",
+        )
+
+    def _require_spectrum_id(self, intent: CanvasIntent) -> str:
+        spectrum_id = intent.spectrum_id
+        if (
+            not spectrum_id
+            or self.workspace_controller.document.spectrum_by_id(spectrum_id) is None
+        ):
+            raise KeyError(f"Unknown spectrum ID: {spectrum_id!r}")
+        return spectrum_id
+
+    def _require_roi(self, intent: CanvasIntent) -> AnalysisROI:
+        roi = self.workspace_controller.document.roi_by_id(str(intent.roi_id or ""))
+        if roi is None:
+            raise KeyError(f"Unknown ROI ID: {intent.roi_id!r}")
+        if intent.spectrum_id and roi.spectrum_id != intent.spectrum_id:
+            raise ValueError("ROI does not belong to the intent spectrum")
+        return roi
+
+    def _require_peak(self, intent: CanvasIntent) -> PeakModel:
+        spectrum_id = self._require_spectrum_id(intent)
+        peak = self.workspace_controller.document.peak_by_id(
+            spectrum_id, str(intent.peak_id or "")
+        )
+        if peak is None:
+            raise KeyError(f"Unknown peak ID: {intent.peak_id!r}")
+        return peak
+
+    @staticmethod
+    def _default_backgrounds(
+        bounds: tuple[float, float],
+    ) -> tuple[tuple[float, float], tuple[float, float]]:
+        lower, upper = bounds
+        width = max(upper - lower, 1.0e-6)
+        sideband_width = max(0.4 * width, 1.0e-3)
+        gap = max(0.08 * width, 1.0e-4)
+        return (
+            (lower - gap - sideband_width, lower - gap),
+            (upper + gap, upper + gap + sideband_width),
+        )
+
+    def _viewport_selection_command(
+        self, spectrum_id: str, roi_id: str | None
+    ) -> UpdateCanvasViewportCommand:
+        before = self.workspace_controller.document.viewport_by_id("primary-spectrum")
+        after = (
+            replace(before, spectrum_id=spectrum_id, selected_roi_id=roi_id)
+            if before is not None
+            else CanvasViewport(
+                viewport_id="primary-spectrum",
+                spectrum_id=spectrum_id,
+                selected_roi_id=roi_id,
+            )
+        )
+        return UpdateCanvasViewportCommand(
+            self.workspace_controller,
+            before=before,
+            after=after,
+            description="Select ROI",
+        )
+
+    def _publish_roi(self, roi: AnalysisROI) -> None:
+        self.selection_bus.publish(
+            SelectionState(
+                spectrum_id=roi.spectrum_id,
+                roi_id=roi.roi_id,
+                roi_bounds_keV=roi.signal_range,
+            )
+        )
+
+    def _publish_peak(self, peak: PeakModel) -> None:
+        roi = (
+            self.workspace_controller.document.roi_by_id(peak.roi_id)
+            if peak.roi_id
+            else None
+        )
+        candidate = self.workspace_controller._candidate_from_peak_model(peak)
+        self.selection_bus.publish(
+            SelectionState(
+                spectrum_id=peak.spectrum_id,
+                peak_id=peak.peak_id,
+                roi_id=peak.roi_id,
+                peak_energy_keV=peak.centroid_energy_keV,
+                roi_bounds_keV=(
+                    roi.signal_range if roi is not None else candidate.roi_bounds_keV
+                ),
+                nuclide=(peak.assignments[0].nuclide if peak.assignments else None),
+                reference_lines_keV=peak.reference_lines_keV,
+            )
+        )
+
+    def _create_roi(self, intent: CanvasIntent) -> None:
+        spectrum_id = self._require_spectrum_id(intent)
+        bounds = intent.bounds
+        assert bounds is not None
+        left, right = self._default_backgrounds(bounds)
+        associated_peaks = tuple(
+            peak
+            for peak in self.workspace_controller.document.peaks
+            if peak.spectrum_id == spectrum_id
+            and peak.roi_id is None
+            and bounds[0] <= peak.centroid_energy_keV <= bounds[1]
+        )
+        roi = AnalysisROI(
+            roi_id=self.id_factory("roi"),
+            spectrum_id=spectrum_id,
+            signal_range=bounds,
+            left_background_range=intent.left_background or left,
+            right_background_range=intent.right_background or right,
+            associated_peak_ids=tuple(peak.peak_id for peak in associated_peaks),
+            label="ROI",
+        )
+        roi.validate("roi")
+        commands: list[object] = [
+            UpsertROICommand(
+                self.workspace_controller,
+                before=None,
+                after=roi,
+                description="Create ROI",
+            )
+        ]
+        commands.extend(
+            UpdatePeakCommand(
+                self.workspace_controller,
+                before=peak,
+                after=self._invalidate_peak_fit(
+                    replace(peak, roi_id=roi.roi_id),
+                    "Create ROI",
+                ),
+                invalidate_diagnostics=True,
+                description="Associate peak with ROI",
+            )
+            for peak in associated_peaks
+        )
+        commands.extend(
+            (
+                self._viewport_selection_command(spectrum_id, roi.roi_id),
+                self._invalidation_command("Create ROI"),
+            )
+        )
+        self._push_macro(
+            "Create ROI",
+            tuple(commands),
+        )
+        self._publish_roi(roi)
+
+    def _select_roi(self, intent: CanvasIntent) -> None:
+        roi = self._require_roi(intent)
+        self._push(self._viewport_selection_command(roi.spectrum_id, roi.roi_id))
+        self._publish_roi(roi)
+
+    def _delete_roi(self, intent: CanvasIntent) -> None:
+        roi = self._require_roi(intent)
+        self._push_scientific(
+            DeleteROICommand(
+                self.workspace_controller,
+                roi=roi,
+                description="Delete ROI",
+            ),
+            "Delete ROI",
+        )
+        self.selection_bus.clear()
+
+    @staticmethod
+    def _backgrounds_for_signal(
+        roi: AnalysisROI, bounds: tuple[float, float]
+    ) -> tuple[tuple[float, float], tuple[float, float]]:
+        left_width = roi.left_background_range[1] - roi.left_background_range[0]
+        right_width = roi.right_background_range[1] - roi.right_background_range[0]
+        left_gap = max(roi.signal_range[0] - roi.left_background_range[1], 0.0)
+        right_gap = max(roi.right_background_range[0] - roi.signal_range[1], 0.0)
+        return (
+            (bounds[0] - left_gap - left_width, bounds[0] - left_gap),
+            (bounds[1] + right_gap, bounds[1] + right_gap + right_width),
+        )
+
+    def _move_roi(self, intent: CanvasIntent) -> None:
+        roi = self._require_roi(intent)
+        assert intent.bounds is not None
+        left, right = self._backgrounds_for_signal(roi, intent.bounds)
+        updated = replace(
+            roi,
+            signal_range=intent.bounds,
+            left_background_range=left,
+            right_background_range=right,
+            fit_revision=roi.fit_revision + 1,
+        )
+        self._push_scientific(
+            MoveROIBoundsCommand(
+                self.workspace_controller,
+                before=roi,
+                after=updated,
+                drag_token=intent.drag_token or self.id_factory("drag"),
+                description="Move ROI bounds",
+            ),
+            "Move ROI bounds",
+        )
+        self._publish_roi(updated)
+
+    def _move_background(self, intent: CanvasIntent) -> None:
+        roi = self._require_roi(intent)
+        updated = replace(
+            roi,
+            left_background_range=intent.left_background or roi.left_background_range,
+            right_background_range=intent.right_background
+            or roi.right_background_range,
+            fit_revision=roi.fit_revision + 1,
+        )
+        updated.validate("roi")
+        self._push_scientific(
+            MoveROIBoundsCommand(
+                self.workspace_controller,
+                before=roi,
+                after=updated,
+                drag_token=intent.drag_token or self.id_factory("drag"),
+                description="Move ROI background",
+            ),
+            "Move ROI background",
+        )
+        self._publish_roi(updated)
+
+    def _channel_and_energy(
+        self, spectrum_id: str, position: float
+    ) -> tuple[float, float]:
+        record = self.workspace_controller.document.spectrum_by_id(spectrum_id)
+        assert record is not None
+        spectrum = record.spectrum
+        if spectrum.energies is None or len(spectrum.energies) == 0:
+            channel = float(position)
+            return channel, channel
+        energies = np.asarray(spectrum.energies, dtype=float)
+        channels = np.asarray(spectrum.channels, dtype=float)
+        index = int(np.argmin(np.abs(energies - float(position))))
+        return float(channels[index]), float(position)
+
+    def _add_peak(self, intent: CanvasIntent) -> None:
+        spectrum_id = self._require_spectrum_id(intent)
+        assert intent.position is not None
+        channel, energy = self._channel_and_energy(spectrum_id, intent.position)
+        record = self.workspace_controller.document.spectrum_by_id(spectrum_id)
+        counts = np.asarray(record.spectrum.counts, dtype=float)
+        count_index = min(max(int(round(channel)), 0), max(len(counts) - 1, 0))
+        net_counts = float(counts[count_index]) if len(counts) else 0.0
+        containing_rois = tuple(
+            roi
+            for roi in self.workspace_controller.document.rois
+            if roi.spectrum_id == spectrum_id
+            and roi.signal_range[0] <= energy <= roi.signal_range[1]
+        )
+        selected_roi = self.workspace_controller.document.roi_by_id(
+            str(self.selection_bus.state.roi_id or "")
+        )
+        target_roi = (
+            selected_roi
+            if selected_roi in containing_rois
+            else (containing_rois[0] if containing_rois else None)
+        )
+        peak = PeakModel(
+            peak_id=self.id_factory("peak"),
+            spectrum_id=spectrum_id,
+            roi_id=target_roi.roi_id if target_roi is not None else None,
+            centroid_channel=channel,
+            centroid_energy_keV=energy,
+            status="manual",
+            manual_overrides={"roi_bounds_keV": [max(energy - 2.0, 0.0), energy + 2.0]},
+            provenance={"source": "canvas_manual_peak"},
+            net_counts=net_counts,
+        )
+        commands: list[object] = [
+            UpdatePeakCommand(
+                self.workspace_controller,
+                before=None,
+                after=peak,
+                description="Add manual peak",
+            )
+        ]
+        if target_roi is not None:
+            commands.append(
+                UpsertROICommand(
+                    self.workspace_controller,
+                    before=target_roi,
+                    after=replace(
+                        target_roi,
+                        associated_peak_ids=tuple(
+                            dict.fromkeys(
+                                (*target_roi.associated_peak_ids, peak.peak_id)
+                            )
+                        ),
+                    ),
+                    description="Associate peak with ROI",
+                )
+            )
+        commands.append(self._invalidation_command("Add manual peak"))
+        self._push_macro("Add manual peak", tuple(commands))
+        self.workspace_controller.select_peak(peak.peak_id)
+        self._publish_peak(peak)
+
+    def _select_peak(self, intent: CanvasIntent) -> None:
+        peak = self._require_peak(intent)
+        self.workspace_controller.select_peak(peak.peak_id)
+        self._publish_peak(peak)
+
+    def _move_peak(self, intent: CanvasIntent) -> None:
+        peak = self._require_peak(intent)
+        assert intent.position is not None
+        channel, energy = self._channel_and_energy(peak.spectrum_id, intent.position)
+        energy_delta = energy - peak.centroid_energy_keV
+        overrides = dict(peak.manual_overrides)
+        raw_bounds = overrides.get("roi_bounds_keV")
+        if isinstance(raw_bounds, (list, tuple)) and len(raw_bounds) == 2:
+            overrides["roi_bounds_keV"] = [
+                float(raw_bounds[0]) + energy_delta,
+                float(raw_bounds[1]) + energy_delta,
+            ]
+        components = tuple(
+            replace(item, centroid=item.centroid + energy_delta)
+            for item in peak.components
+        )
+        updated = self._invalidate_peak_fit(
+            replace(
+                peak,
+                centroid_channel=channel,
+                centroid_energy_keV=energy,
+                components=components,
+                manual_overrides=overrides,
+                status="manual",
+            ),
+            "Move peak centroid",
+        )
+        self._push_scientific(
+            UpdatePeakCommand(
+                self.workspace_controller,
+                before=peak,
+                after=updated,
+                invalidate_diagnostics=True,
+                description="Move peak centroid",
+            ),
+            "Move peak centroid",
+        )
+        self.workspace_controller.select_peak(updated.peak_id)
+        self._publish_peak(updated)
+
+    def _delete_peak(self, intent: CanvasIntent) -> None:
+        peak = self._require_peak(intent)
+        self._push_scientific(
+            DeletePeakCommand(
+                self.workspace_controller,
+                peak=peak,
+                description="Delete peak",
+            ),
+            "Delete peak",
+        )
+        self.workspace_controller.select_peak(None)
+        self.selection_bus.clear()
+
+    def _update_peak(
+        self,
+        before: PeakModel,
+        after: PeakModel,
+        description: str,
+        *,
+        invalidate: bool = True,
+        invalidate_fit: bool = False,
+    ) -> None:
+        if invalidate_fit:
+            after = self._invalidate_peak_fit(after, description)
+        command = UpdatePeakCommand(
+            self.workspace_controller,
+            before=before,
+            after=after,
+            invalidate_diagnostics=invalidate_fit,
+            description=description,
+        )
+        if invalidate:
+            self._push_scientific(command, description)
+        else:
+            self._push(command)
+        self.workspace_controller.select_peak(after.peak_id)
+        self._publish_peak(after)
+
+    @staticmethod
+    def _invalidate_peak_fit(peak: PeakModel, reason: str) -> PeakModel:
+        return replace(
+            peak,
+            status="invalidated",
+            fit_quality=0.0,
+            normalized_residuals=(),
+            residual_channels=(),
+            provenance={
+                **dict(peak.provenance),
+                "fit_invalidated_by": reason,
+            },
+        )
+
+    def _add_component(self, intent: CanvasIntent) -> None:
+        peak = self._require_peak(intent)
+        position = (
+            float(intent.position)
+            if intent.position is not None
+            else peak.centroid_energy_keV
+        )
+        component = PeakComponent(
+            component_id=self.id_factory("component"),
+            shape=peak.shape,
+            centroid=position,
+            area=max(peak.net_counts, 0.0),
+        )
+        self._update_peak(
+            peak,
+            replace(peak, components=(*peak.components, component), status="manual"),
+            "Add overlap component",
+            invalidate_fit=True,
+        )
+
+    def _split_peak(self, intent: CanvasIntent) -> None:
+        peak = self._require_peak(intent)
+        components = list(peak.components)
+        if components:
+            target_index = 0
+            if intent.component_ids:
+                requested = intent.component_ids[0]
+                target_index = next(
+                    (
+                        index
+                        for index, item in enumerate(components)
+                        if item.component_id == requested
+                    ),
+                    0,
+                )
+            target = components.pop(target_index)
+        else:
+            target_index = 0
+            target = PeakComponent(
+                component_id=self.id_factory("component"),
+                shape=peak.shape,
+                centroid=peak.centroid_energy_keV,
+                area=max(peak.net_counts, 0.0),
+            )
+        delta = max(target.fwhm * 0.25, 0.25)
+        children = (
+            replace(
+                target,
+                component_id=self.id_factory("component"),
+                centroid=target.centroid - delta,
+                area=target.area * 0.5,
+                amplitude=target.amplitude * 0.5,
+            ),
+            replace(
+                target,
+                component_id=self.id_factory("component"),
+                centroid=target.centroid + delta,
+                area=target.area * 0.5,
+                amplitude=target.amplitude * 0.5,
+            ),
+        )
+        components[target_index:target_index] = children
+        self._update_peak(
+            peak,
+            replace(peak, components=tuple(components), status="manual"),
+            "Split overlap component",
+            invalidate_fit=True,
+        )
+
+    def _merge_components(self, intent: CanvasIntent) -> None:
+        document = self.workspace_controller.document
+        peak = (
+            document.peak_by_id(str(intent.spectrum_id), str(intent.peak_id))
+            if intent.spectrum_id and intent.peak_id
+            else next(
+                (
+                    item
+                    for item in document.peaks
+                    if set(intent.component_ids).issubset(
+                        {component.component_id for component in item.components}
+                    )
+                ),
+                None,
+            )
+        )
+        if peak is None:
+            raise KeyError("No peak owns all requested overlap components")
+        selected = [
+            item
+            for item in peak.components
+            if item.component_id in intent.component_ids
+        ]
+        if len(selected) < 2:
+            raise ValueError("At least two existing components are required")
+        total_area = sum(item.area for item in selected)
+        centroid = (
+            sum(item.centroid * item.area for item in selected) / total_area
+            if total_area > 0.0
+            else sum(item.centroid for item in selected) / len(selected)
+        )
+        merged = PeakComponent(
+            component_id=self.id_factory("component"),
+            shape=selected[0].shape,
+            centroid=centroid,
+            area=total_area,
+            amplitude=max(item.amplitude for item in selected),
+            fwhm=max(item.fwhm for item in selected),
+            uncertainty=sqrt(sum(item.uncertainty**2 for item in selected)),
+            provenance={"merged_from": list(intent.component_ids)},
+        )
+        selected_ids = set(intent.component_ids)
+        first_index = min(
+            index
+            for index, item in enumerate(peak.components)
+            if item.component_id in selected_ids
+        )
+        remaining = [
+            item for item in peak.components if item.component_id not in selected_ids
+        ]
+        remaining.insert(first_index, merged)
+        self._update_peak(
+            peak,
+            replace(peak, components=tuple(remaining), status="manual"),
+            "Merge overlap components",
+            invalidate_fit=True,
+        )
+
+    def _assign_nuclide(self, intent: CanvasIntent) -> None:
+        peak = self._require_peak(intent)
+        assert intent.nuclide is not None
+        assignment = NuclideAssignment(
+            nuclide=intent.nuclide,
+            line_energy_keV=peak.centroid_energy_keV,
+            manual=True,
+            provenance={"source": "canvas_context_menu"},
+        )
+        updated = replace(
+            peak,
+            assignments=(assignment, *peak.assignments[1:]),
+            candidate_nuclides=tuple(
+                dict.fromkeys((intent.nuclide, *peak.candidate_nuclides))
+            ),
+            status="manual",
+        )
+        self._update_peak(peak, updated, "Assign peak nuclide")
+
+    def _clear_nuclide(self, intent: CanvasIntent) -> None:
+        peak = self._require_peak(intent)
+        if not peak.assignments and not peak.reference_lines_keV:
+            return
+        self._update_peak(
+            peak,
+            replace(peak, assignments=(), reference_lines_keV=(), status="manual"),
+            "Clear peak nuclide",
+        )
+
+    def _pin_nuclide(self, intent: CanvasIntent) -> None:
+        assert intent.nuclide is not None
+        before = self.workspace_controller.document.pinned_nuclides
+        if intent.nuclide in before:
+            return
+        after = tuple(dict.fromkeys((*before, intent.nuclide)))
+        self._push_macro(
+            "Pin nuclide",
+            (
+                TogglePinnedNuclideCommand(
+                    self.workspace_controller,
+                    before=before,
+                    after=after,
+                    description="Pin nuclide",
+                ),
+                self._cascade_workflow_command(after),
+            ),
+        )
+
+    def _unpin_nuclide(self, intent: CanvasIntent) -> None:
+        assert intent.nuclide is not None
+        before = self.workspace_controller.document.pinned_nuclides
+        if intent.nuclide not in before:
+            return
+        after = tuple(item for item in before if item != intent.nuclide)
+        self._push_macro(
+            "Unpin nuclide",
+            (
+                TogglePinnedNuclideCommand(
+                    self.workspace_controller,
+                    before=before,
+                    after=after,
+                    description="Unpin nuclide",
+                ),
+                self._cascade_workflow_command(after),
+            ),
+        )
+
+    def _tag_peak(self, intent: CanvasIntent) -> None:
+        peak = self._require_peak(intent)
+        assert intent.tag is not None
+        if intent.tag in peak.tags:
+            return
+        self._update_peak(
+            peak,
+            replace(peak, tags=tuple(dict.fromkeys((*peak.tags, intent.tag)))),
+            "Tag peak",
+            invalidate=False,
+        )
+
+    def _tag_nuclide(self, intent: CanvasIntent) -> None:
+        assert intent.nuclide is not None
+        assert intent.tag is not None
+        before = self.workspace_controller.document.nuclide_tags
+        if intent.tag in before.get(intent.nuclide, ()):
+            return
+        after = {key: tuple(value) for key, value in before.items()}
+        after[intent.nuclide] = tuple(
+            dict.fromkeys((*after.get(intent.nuclide, ()), intent.tag))
+        )
+        self._push(
+            UpdateNuclideTagsCommand(
+                self.workspace_controller,
+                before=before,
+                after=after,
+                description="Tag nuclide",
+            )
+        )
+
+    def _assign_role(self, intent: CanvasIntent) -> None:
+        spectrum_id = self._require_spectrum_id(intent)
+        assert intent.role is not None
+        existing = next(
+            (
+                item
+                for item in self.workspace_controller.document.spectrum_roles
+                if item.role == intent.role
+            ),
+            None,
+        )
+        before = existing.spectrum_ids if existing is not None else ()
+        if before == (spectrum_id,):
+            return
+        self._push_scientific(
+            AssignSpectrumRoleCommand(
+                self.workspace_controller,
+                role=intent.role,
+                before=before,
+                after=(spectrum_id,),
+                description=f"Assign {intent.role} spectrum",
+            ),
+            f"Assign {intent.role} spectrum",
+        )
+
+    def _viewport(self, intent: CanvasIntent) -> CanvasViewport:
+        viewport_id = intent.viewport_id or "primary-spectrum"
+        current = self.workspace_controller.document.viewport_by_id(viewport_id)
+        if current is not None and (
+            intent.spectrum_id is None
+            or current.spectrum_id in {None, intent.spectrum_id}
+        ):
+            return current
+        return CanvasViewport(
+            viewport_id=viewport_id,
+            spectrum_id=intent.spectrum_id,
+        )
+
+    def _commit_viewport(
+        self, before: CanvasViewport | None, after: CanvasViewport, description: str
+    ) -> None:
+        self._push(
+            UpdateCanvasViewportCommand(
+                self.workspace_controller,
+                before=before,
+                after=after,
+                description=description,
+            )
+        )
+
+    def _change_viewport(self, intent: CanvasIntent) -> None:
+        current = self._viewport(intent)
+        before = self.workspace_controller.document.viewport_by_id(current.viewport_id)
+        after = replace(
+            current,
+            x_range=intent.x_range or current.x_range,
+            y_range=intent.y_range or current.y_range,
+        )
+        self._commit_viewport(before, after, "Change spectrum viewport")
+
+    def _toggle_crosshair(self, intent: CanvasIntent) -> None:
+        current = self._viewport(intent)
+        before = self.workspace_controller.document.viewport_by_id(current.viewport_id)
+        self._commit_viewport(
+            before,
+            replace(current, crosshair_enabled=bool(intent.enabled)),
+            "Toggle crosshair",
+        )
+
+    def _set_log_scale(self, intent: CanvasIntent) -> None:
+        current = self._viewport(intent)
+        before = self.workspace_controller.document.viewport_by_id(current.viewport_id)
+        self._commit_viewport(
+            before,
+            replace(current, log_y=bool(intent.enabled)),
+            "Change spectrum scale",
+        )
+
+    def _set_labels_visible(self, intent: CanvasIntent) -> None:
+        current = self._viewport(intent)
+        before = self.workspace_controller.document.viewport_by_id(current.viewport_id)
+        self._commit_viewport(
+            before,
+            replace(current, labels_visible=bool(intent.enabled)),
+            "Change spectrum labels",
+        )
+
+
+__all__ = ["CanvasIntentDispatcher"]

--- a/src/fluxforge/gui/canvas_intents.py
+++ b/src/fluxforge/gui/canvas_intents.py
@@ -45,10 +45,13 @@ class CanvasIntentKind(str, Enum):
     MOVE_ROI = "roi.move"
     MOVE_BACKGROUND = "roi.background.move"
     ADD_PEAK = "peak.add"
+    SELECT_PEAK = "peak.select"
     MOVE_PEAK = "peak.move"
     DELETE_PEAK = "peak.delete"
+    ADD_COMPONENT = "peak.component.add"
     SPLIT_PEAK = "peak.split"
     MERGE_PEAKS = "peak.merge"
+    TAG_PEAK = "peak.tag"
     ASSIGN_NUCLIDE = "nuclide.assign"
     CLEAR_NUCLIDE = "nuclide.clear"
     PIN_NUCLIDE = "nuclide.pin"
@@ -68,9 +71,12 @@ _ROI_ID_KINDS = {
     CanvasIntentKind.MOVE_BACKGROUND,
 }
 _PEAK_ID_KINDS = {
+    CanvasIntentKind.SELECT_PEAK,
     CanvasIntentKind.MOVE_PEAK,
     CanvasIntentKind.DELETE_PEAK,
+    CanvasIntentKind.ADD_COMPONENT,
     CanvasIntentKind.SPLIT_PEAK,
+    CanvasIntentKind.TAG_PEAK,
     CanvasIntentKind.ASSIGN_NUCLIDE,
     CanvasIntentKind.CLEAR_NUCLIDE,
 }
@@ -127,6 +133,7 @@ class CanvasIntent:
             CanvasIntentKind.PIN_NUCLIDE,
             CanvasIntentKind.UNPIN_NUCLIDE,
             CanvasIntentKind.TAG_NUCLIDE,
+            *tuple(_ENABLED_KINDS),
         } and not _text(self.spectrum_id):
             raise ValueError(f"{self.kind.value} requires spectrum_id.")
         if self.kind in _ROI_ID_KINDS and not _text(self.roi_id):
@@ -135,6 +142,13 @@ class CanvasIntent:
             raise ValueError(f"{self.kind.value} requires peak_id.")
         if self.kind in _BOUNDS_KINDS:
             _validate_range(self.bounds, "bounds")
+        if self.kind is CanvasIntentKind.CREATE_ROI:
+            if self.left_background is None or self.right_background is None:
+                raise ValueError(
+                    "roi.create requires left and right background ranges."
+                )
+            _validate_range(self.left_background, "left_background")
+            _validate_range(self.right_background, "right_background")
         if self.kind is CanvasIntentKind.MOVE_BACKGROUND:
             if self.left_background is None and self.right_background is None:
                 raise ValueError("roi.background.move requires a background range.")
@@ -149,7 +163,11 @@ class CanvasIntent:
                 or not isfinite(float(self.position))
             ):
                 raise ValueError(f"{self.kind.value} requires a finite position.")
+        if self.kind is CanvasIntentKind.ADD_COMPONENT and self.position is not None:
+            _finite_number(self.position, "position")
         if self.kind is CanvasIntentKind.MERGE_PEAKS:
+            if any(not _text(value) for value in self.component_ids):
+                raise ValueError("peak.merge component IDs must be non-empty strings.")
             if len(set(self.component_ids)) < 2:
                 raise ValueError(
                     "peak.merge requires at least two unique component IDs."
@@ -164,6 +182,8 @@ class CanvasIntent:
             raise ValueError(f"{self.kind.value} requires nuclide.")
         if self.kind is CanvasIntentKind.TAG_NUCLIDE and not _text(self.tag):
             raise ValueError("nuclide.tag requires tag.")
+        if self.kind is CanvasIntentKind.TAG_PEAK and not _text(self.tag):
+            raise ValueError("peak.tag requires tag.")
         if self.kind is CanvasIntentKind.ASSIGN_SPECTRUM_ROLE and not _text(self.role):
             raise ValueError("spectrum.role.assign requires role.")
         if self.kind is CanvasIntentKind.CHANGE_VIEWPORT:
@@ -246,6 +266,8 @@ class CanvasIntent:
         component_ids = payload.get("component_ids", ())
         if not isinstance(component_ids, (list, tuple)):
             raise ValueError("component_ids must be an array.")
+        if any(not isinstance(value, str) for value in component_ids):
+            raise ValueError("component_ids must contain only strings.")
         raw_enabled = payload.get("enabled")
         if raw_enabled is not None and not isinstance(raw_enabled, bool):
             raise ValueError("enabled must be a boolean.")
@@ -254,7 +276,7 @@ class CanvasIntent:
             spectrum_id=_optional_text(payload.get("spectrum_id")),
             roi_id=_optional_text(payload.get("roi_id")),
             peak_id=_optional_text(payload.get("peak_id")),
-            component_ids=tuple(str(value) for value in component_ids),
+            component_ids=tuple(component_ids),
             bounds=pair("bounds"),
             left_background=pair("left_background"),
             right_background=pair("right_background"),
@@ -271,16 +293,20 @@ class CanvasIntent:
             y_range=pair("y_range"),
             enabled=raw_enabled,
             drag_token=_optional_text(payload.get("drag_token")),
-            schema=str(payload.get("schema") or ""),
+            schema=(
+                payload.get("schema") if isinstance(payload.get("schema"), str) else ""
+            ),
             version=version,
         )
 
 
 def _text(value: object) -> str:
-    return str(value or "").strip()
+    return value.strip() if isinstance(value, str) else ""
 
 
 def _optional_text(value: object) -> str | None:
+    if value is not None and not isinstance(value, str):
+        raise ValueError("text fields must be strings or null.")
     text = _text(value)
     return text or None
 

--- a/src/fluxforge/gui/main_window.py
+++ b/src/fluxforge/gui/main_window.py
@@ -656,11 +656,17 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 selection_bus=self.selection_bus,
                 workspace_controller=self.analysis_workspace,
                 qa_monitor=self.qa_monitor,
+                undo_stack=self.undo_stack,
                 parent=self,
             )
             self.setCentralWidget(self.central_tabs)
-            self._toggle_log_scale(self._log_scale_action.isChecked())
-            self._toggle_peak_labels(self._peak_labels_action.isChecked())
+            if hasattr(self.central_tabs, "canvas"):
+                self.central_tabs.canvas.set_log_scale(
+                    self._log_scale_action.isChecked()
+                )
+                self.central_tabs.canvas.set_peak_labels_visible(
+                    self._peak_labels_action.isChecked()
+                )
 
         def _wrap_dock(self, title: str, widget, area) -> QDockWidget:
             dock = QDockWidget(title, self)
@@ -1173,7 +1179,13 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 if viewport is not None and viewport.selected_roi_id:
                     roi = session.document.roi_by_id(viewport.selected_roi_id)
                     if roi is not None:
-                        self.selection_bus.publish_roi(*roi.signal_range)
+                        self.selection_bus.publish(
+                            SelectionState(
+                                spectrum_id=roi.spectrum_id,
+                                roi_id=roi.roi_id,
+                                roi_bounds_keV=roi.signal_range,
+                            )
+                        )
                 self.recent_files.record_many((source, *session.recent_files))
                 self._document_dirty = False
                 self.setWindowModified(False)
@@ -1198,7 +1210,17 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 self._document_dirty = False
                 self.setWindowModified(False)
 
-        def _on_workspace_document_changed(self, _document) -> None:
+        def _on_workspace_document_changed(self, document) -> None:
+            viewport = document.viewport_by_id("primary-spectrum")
+            log_y = viewport.log_y if viewport is not None else False
+            labels_visible = viewport.labels_visible if viewport is not None else True
+            for action, checked in (
+                (self._log_scale_action, log_y),
+                (self._peak_labels_action, labels_visible),
+            ):
+                action.blockSignals(True)
+                action.setChecked(bool(checked))
+                action.blockSignals(False)
             self._document_dirty = True
             self.setWindowModified(True)
 

--- a/src/fluxforge/gui/panels/modern_shell.py
+++ b/src/fluxforge/gui/panels/modern_shell.py
@@ -795,8 +795,12 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                     )
                 )
                 peak = self.workspace_controller.selected_peak()
+                current_selection = self.selection_bus.state
                 self.selection_bus.publish(
                     SelectionState(
+                        spectrum_id=current_selection.spectrum_id,
+                        peak_id=current_selection.peak_id,
+                        roi_id=current_selection.roi_id,
                         peak_energy_keV=(
                             peak.energy_keV if peak is not None else energy_keV
                         ),
@@ -807,6 +811,7 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                         reference_lines_keV=(
                             peak.reference_lines_keV if peak is not None else ()
                         ),
+                        zoom_requested=current_selection.zoom_requested,
                     )
                 )
 
@@ -824,8 +829,12 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             reference_lines = self.nuclide_controller.reference_lines_for_nuclide(
                 match.nuclide
             )
+            current_selection = self.selection_bus.state
             self.selection_bus.publish(
                 SelectionState(
+                    spectrum_id=current_selection.spectrum_id,
+                    peak_id=current_selection.peak_id,
+                    roi_id=current_selection.roi_id,
                     peak_energy_keV=(
                         peak.energy_keV
                         if peak is not None
@@ -835,6 +844,7 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                     nuclide=match.nuclide,
                     reference_lines_keV=reference_lines,
                     annotation_lines=self._peak_annotations_for_match(match),
+                    zoom_requested=current_selection.zoom_requested,
                 )
             )
 
@@ -865,13 +875,18 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 state,
                 state.__class__(**{**state.__dict__, "peaks": tuple(peaks)}),
             )
+            current_selection = self.selection_bus.state
             self.selection_bus.publish(
                 SelectionState(
+                    spectrum_id=current_selection.spectrum_id,
+                    peak_id=updated_peak.peak_id,
+                    roi_id=current_selection.roi_id,
                     peak_energy_keV=updated_peak.energy_keV,
                     roi_bounds_keV=updated_peak.roi_bounds_keV,
                     nuclide=updated_peak.nuclide,
                     reference_lines_keV=updated_peak.reference_lines_keV,
                     annotation_lines=self._peak_annotations_for_match(match),
+                    zoom_requested=current_selection.zoom_requested,
                 )
             )
 
@@ -895,12 +910,17 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 state,
                 state.__class__(**{**state.__dict__, "peaks": tuple(peaks)}),
             )
+            current_selection = self.selection_bus.state
             self.selection_bus.publish(
                 SelectionState(
+                    spectrum_id=current_selection.spectrum_id,
+                    peak_id=updated_peak.peak_id,
+                    roi_id=current_selection.roi_id,
                     peak_energy_keV=updated_peak.energy_keV,
                     roi_bounds_keV=updated_peak.roi_bounds_keV,
                     nuclide=None,
                     reference_lines_keV=(),
+                    zoom_requested=current_selection.zoom_requested,
                 )
             )
 
@@ -1075,6 +1095,17 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 return
             peak = self.workspace_controller.state.peaks[row]
             self.workspace_controller.select_peak(peak.peak_id)
+            spectrum_id = self.workspace_controller.document.active_spectrum_id
+            peak_model = (
+                self.workspace_controller.document.peak_by_id(spectrum_id, peak.peak_id)
+                if spectrum_id is not None
+                else None
+            )
+            canonical_roi = (
+                self.workspace_controller.document.roi_by_id(peak_model.roi_id)
+                if peak_model is not None and peak_model.roi_id is not None
+                else None
+            )
             annotation_lines = ()
             if peak.nuclide and peak.reference_lines_keV:
                 annotation_lines = tuple(
@@ -1086,30 +1117,54 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 )
             self.selection_bus.publish(
                 SelectionState(
+                    spectrum_id=spectrum_id,
+                    peak_id=peak.peak_id,
+                    roi_id=peak_model.roi_id if peak_model is not None else None,
                     peak_energy_keV=peak.energy_keV,
-                    roi_bounds_keV=peak.roi_bounds_keV,
+                    roi_bounds_keV=(
+                        canonical_roi.signal_range
+                        if canonical_roi is not None
+                        else peak.roi_bounds_keV
+                    ),
                     nuclide=peak.nuclide,
                     reference_lines_keV=peak.reference_lines_keV,
                     annotation_lines=annotation_lines,
+                    zoom_requested=True,
                 )
             )
 
         def _sync_from_selection_bus(self, state: SelectionState) -> None:
             if self._selection_sync_guard:
                 return
-            if state.peak_energy_keV is None:
-                return
             peaks = self.workspace_controller.state.peaks
             if not peaks:
                 return
-            target_row = min(
-                range(len(peaks)),
-                key=lambda index: abs(
-                    float(peaks[index].energy_keV) - float(state.peak_energy_keV)
-                ),
-            )
+            if state.peak_id is not None:
+                target_row = next(
+                    (
+                        index
+                        for index, peak in enumerate(peaks)
+                        if peak.peak_id == state.peak_id
+                    ),
+                    -1,
+                )
+                if target_row < 0:
+                    return
+            else:
+                if state.peak_energy_keV is None:
+                    return
+                target_row = min(
+                    range(len(peaks)),
+                    key=lambda index: abs(
+                        float(peaks[index].energy_keV) - float(state.peak_energy_keV)
+                    ),
+                )
             target_peak = peaks[target_row]
-            if abs(float(target_peak.energy_keV) - float(state.peak_energy_keV)) > 3.0:
+            if (
+                state.peak_id is None
+                and abs(float(target_peak.energy_keV) - float(state.peak_energy_keV))
+                > 3.0
+            ):
                 return
             current_row = self.table.currentRow()
             if (
@@ -2736,7 +2791,20 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 self._background_method_changed
             )
             self.workspace_controller.subscribe(self._sync_state)
+            self.selection_bus.subscribe(self._sync_selection)
             self._sync_state(self.workspace_controller.state)
+
+        def _sync_selection(self, state: SelectionState) -> None:
+            if state.roi_bounds_keV is None:
+                return
+            self.roi_left.blockSignals(True)
+            self.roi_right.blockSignals(True)
+            try:
+                self.roi_left.setValue(float(state.roi_bounds_keV[0]))
+                self.roi_right.setValue(float(state.roi_bounds_keV[1]))
+            finally:
+                self.roi_left.blockSignals(False)
+                self.roi_right.blockSignals(False)
 
         def _use_selected_peak_roi(self) -> None:
             peak = self.workspace_controller.selected_peak()
@@ -2744,12 +2812,17 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 return
             self.roi_left.setValue(float(peak.roi_bounds_keV[0]))
             self.roi_right.setValue(float(peak.roi_bounds_keV[1]))
+            current_selection = self.selection_bus.state
             self.selection_bus.publish(
                 SelectionState(
+                    spectrum_id=current_selection.spectrum_id,
+                    peak_id=peak.peak_id,
+                    roi_id=current_selection.roi_id,
                     peak_energy_keV=peak.energy_keV,
                     roi_bounds_keV=peak.roi_bounds_keV,
                     nuclide=peak.nuclide,
                     reference_lines_keV=peak.reference_lines_keV,
+                    zoom_requested=True,
                 )
             )
 

--- a/src/fluxforge/gui/panels/modern_shell_center.py
+++ b/src/fluxforge/gui/panels/modern_shell_center.py
@@ -7,13 +7,15 @@ from datetime import datetime
 import numpy as np
 
 from fluxforge.core.analysis_workspace import subtract_background_counts
-from fluxforge.core.workspace_document import CanvasViewport
+from fluxforge.core.workspace_document import CanvasViewport, WorkspaceValidationError
 from fluxforge.core.predictive import (
     estimate_count_target_forecast,
     estimate_dead_time_forecast,
     estimate_recalibration_forecast,
 )
 from fluxforge.gui.analysis_workspace import AnalysisWorkspaceController
+from fluxforge.gui.canvas_controller import CanvasIntentDispatcher
+from fluxforge.gui.canvas_intents import CanvasIntent, CanvasIntentKind
 from fluxforge.gui.backends import PYQTGRAPH_AVAILABLE, pyqtgraph_backend_status
 from fluxforge.gui.backends.pyqtgraph_backend import catalog_pyqtgraph_export_action
 from fluxforge.gui.mode_manager import GUIMode, ModeManager
@@ -25,7 +27,11 @@ from fluxforge.gui.panels.modern_shell_shared import (
 )
 from fluxforge.gui.qt_compat import QT_AVAILABLE
 from fluxforge.gui.selection_bus import SelectionBus, SelectionState
-from fluxforge.gui.spectrum_canvas import SpectrumTrace
+from fluxforge.gui.spectrum_canvas import (
+    CanvasPeakOverlay,
+    CanvasROIOverlay,
+    SpectrumTrace,
+)
 from fluxforge.standards import QAMonitor
 
 if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
@@ -277,6 +283,7 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             selection_bus: SelectionBus,
             workspace_controller: AnalysisWorkspaceController,
             qa_monitor: QAMonitor,
+            undo_stack=None,
             parent=None,
         ) -> None:
             super().__init__(parent)
@@ -284,6 +291,14 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             self.selection_bus = selection_bus
             self.workspace_controller = workspace_controller
             self.qa_monitor = qa_monitor
+            self.undo_stack = undo_stack
+            self.canvas_intent_dispatcher = CanvasIntentDispatcher(
+                self.workspace_controller,
+                self.selection_bus,
+                undo_stack=self.undo_stack,
+            )
+            self._last_canvas_viewport: CanvasViewport | None | object = object()
+            self._last_canvas_spectrum_id: str | None | object = object()
             self._current_spectrum = workspace_controller.spectrum()
             self.setObjectName("CentralWorkspaceTabs")
             self.addTab(self._build_spectrum_tab(), "Spectrum")
@@ -297,6 +312,7 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             )
             self.mode_manager.subscribe(self._sync_mode_banner)
             self.mode_manager.subscribe(self._sync_workspace_mode)
+            self.selection_bus.subscribe(self._sync_canvas_selection)
             self.workspace_controller.subscribe(self._sync_workspace_state)
             self._sync_mode_banner(self.mode_manager.state)
             self._sync_workspace_state(self.workspace_controller.state)
@@ -322,6 +338,10 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                     selection_bus=self.selection_bus,
                     parent=widget,
                 )
+                if hasattr(self.canvas, "set_intent_sink"):
+                    self.canvas.set_intent_sink(self._dispatch_canvas_intent)
+                elif hasattr(self.canvas, "subscribe_intents"):
+                    self.canvas.subscribe_intents(self._dispatch_canvas_intent)
                 layout.addWidget(self.canvas, 1)
             else:
                 status = pyqtgraph_backend_status()
@@ -370,7 +390,15 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 and hasattr(self, "canvas")
                 and hasattr(self.canvas, "set_log_scale")
             ):
-                self.canvas.set_log_scale(bool(enabled))
+                spectrum_id = self.workspace_controller.document.active_spectrum_id
+                self._dispatch_canvas_intent(
+                    CanvasIntent(
+                        CanvasIntentKind.SET_LOG_SCALE,
+                        spectrum_id=spectrum_id,
+                        viewport_id="primary-spectrum",
+                        enabled=bool(enabled),
+                    )
+                )
 
         def set_peak_labels_visible(self, visible: bool) -> None:
             if (
@@ -378,7 +406,25 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 and hasattr(self, "canvas")
                 and hasattr(self.canvas, "set_peak_labels_visible")
             ):
-                self.canvas.set_peak_labels_visible(bool(visible))
+                spectrum_id = self.workspace_controller.document.active_spectrum_id
+                self._dispatch_canvas_intent(
+                    CanvasIntent(
+                        CanvasIntentKind.SET_LABELS_VISIBLE,
+                        spectrum_id=spectrum_id,
+                        viewport_id="primary-spectrum",
+                        enabled=bool(visible),
+                    )
+                )
+
+        def _dispatch_canvas_intent(self, intent: CanvasIntent) -> None:
+            """Apply one canvas edit and restore the canonical view if rejected."""
+
+            try:
+                self.canvas_intent_dispatcher.handle(intent)
+            except (WorkspaceValidationError, ValueError, KeyError) as exc:
+                self._sync_analysis_overlays(self.selection_bus.state)
+                if hasattr(self.canvas, "show_interaction_error"):
+                    self.canvas.show_interaction_error(str(exc))
 
         def viewport_state(self) -> CanvasViewport | None:
             if not PYQTGRAPH_AVAILABLE or not hasattr(self, "canvas"):
@@ -395,6 +441,97 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
         def apply_viewport_state(self, viewport: CanvasViewport) -> None:
             if PYQTGRAPH_AVAILABLE and hasattr(self, "canvas"):
                 self.canvas.apply_viewport_state(viewport)
+
+        def _sync_canvas_selection(self, selection: SelectionState) -> None:
+            if not PYQTGRAPH_AVAILABLE or not hasattr(self, "canvas"):
+                return
+            roi = (
+                self.workspace_controller.document.roi_by_id(selection.roi_id)
+                if selection.roi_id is not None
+                else None
+            )
+            bounds = roi.signal_range if roi is not None else selection.roi_bounds_keV
+            if (
+                selection.zoom_requested
+                and bounds is not None
+                and hasattr(self.canvas, "zoom_to_range")
+            ):
+                self.canvas.zoom_to_range(float(bounds[0]), float(bounds[1]))
+            self._sync_analysis_overlays(selection)
+
+        def _sync_analysis_overlays(
+            self, selection: SelectionState | None = None
+        ) -> None:
+            if not PYQTGRAPH_AVAILABLE or not hasattr(self, "canvas"):
+                return
+            document = self.workspace_controller.document
+            spectrum_id = document.active_spectrum_id
+            if hasattr(self.canvas, "set_interaction_context"):
+                self.canvas.set_interaction_context(spectrum_id)
+            if not hasattr(self.canvas, "set_analysis_overlays"):
+                return
+            selection = selection or self.selection_bus.state
+            viewport = document.viewport_by_id("primary-spectrum")
+            selected_roi_id = (
+                selection.roi_id
+                if document.roi_by_id(selection.roi_id or "") is not None
+                else None
+            ) or (viewport.selected_roi_id if viewport is not None else None)
+            requested_peak_id = (
+                selection.peak_id or self.workspace_controller.state.selected_peak_id
+            )
+            selected_peak_id = (
+                requested_peak_id
+                if requested_peak_id is not None
+                and document.peak_by_id(spectrum_id, requested_peak_id) is not None
+                else None
+            )
+            rois = tuple(
+                CanvasROIOverlay(
+                    roi_id=roi.roi_id,
+                    spectrum_id=roi.spectrum_id,
+                    signal_range=roi.signal_range,
+                    left_background_range=roi.left_background_range,
+                    right_background_range=roi.right_background_range,
+                    color=roi.color,
+                    selected=roi.roi_id == selected_roi_id,
+                )
+                for roi in document.rois
+                if roi.spectrum_id == spectrum_id
+            )
+            pinned = set(document.pinned_nuclides)
+            peaks = tuple(
+                CanvasPeakOverlay(
+                    peak_id=peak.peak_id,
+                    spectrum_id=peak.spectrum_id,
+                    position=peak.centroid_energy_keV,
+                    y_value=max(float(peak.net_counts), 0.0),
+                    component_ids=tuple(
+                        component.component_id for component in peak.components
+                    ),
+                    nuclide=(peak.assignments[0].nuclide if peak.assignments else None),
+                    tags=peak.tags,
+                    nuclide_tags=(
+                        tuple(
+                            document.nuclide_tags.get(peak.assignments[0].nuclide, ())
+                        )
+                        if peak.assignments
+                        else ()
+                    ),
+                    pinned=any(
+                        assignment.nuclide in pinned for assignment in peak.assignments
+                    ),
+                    selected=peak.peak_id == selected_peak_id,
+                )
+                for peak in document.peaks
+                if peak.spectrum_id == spectrum_id
+            )
+            self.canvas.set_analysis_overlays(
+                rois,
+                peaks,
+                selected_roi_id=selected_roi_id,
+                selected_peak_id=selected_peak_id,
+            )
 
         def _slot_tab_changed(self, index: int) -> None:
             if index < 0 or index >= len(self.workspace_controller.state.spectra):
@@ -433,6 +570,7 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
 
         def _sync_workspace_state(self, state) -> None:
             self._current_spectrum = self.workspace_controller.spectrum()
+            self._reconcile_selection_with_document()
             self._sync_slot_tabs(state)
             if not PYQTGRAPH_AVAILABLE or not hasattr(self, "canvas"):
                 return
@@ -445,7 +583,7 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                     foreground_slot = slot
                 elif slot.key == "background":
                     background_slot = slot
-                elif slot.key == "overlay":
+                elif slot.key in {"overlay", "secondary"}:
                     overlay_slot = slot
             foreground = (
                 foreground_slot.spectrum if foreground_slot is not None else None
@@ -560,7 +698,9 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                     )
                 )
             self.canvas.set_traces(traces)
+            self._apply_document_viewport()
             self.canvas.set_peak_candidates(state.peaks)
+            self._sync_analysis_overlays()
             self.canvas.set_cascade_sum_lines(state.cascade_sum_lines_keV)
             self.canvas.set_peak_residuals(
                 state.peaks[:3],
@@ -578,12 +718,110 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
                 if selected_peak is not None:
                     self.selection_bus.publish(
                         SelectionState(
+                            spectrum_id=(
+                                self.workspace_controller.document.active_spectrum_id
+                            ),
+                            peak_id=selected_peak.peak_id,
                             peak_energy_keV=selected_peak.energy_keV,
                             roi_bounds_keV=selected_peak.roi_bounds_keV,
                             nuclide=selected_peak.nuclide,
                             reference_lines_keV=selected_peak.reference_lines_keV,
                         )
                     )
+
+        def _reconcile_selection_with_document(self) -> None:
+            """Remove exact IDs that no longer exist after undo or session load."""
+
+            document = self.workspace_controller.document
+            state = self.selection_bus.state
+            spectrum_exists = state.spectrum_id is None or (
+                state.spectrum_id == document.active_spectrum_id
+                and document.spectrum_by_id(state.spectrum_id) is not None
+            )
+            peak_exists = state.peak_id is None or (
+                spectrum_exists
+                and document.peak_by_id(
+                    state.spectrum_id or document.active_spectrum_id,
+                    state.peak_id,
+                )
+                is not None
+            )
+            selected_roi = (
+                document.roi_by_id(state.roi_id) if state.roi_id is not None else None
+            )
+            roi_exists = state.roi_id is None or (
+                selected_roi is not None
+                and selected_roi.spectrum_id == document.active_spectrum_id
+            )
+            if spectrum_exists and peak_exists and roi_exists:
+                return
+            reconciled = SelectionState(
+                spectrum_id=state.spectrum_id if spectrum_exists else None,
+                peak_id=state.peak_id if peak_exists else None,
+                roi_id=state.roi_id if roi_exists else None,
+                peak_energy_keV=(state.peak_energy_keV if peak_exists else None),
+                roi_bounds_keV=(state.roi_bounds_keV if roi_exists else None),
+                nuclide=state.nuclide if peak_exists else None,
+                reference_lines_keV=(state.reference_lines_keV if peak_exists else ()),
+                annotation_lines=state.annotation_lines if peak_exists else (),
+                zoom_requested=False,
+            )
+            self.selection_bus.publish(reconciled)
+
+        def _apply_document_viewport(self) -> None:
+            """Reapply canonical viewport changes, including undo to no viewport."""
+
+            if not PYQTGRAPH_AVAILABLE or not hasattr(self, "canvas"):
+                return
+            document = self.workspace_controller.document
+            active_spectrum_id = document.active_spectrum_id
+            persisted_viewport = document.viewport_by_id("primary-spectrum")
+            viewport = (
+                persisted_viewport
+                if persisted_viewport is None
+                or persisted_viewport.spectrum_id in {None, active_spectrum_id}
+                else None
+            )
+            if (
+                viewport == self._last_canvas_viewport
+                and active_spectrum_id == self._last_canvas_spectrum_id
+            ):
+                return
+            previous = self._last_canvas_viewport
+            self._last_canvas_viewport = viewport
+            spectrum_changed = active_spectrum_id != self._last_canvas_spectrum_id
+            self._last_canvas_spectrum_id = active_spectrum_id
+            if viewport is not None:
+                self.canvas.apply_viewport_state(viewport)
+            elif isinstance(previous, CanvasViewport) or spectrum_changed:
+                if hasattr(self.canvas, "reset_persisted_viewport_state"):
+                    self.canvas.reset_persisted_viewport_state()
+            previous_roi_id = (
+                previous.selected_roi_id
+                if isinstance(previous, CanvasViewport)
+                else None
+            )
+            selected_roi_id = viewport.selected_roi_id if viewport is not None else None
+            if selected_roi_id != previous_roi_id:
+                state = self.selection_bus.state
+                roi = (
+                    document.roi_by_id(selected_roi_id)
+                    if selected_roi_id is not None
+                    else None
+                )
+                self.selection_bus.publish(
+                    SelectionState(
+                        spectrum_id=state.spectrum_id or document.active_spectrum_id,
+                        peak_id=state.peak_id,
+                        roi_id=roi.roi_id if roi is not None else None,
+                        peak_energy_keV=state.peak_energy_keV,
+                        roi_bounds_keV=(roi.signal_range if roi is not None else None),
+                        nuclide=state.nuclide,
+                        reference_lines_keV=state.reference_lines_keV,
+                        annotation_lines=state.annotation_lines,
+                        zoom_requested=False,
+                    )
+                )
 
         def _sync_slot_tabs(self, state) -> None:
             self.spectrum_slot_tabs.blockSignals(True)

--- a/src/fluxforge/gui/panels/modern_shell_context.py
+++ b/src/fluxforge/gui/panels/modern_shell_context.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from fluxforge.gui.analysis_workspace import AnalysisWorkspaceController
 from fluxforge.gui.mode_manager import ModeManager
 from fluxforge.gui.qt_compat import QT_AVAILABLE
 from fluxforge.gui.selection_bus import SelectionBus, SelectionState
 
 if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
-    from fluxforge.gui.panels.modern_shell_shared import selection_summary as _selection_summary
+    from fluxforge.gui.panels.modern_shell_shared import (
+        selection_summary as _selection_summary,
+    )
     from fluxforge.gui.qt_compat import QLabel, QVBoxLayout, QWidget
 
     class ToolContextPanel(QWidget):
@@ -111,12 +115,22 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             )
             roi = state.roi_analysis
             efficiency = state.efficiency_fit
+            invalidation = self.workspace_controller.document.workflow_state.get(
+                "analysis_invalidation"
+            )
+            invalidation_line = ""
+            if isinstance(invalidation, Mapping) and invalidation.get(
+                "requires_reanalysis"
+            ):
+                reason = str(invalidation.get("reason") or "scientific edit")
+                invalidation_line = f"\nAnalysis status: re-run required ({reason})"
             self.analysis_summary.setText(
                 (
                     f"Efficiency calibration: {'ready' if efficiency is not None else 'not fitted'}\n"
                     f"Activity results: {len(state.activity_results)}\n"
                     f"ROI analysis: "
                     f"{f'{roi.roi_bounds_keV[0]:.2f}-{roi.roi_bounds_keV[1]:.2f} keV' if roi is not None else 'not run'}"
+                    f"{invalidation_line}"
                 )
             )
 

--- a/src/fluxforge/gui/panels/modern_shell_sidebar.py
+++ b/src/fluxforge/gui/panels/modern_shell_sidebar.py
@@ -122,7 +122,7 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             layout.addWidget(self.acquisition_status)
 
             layout.addWidget(self._build_reference_workbench_panel(), 3)
-            self._refresh_nuclide_results("cs")
+            self._refresh_nuclide_results("")
 
             self.selection_note = QTextEdit(self)
             self.selection_note.setObjectName("SidebarNote")
@@ -783,9 +783,13 @@ if QT_AVAILABLE:  # pragma: no cover - optional dependency branch
             self._sync_qa_summary()
 
         def _refresh_nuclide_results(self, query: str) -> None:
+            query = str(query).strip()
             previous = self._selected_nuclide_name()
             self.nuclides.clear()
-            for hit in self.nuclide_controller.search(query or "c"):
+            if not query:
+                self._refresh_nuclide_details()
+                return
+            for hit in self.nuclide_controller.search(query):
                 label = hit.display_name
                 if hit.strongest_lines_keV:
                     label += (

--- a/src/fluxforge/gui/selection_bus.py
+++ b/src/fluxforge/gui/selection_bus.py
@@ -12,11 +12,15 @@ from fluxforge.gui.spectrum_canvas import ReferenceLine
 class SelectionState:
     """Shared selection state between coordinated GUI surfaces."""
 
+    spectrum_id: str | None = None
+    peak_id: str | None = None
+    roi_id: str | None = None
     peak_energy_keV: float | None = None
     roi_bounds_keV: tuple[float, float] | None = None
     nuclide: str | None = None
     reference_lines_keV: tuple[float, ...] = ()
     annotation_lines: tuple[ReferenceLine, ...] = ()
+    zoom_requested: bool = False
 
 
 SelectionListener = Callable[[SelectionState], None]
@@ -67,11 +71,15 @@ class SelectionBus:
 
         return self.publish(
             SelectionState(
+                spectrum_id=self._state.spectrum_id,
+                peak_id=self._state.peak_id,
+                roi_id=self._state.roi_id,
                 peak_energy_keV=float(peak_energy_keV),
                 roi_bounds_keV=self._state.roi_bounds_keV,
                 nuclide=nuclide or self._state.nuclide,
                 reference_lines_keV=self._state.reference_lines_keV,
                 annotation_lines=self._state.annotation_lines,
+                zoom_requested=False,
             )
         )
 
@@ -81,11 +89,15 @@ class SelectionBus:
         lower, upper = sorted((float(start_keV), float(end_keV)))
         return self.publish(
             SelectionState(
+                spectrum_id=self._state.spectrum_id,
+                peak_id=self._state.peak_id,
+                roi_id=self._state.roi_id,
                 peak_energy_keV=self._state.peak_energy_keV,
                 roi_bounds_keV=(lower, upper),
                 nuclide=self._state.nuclide,
                 reference_lines_keV=self._state.reference_lines_keV,
                 annotation_lines=self._state.annotation_lines,
+                zoom_requested=False,
             )
         )
 
@@ -100,11 +112,15 @@ class SelectionBus:
 
         return self.publish(
             SelectionState(
+                spectrum_id=self._state.spectrum_id,
+                peak_id=self._state.peak_id,
+                roi_id=self._state.roi_id,
                 peak_energy_keV=self._state.peak_energy_keV,
                 roi_bounds_keV=self._state.roi_bounds_keV,
                 nuclide=nuclide,
                 reference_lines_keV=reference_lines_keV,
                 annotation_lines=annotation_lines,
+                zoom_requested=False,
             )
         )
 
@@ -117,10 +133,14 @@ class SelectionBus:
         """Return a small serializable description of the current selection."""
 
         return {
+            "spectrum_id": self._state.spectrum_id,
+            "peak_id": self._state.peak_id,
+            "roi_id": self._state.roi_id,
             "peak_energy_keV": self._state.peak_energy_keV,
             "roi_bounds_keV": self._state.roi_bounds_keV,
             "nuclide": self._state.nuclide,
             "reference_lines_keV": self._state.reference_lines_keV,
             "annotation_line_count": len(self._state.annotation_lines),
+            "zoom_requested": self._state.zoom_requested,
             "listener_count": len(self._listeners),
         }

--- a/src/fluxforge/gui/spectrum_canvas.py
+++ b/src/fluxforge/gui/spectrum_canvas.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Sequence
+from typing import Callable, Sequence
 
 from fluxforge.core.analysis_workspace import PeakCandidate
 from fluxforge.core.workspace_document import CanvasViewport
+from fluxforge.gui.canvas_intents import CanvasIntent
 
 
 @dataclass(frozen=True)
@@ -41,6 +42,38 @@ class ReferenceLine:
     energy_keV: float
     label: str = ""
     color: str = "#f59e0b"
+
+
+@dataclass(frozen=True)
+class CanvasROIOverlay:
+    """Renderer-neutral description of one persisted analysis ROI."""
+
+    roi_id: str
+    spectrum_id: str
+    signal_range: tuple[float, float]
+    left_background_range: tuple[float, float]
+    right_background_range: tuple[float, float]
+    color: str = "#2dd4bf"
+    selected: bool = False
+
+
+@dataclass(frozen=True)
+class CanvasPeakOverlay:
+    """Renderer-neutral description of one exact peak or component handle."""
+
+    peak_id: str
+    spectrum_id: str
+    position: float
+    y_value: float = 0.0
+    component_ids: tuple[str, ...] = ()
+    nuclide: str | None = None
+    tags: tuple[str, ...] = ()
+    nuclide_tags: tuple[str, ...] = ()
+    pinned: bool = False
+    selected: bool = False
+
+
+CanvasIntentListener = Callable[[CanvasIntent], None]
 
 
 @dataclass(frozen=True)
@@ -109,6 +142,39 @@ class SpectrumCanvas:
     backend_key: str
     capabilities: RendererCapabilities
 
+    def set_intent_sink(self, listener: CanvasIntentListener | None) -> None:
+        """Replace the renderer-intent subscribers with one optional sink."""
+
+        self._canvas_intent_listeners = []
+        if listener is not None:
+            self._canvas_intent_listeners.append(listener)
+
+    def subscribe_intents(self, listener: CanvasIntentListener) -> None:
+        """Subscribe to validated, renderer-independent interaction commits."""
+
+        listeners = self._intent_listeners()
+        if listener not in listeners:
+            listeners.append(listener)
+
+    def unsubscribe_intents(self, listener: CanvasIntentListener) -> None:
+        """Remove a previously registered interaction subscriber."""
+
+        listeners = self._intent_listeners()
+        if listener in listeners:
+            listeners.remove(listener)
+
+    def _intent_listeners(self) -> list[CanvasIntentListener]:
+        listeners = getattr(self, "_canvas_intent_listeners", None)
+        if listeners is None:
+            listeners = []
+            self._canvas_intent_listeners = listeners
+        return listeners
+
+    def _emit_canvas_intent(self, intent: CanvasIntent) -> None:
+        intent.validate()
+        for listener in tuple(self._intent_listeners()):
+            listener(intent)
+
     def set_spectrum(self, counts: Sequence[float]) -> None:
         """Load the primary spectrum."""
         raise NotImplementedError
@@ -138,6 +204,35 @@ class SpectrumCanvas:
         """Optional bulk update for detected peak overlays."""
 
         del peaks
+
+    def set_interaction_context(self, spectrum_id: str | None) -> None:
+        """Set the exact spectrum identity used by newly emitted intents."""
+
+        del spectrum_id
+
+    def set_analysis_overlays(
+        self,
+        rois: Sequence[CanvasROIOverlay],
+        peaks: Sequence[CanvasPeakOverlay],
+        *,
+        selected_roi_id: str | None = None,
+        selected_peak_id: str | None = None,
+    ) -> None:
+        """Render canonical ROI and peak leaves without mutating them."""
+
+        del rois, peaks, selected_roi_id, selected_peak_id
+
+    def zoom_to_range(
+        self,
+        lower: float,
+        upper: float,
+        *,
+        padding_fraction: float = 0.12,
+    ) -> None:
+        """Zoom to an increasing x range with proportional visual padding."""
+
+        del lower, upper, padding_fraction
+        raise NotImplementedError
 
     def set_cascade_sum_lines(self, energies_keV: Sequence[float]) -> None:
         """Optional bulk update for cascade-sum overlays."""

--- a/src/fluxforge/gui/workspace_undo.py
+++ b/src/fluxforge/gui/workspace_undo.py
@@ -10,8 +10,8 @@ that share one explicit drag token into a single undo-stack entry.
 from __future__ import annotations
 
 from copy import deepcopy
-from dataclasses import dataclass
-from typing import Protocol, Sequence, TypeAlias
+from dataclasses import dataclass, replace
+from typing import Any, Mapping, Protocol, Sequence, TypeAlias
 
 from fluxforge.core.workspace_document import (
     AnalysisROI,
@@ -45,6 +45,59 @@ else:  # pragma: no cover - import-safe fallback for non-GUI installations
 
 
 CalibrationLeaf: TypeAlias = CalibrationModel | DetectorProfile | None
+
+
+def _copy_workflow_leaf(value: Any) -> Any:
+    """Copy immutable JSON-like workflow leaves, including mapping proxies."""
+
+    if isinstance(value, Mapping):
+        return {str(key): _copy_workflow_leaf(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return tuple(_copy_workflow_leaf(item) for item in value)
+    if isinstance(value, list):
+        return [_copy_workflow_leaf(item) for item in value]
+    return deepcopy(value)
+
+
+def _invalidated_diagnostic(
+    diagnostic: FitDiagnostics,
+    reason: str,
+) -> FitDiagnostics:
+    """Return an explicit invalid state without obsolete fit arrays."""
+
+    return replace(
+        diagnostic,
+        status="invalid",
+        x=(),
+        observed=(),
+        model=(),
+        uncertainty=(),
+        normalized_residuals=(),
+        goodness_of_fit={},
+        warning_flags=tuple(
+            dict.fromkeys((*diagnostic.warning_flags, "analysis-edit-invalidated"))
+        ),
+        provenance={
+            **dict(diagnostic.provenance),
+            "invalidated_by": reason,
+        },
+    )
+
+
+def _invalidated_peak(peak: PeakModel, reason: str) -> PeakModel:
+    """Return a peak leaf with no displayable residuals from an obsolete fit."""
+
+    return replace(
+        peak,
+        status="invalidated",
+        fit_quality=0.0,
+        normalized_residuals=(),
+        residual_channels=(),
+        provenance={
+            **dict(peak.provenance),
+            "fit_invalidated_by": reason,
+        },
+    )
 
 
 @dataclass(frozen=True)
@@ -97,6 +150,10 @@ class WorkspaceLeafController(Protocol):
 
     def upsert_fit_diagnostic(self, diagnostic: FitDiagnostics) -> object: ...
 
+    def set_fit_diagnostics(self, diagnostics: Sequence[FitDiagnostics]) -> object: ...
+
+    def set_workflow_state(self, workflow_state: Mapping[str, Any]) -> object: ...
+
     def assign_spectrum_role(
         self, role: str, spectrum_ids: str | Sequence[str] | None
     ) -> object: ...
@@ -110,6 +167,8 @@ class WorkspaceLeafController(Protocol):
     def delete_viewport(self, viewport_id: str) -> object: ...
 
     def set_pinned_nuclides(self, pinned_nuclides: Sequence[str]) -> object: ...
+
+    def set_nuclide_tags(self, nuclide_tags: Mapping[str, Sequence[str]]) -> object: ...
 
     def apply_calibration(
         self, spectrum_id: str, calibration_state: CalibrationLeaf
@@ -208,6 +267,7 @@ class UpdatePeakCommand(_WorkspaceLeafCommand):
         *,
         before: PeakModel | None,
         after: PeakModel,
+        invalidate_diagnostics: bool = False,
         description: str = "Update peak",
     ) -> None:
         super().__init__(controller, description)
@@ -220,15 +280,56 @@ class UpdatePeakCommand(_WorkspaceLeafCommand):
         self.peak_id = after.peak_id
         self.before = before
         self.after = after
+        document = _controller_document(controller)
+        self.related_diagnostics = (
+            tuple(
+                item
+                for item in document.fit_diagnostics
+                if item.spectrum_id == after.spectrum_id
+                and (
+                    item.peak_id == after.peak_id
+                    or (after.roi_id is not None and item.roi_id == after.roi_id)
+                )
+            )
+            if invalidate_diagnostics and document is not None
+            else ()
+        )
+        self.invalid_diagnostics = tuple(
+            _invalidated_diagnostic(item, description)
+            for item in self.related_diagnostics
+        )
+        self.related_roi_peaks = (
+            tuple(
+                item
+                for item in document.peaks
+                if item.spectrum_id == after.spectrum_id
+                and after.roi_id is not None
+                and item.roi_id == after.roi_id
+                and item.peak_id != after.peak_id
+            )
+            if invalidate_diagnostics and document is not None
+            else ()
+        )
+        self.invalid_roi_peaks = tuple(
+            _invalidated_peak(item, description) for item in self.related_roi_peaks
+        )
 
     def undo(self) -> None:
         if self.before is None:
             self.controller.delete_peak_model(self.spectrum_id, self.peak_id)
         else:
             self.controller.upsert_peak_model(self.before)
+        for peak in self.related_roi_peaks:
+            self.controller.upsert_peak_model(peak)
+        for diagnostic in self.related_diagnostics:
+            self.controller.upsert_fit_diagnostic(diagnostic)
 
     def redo(self) -> None:
         self.controller.upsert_peak_model(self.after)
+        for peak in self.invalid_roi_peaks:
+            self.controller.upsert_peak_model(peak)
+        for diagnostic in self.invalid_diagnostics:
+            self.controller.upsert_fit_diagnostic(diagnostic)
 
 
 class DeletePeakCommand(_WorkspaceLeafCommand):
@@ -343,6 +444,50 @@ class TogglePinnedNuclideCommand(_WorkspaceLeafCommand):
 
     def redo(self) -> None:
         self.controller.set_pinned_nuclides(self.after)
+
+
+class UpdateNuclideTagsCommand(_WorkspaceLeafCommand):
+    """Replace the small persisted map of analyst tags by nuclide."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        before: Mapping[str, Sequence[str]],
+        after: Mapping[str, Sequence[str]],
+        description: str = "Tag nuclide",
+    ) -> None:
+        super().__init__(controller, description)
+        self.before = {key: tuple(value) for key, value in before.items()}
+        self.after = {key: tuple(value) for key, value in after.items()}
+
+    def undo(self) -> None:
+        self.controller.set_nuclide_tags(self.before)
+
+    def redo(self) -> None:
+        self.controller.set_nuclide_tags(self.after)
+
+
+class UpdateWorkflowStateCommand(_WorkspaceLeafCommand):
+    """Replace derived workflow state so scientific edits cannot leave stale output."""
+
+    def __init__(
+        self,
+        controller: WorkspaceLeafController,
+        *,
+        before: Mapping[str, Any],
+        after: Mapping[str, Any],
+        description: str = "Invalidate derived analysis",
+    ) -> None:
+        super().__init__(controller, description)
+        self.before = _copy_workflow_leaf(before)
+        self.after = _copy_workflow_leaf(after)
+
+    def undo(self) -> None:
+        self.controller.set_workflow_state(self.before)
+
+    def redo(self) -> None:
+        self.controller.set_workflow_state(self.after)
 
 
 class UpsertROICommand(_WorkspaceLeafCommand):
@@ -480,6 +625,34 @@ class MoveROIBoundsCommand(_WorkspaceLeafCommand):
         self.drag_token = drag_token
         self.before = before
         self.after = after
+        document = _controller_document(controller)
+        self.related_peaks = (
+            tuple(
+                item
+                for item in document.peaks
+                if item.spectrum_id == before.spectrum_id
+                and item.roi_id == before.roi_id
+            )
+            if document is not None
+            else ()
+        )
+        self.invalid_peaks = tuple(
+            _invalidated_peak(item, description) for item in self.related_peaks
+        )
+        self.related_diagnostics = (
+            tuple(
+                item
+                for item in document.fit_diagnostics
+                if item.spectrum_id == before.spectrum_id
+                and item.roi_id == before.roi_id
+            )
+            if document is not None
+            else ()
+        )
+        self.invalid_diagnostics = tuple(
+            _invalidated_diagnostic(item, description)
+            for item in self.related_diagnostics
+        )
 
     def id(self) -> int:
         return self.COMMAND_ID
@@ -499,9 +672,17 @@ class MoveROIBoundsCommand(_WorkspaceLeafCommand):
 
     def undo(self) -> None:
         self.controller.upsert_roi(self.before)
+        for peak in self.related_peaks:
+            self.controller.upsert_peak_model(peak)
+        for diagnostic in self.related_diagnostics:
+            self.controller.upsert_fit_diagnostic(diagnostic)
 
     def redo(self) -> None:
         self.controller.upsert_roi(self.after)
+        for peak in self.invalid_peaks:
+            self.controller.upsert_peak_model(peak)
+        for diagnostic in self.invalid_diagnostics:
+            self.controller.upsert_fit_diagnostic(diagnostic)
 
 
 class AssignSpectrumRoleCommand(_WorkspaceLeafCommand):
@@ -644,8 +825,10 @@ __all__ = [
     "TogglePinnedNuclideCommand",
     "UpdateCanvasViewportCommand",
     "UpdateDetectorProfileCommand",
+    "UpdateNuclideTagsCommand",
     "UpdatePeakAssignmentCommand",
     "UpdatePeakCommand",
+    "UpdateWorkflowStateCommand",
     "UpsertROICommand",
     "WorkspaceLeafController",
 ]

--- a/tests/test_bgamma_canvas_integration_qt.py
+++ b/tests/test_bgamma_canvas_integration_qt.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from fluxforge.core.analysis_workspace import detect_peak_candidates  # noqa: E402
+from fluxforge.core.workspace_document import AnalysisROI  # noqa: E402
+from fluxforge.gui import QT_AVAILABLE, SelectionBus  # noqa: E402
+from fluxforge.gui.backends import PYQTGRAPH_AVAILABLE  # noqa: E402
+from fluxforge.gui.main_window import FluxForgeMainWindow  # noqa: E402
+from fluxforge.gui.mode_manager import ModeManager  # noqa: E402
+from fluxforge.gui.panels.modern_shell import build_demo_spectrum  # noqa: E402
+from fluxforge.gui.qt_compat import QApplication  # noqa: E402
+from fluxforge.io.session import read_ffs_session  # noqa: E402
+
+
+pytestmark = pytest.mark.skipif(
+    not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
+    reason="Qt spectrum renderer dependencies are unavailable.",
+)
+
+
+def _qapp() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def _window_with_duplicate_energy_peaks():
+    app = _qapp()
+    window = FluxForgeMainWindow(
+        mode_manager=ModeManager(),
+        selection_bus=SelectionBus(),
+        load_example=True,
+    )
+    window.resize(1200, 800)
+    window.show()
+    app.processEvents()
+
+    detected = detect_peak_candidates(build_demo_spectrum())
+    assert detected
+    source = detected[0]
+    peaks = (
+        replace(
+            source,
+            peak_id="duplicate-a",
+            energy_keV=500.0,
+            roi_bounds_keV=(480.0, 490.0),
+        ),
+        replace(
+            source,
+            peak_id="duplicate-b",
+            energy_keV=500.0,
+            roi_bounds_keV=(700.0, 720.0),
+        ),
+    )
+    window.analysis_workspace.replace_peaks(peaks)
+    spectrum_id = window.analysis_workspace.document.active_spectrum_id
+    duplicate_b = window.analysis_workspace.document.peak_by_id(
+        spectrum_id,
+        "duplicate-b",
+    )
+    assert duplicate_b is not None
+    canonical_roi = AnalysisROI(
+        roi_id="canonical-duplicate-b-roi",
+        spectrum_id=spectrum_id,
+        signal_range=(730.0, 740.0),
+        left_background_range=(720.0, 728.0),
+        right_background_range=(742.0, 750.0),
+        associated_peak_ids=("duplicate-b",),
+        label="Canonical duplicate B",
+    )
+    window.analysis_workspace.upsert_roi(canonical_roi)
+    window.analysis_workspace.upsert_peak_model(
+        replace(duplicate_b, roi_id=canonical_roi.roi_id)
+    )
+    app.processEvents()
+    return window, app
+
+
+def test_peak_table_uses_exact_id_and_zooms_to_that_peaks_roi() -> None:
+    window, app = _window_with_duplicate_energy_peaks()
+    try:
+        peak_panel = window.bottom_dock.widget().peak_table_panel
+        peak_panel.table.setCurrentCell(1, 0)
+        peak_panel.table.selectRow(1)
+        peak_panel._publish_selected_peak()
+        app.processEvents()
+
+        assert window.analysis_workspace.selected_peak().peak_id == "duplicate-b"
+        assert window.selection_bus.state.peak_id == "duplicate-b"
+        assert window.central_tabs.canvas._selected_peak_id == "duplicate-b"
+        assert window.central_tabs.canvas.plot_item.viewRange()[0] == pytest.approx(
+            (728.8, 741.2), abs=0.1
+        )
+        assert peak_panel.table.item(1, 2).text() == "730.0-740.0"
+
+        roi_bundle = window.central_tabs.canvas._roi_items_by_id[
+            "canonical-duplicate-b-roi"
+        ]
+        roi_bundle.signal.setRegion((732.0, 742.0))
+        app.processEvents()
+        assert peak_panel.table.item(1, 2).text() == "732.0-742.0"
+        window.undo_stack.undo()
+        app.processEvents()
+        assert peak_panel.table.item(1, 2).text() == "730.0-740.0"
+    finally:
+        window.close()
+
+
+def test_canvas_exact_id_selection_updates_the_peak_table() -> None:
+    window, app = _window_with_duplicate_energy_peaks()
+    try:
+        canvas = window.central_tabs.canvas
+        point = next(
+            item
+            for item in canvas._peak_scatter.points()
+            if item.data() == "duplicate-a"
+        )
+        canvas._peak_scatter_clicked(canvas._peak_scatter, [point])
+        app.processEvents()
+
+        peak_panel = window.bottom_dock.widget().peak_table_panel
+        assert window.analysis_workspace.selected_peak().peak_id == "duplicate-a"
+        assert window.selection_bus.state.peak_id == "duplicate-a"
+        assert peak_panel.table.currentRow() == 0
+    finally:
+        window.close()
+
+
+def test_context_edits_persist_and_undo_as_focused_operations(tmp_path) -> None:
+    app = _qapp()
+    window = FluxForgeMainWindow(
+        mode_manager=ModeManager(),
+        selection_bus=SelectionBus(),
+        load_example=True,
+    )
+    window.show()
+    app.processEvents()
+    try:
+        original_peak_ids = {
+            peak.peak_id for peak in window.analysis_workspace.document.peaks
+        }
+        original_roi_ids = {
+            roi.roi_id for roi in window.analysis_workspace.document.rois
+        }
+        canvas = window.central_tabs.canvas
+
+        canvas._prepare_context_menu(500.0)
+        canvas.add_peak_action.trigger()
+        app.processEvents()
+        added_peak = next(
+            peak
+            for peak in window.analysis_workspace.document.peaks
+            if peak.peak_id not in original_peak_ids
+        )
+        assert "re-run required" in window.right_dock.widget().analysis_summary.text()
+
+        canvas._prepare_context_menu(added_peak.centroid_energy_keV)
+        canvas.add_component_action.trigger()
+        app.processEvents()
+        assert (
+            len(
+                window.analysis_workspace.document.peak_by_id(
+                    added_peak.spectrum_id, added_peak.peak_id
+                ).components
+            )
+            == 1
+        )
+
+        canvas._prepare_context_menu(540.0)
+        canvas.create_roi_action.trigger()
+        app.processEvents()
+        added_roi = next(
+            roi
+            for roi in window.analysis_workspace.document.rois
+            if roi.roi_id not in original_roi_ids
+        )
+        assert window.undo_stack.count() == 3
+
+        target = tmp_path / "direct-manipulation.ffs"
+        assert window.save_session(target)
+        persisted = read_ffs_session(target).document
+        assert persisted.roi_by_id(added_roi.roi_id) == added_roi
+        assert (
+            len(
+                persisted.peak_by_id(
+                    added_peak.spectrum_id, added_peak.peak_id
+                ).components
+            )
+            == 1
+        )
+
+        window.undo_stack.undo()
+        window.undo_stack.undo()
+        window.undo_stack.undo()
+        app.processEvents()
+        assert {
+            peak.peak_id for peak in window.analysis_workspace.document.peaks
+        } == original_peak_ids
+        assert {
+            roi.roi_id for roi in window.analysis_workspace.document.rois
+        } == original_roi_ids
+        assert window.selection_bus.state.peak_id is None
+        assert window.selection_bus.state.roi_id is None
+    finally:
+        window.close()
+
+
+def test_invalid_background_drag_reverts_overlay_and_shows_clear_error() -> None:
+    window, app = _window_with_duplicate_energy_peaks()
+    try:
+        canvas = window.central_tabs.canvas
+        roi = window.analysis_workspace.document.roi_by_id("canonical-duplicate-b-roi")
+        assert roi is not None
+        window.central_tabs._sync_analysis_overlays()
+        bundle = canvas._roi_items_by_id[roi.roi_id]
+        original = tuple(bundle.left_background.getRegion())
+        undo_count = window.undo_stack.count()
+
+        bundle.left_background.setRegion((731.0, 735.0))
+        app.processEvents()
+
+        persisted = window.analysis_workspace.document.roi_by_id(roi.roi_id)
+        restored = canvas._roi_items_by_id[roi.roi_id]
+        assert persisted.left_background_range == pytest.approx(original)
+        assert tuple(restored.left_background.getRegion()) == pytest.approx(original)
+        assert window.undo_stack.count() == undo_count
+        assert canvas.status_label.text().startswith("Edit rejected:")
+    finally:
+        window.close()
+
+
+def test_view_actions_and_crosshair_are_canonical_undoable_and_persisted(
+    tmp_path,
+) -> None:
+    window, app = _window_with_duplicate_energy_peaks()
+    try:
+        assert window.undo_stack.count() == 0
+        window._log_scale_action.trigger()
+        app.processEvents()
+        viewport = window.analysis_workspace.document.viewport_by_id("primary-spectrum")
+        assert viewport.log_y
+        assert window.central_tabs.canvas._log_scale
+        assert window._log_scale_action.isChecked()
+
+        window.undo_stack.undo()
+        app.processEvents()
+        assert (
+            window.analysis_workspace.document.viewport_by_id("primary-spectrum")
+            is None
+        )
+        assert not window.central_tabs.canvas._log_scale
+        assert not window._log_scale_action.isChecked()
+        window.undo_stack.redo()
+        app.processEvents()
+        assert window.central_tabs.canvas._log_scale
+        assert window._log_scale_action.isChecked()
+
+        window._peak_labels_action.trigger()
+        app.processEvents()
+        assert not window.central_tabs.canvas._peak_labels_visible
+        window.undo_stack.undo()
+        app.processEvents()
+        assert window.central_tabs.canvas._peak_labels_visible
+        assert window._peak_labels_action.isChecked()
+
+        window.central_tabs.canvas.crosshair_button.click()
+        app.processEvents()
+        assert window.central_tabs.canvas._crosshair_enabled
+        window.undo_stack.undo()
+        app.processEvents()
+        assert not window.central_tabs.canvas._crosshair_enabled
+        window.undo_stack.redo()
+        app.processEvents()
+        assert window.central_tabs.canvas._crosshair_enabled
+
+        target = tmp_path / "viewport.ffs"
+        assert window.save_session(target)
+        persisted = read_ffs_session(target).document.viewport_by_id("primary-spectrum")
+        assert persisted.log_y
+        assert persisted.crosshair_enabled
+    finally:
+        window.close()
+
+
+def test_switching_spectrum_clears_exact_selection_and_retargets_viewport() -> None:
+    window, app = _window_with_duplicate_energy_peaks()
+    try:
+        peak_panel = window.bottom_dock.widget().peak_table_panel
+        peak_panel.table.selectRow(1)
+        peak_panel._publish_selected_peak()
+        assert window.selection_bus.state.peak_id == "duplicate-b"
+
+        window.analysis_workspace.select_spectrum("background")
+        app.processEvents()
+        assert window.selection_bus.state.peak_id is None
+        assert window.selection_bus.state.roi_id is None
+        assert window.central_tabs.canvas._selected_peak_id is None
+
+        window.central_tabs.canvas.crosshair_button.click()
+        app.processEvents()
+        viewport = window.analysis_workspace.document.viewport_by_id("primary-spectrum")
+        assert (
+            viewport.spectrum_id
+            == window.analysis_workspace.document.active_spectrum_id
+        )
+    finally:
+        window.close()

--- a/tests/test_canvas_intent_dispatcher.py
+++ b/tests/test_canvas_intent_dispatcher.py
@@ -1,0 +1,528 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PySide6")
+
+from PySide6.QtGui import QUndoStack
+
+from fluxforge.core.analysis_workspace import ActivityCalculationResult
+from fluxforge.core.workspace_document import (
+    FitDiagnostics,
+    SpectrumRoleAssignment,
+    WorkspaceDocument,
+    WorkspaceSpectrum,
+)
+from fluxforge.gui.analysis_workspace import AnalysisWorkspaceController
+from fluxforge.gui.canvas_controller import CanvasIntentDispatcher
+from fluxforge.gui.canvas_intents import CanvasIntent, CanvasIntentKind
+from fluxforge.gui.selection_bus import SelectionBus
+from fluxforge.io.spe import GammaSpectrum
+
+
+def _document() -> WorkspaceDocument:
+    spectrum = GammaSpectrum(
+        counts=np.asarray([2.0, 8.0, 5.0, 1.0]),
+        channels=np.arange(4, dtype=float),
+        energies=np.asarray([100.0, 101.0, 102.0, 103.0]),
+        live_time=10.0,
+        real_time=11.0,
+        spectrum_id="spec-1",
+    )
+    return WorkspaceDocument(
+        spectra=(
+            WorkspaceSpectrum(
+                spectrum_id="spec-1",
+                spectrum=spectrum,
+                label="Direct manipulation",
+            ),
+        ),
+        spectrum_roles=(
+            SpectrumRoleAssignment(role="foreground", spectrum_ids=("spec-1",)),
+        ),
+        active_spectrum_id="spec-1",
+    )
+
+
+def _dispatcher():
+    controller = AnalysisWorkspaceController(_document())
+    selection = SelectionBus()
+    stack = QUndoStack()
+    counts: dict[str, int] = {}
+
+    def next_id(prefix: str) -> str:
+        counts[prefix] = counts.get(prefix, 0) + 1
+        return f"{prefix}-{counts[prefix]}"
+
+    return (
+        CanvasIntentDispatcher(
+            controller,
+            selection,
+            undo_stack=stack,
+            id_factory=next_id,
+        ),
+        controller,
+        selection,
+        stack,
+    )
+
+
+def _create_roi(dispatcher: CanvasIntentDispatcher) -> None:
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.CREATE_ROI,
+            spectrum_id="spec-1",
+            bounds=(100.8, 102.2),
+            left_background=(99.8, 100.6),
+            right_background=(102.4, 103.2),
+        )
+    )
+
+
+def _add_peak(dispatcher: CanvasIntentDispatcher) -> None:
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.ADD_PEAK,
+            spectrum_id="spec-1",
+            position=101.1,
+        )
+    )
+
+
+def _activity_result() -> ActivityCalculationResult:
+    return ActivityCalculationResult(
+        nuclide="Co60",
+        line_energy_keV=1173.2,
+        activity_bq=5.0,
+        uncertainty_bq=0.5,
+        age_corrected_activity_bq=6.0,
+        mda_bq=0.1,
+        half_life_s=1.0e8,
+        source_age_s=100.0,
+        chain_summary="test fixture",
+    )
+
+
+def _diagnostic(
+    controller: AnalysisWorkspaceController,
+    diagnostic_id: str,
+) -> FitDiagnostics:
+    return next(
+        item
+        for item in controller.document.fit_diagnostics
+        if item.diagnostic_id == diagnostic_id
+    )
+
+
+def test_shift_drag_roi_intent_creates_one_undoable_canonical_edit() -> None:
+    dispatcher, controller, selection, stack = _dispatcher()
+
+    _create_roi(dispatcher)
+
+    assert stack.count() == 1
+    roi = controller.document.roi_by_id("roi-1")
+    assert roi is not None
+    assert roi.signal_range == pytest.approx((100.8, 102.2))
+    assert roi.left_background_range == pytest.approx((99.8, 100.6))
+    assert roi.right_background_range == pytest.approx((102.4, 103.2))
+    assert (
+        controller.document.viewport_by_id("primary-spectrum").selected_roi_id
+        == "roi-1"
+    )
+    assert selection.state.roi_id == "roi-1"
+
+    stack.undo()
+    assert controller.document.rois == ()
+    assert controller.document.viewport_by_id("primary-spectrum") is None
+    stack.redo()
+    assert controller.document.roi_by_id("roi-1") is not None
+
+
+def test_roi_and_background_moves_commit_once_and_restore_exactly() -> None:
+    dispatcher, controller, _selection, stack = _dispatcher()
+    _create_roi(dispatcher)
+    original = controller.document.roi_by_id("roi-1")
+    stack.clear()
+
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.MOVE_ROI,
+            spectrum_id="spec-1",
+            roi_id="roi-1",
+            bounds=(101.0, 102.5),
+            drag_token="signal-drag",
+        )
+    )
+    moved = controller.document.roi_by_id("roi-1")
+    assert stack.count() == 1
+    assert moved.signal_range == pytest.approx((101.0, 102.5))
+    stack.undo()
+    assert controller.document.roi_by_id("roi-1") == original
+    stack.redo()
+
+    before_background = controller.document.roi_by_id("roi-1")
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.MOVE_BACKGROUND,
+            spectrum_id="spec-1",
+            roi_id="roi-1",
+            left_background=(99.5, 100.5),
+            right_background=(102.8, 103.8),
+            drag_token="background-drag",
+        )
+    )
+    assert controller.document.roi_by_id(
+        "roi-1"
+    ).left_background_range == pytest.approx((99.5, 100.5))
+    stack.undo()
+    assert controller.document.roi_by_id("roi-1") == before_background
+
+
+def test_peak_add_select_move_delete_and_undo_use_exact_ids() -> None:
+    dispatcher, controller, selection, stack = _dispatcher()
+    controller.set_activity_results((_activity_result(),))
+    original_workflow = controller.document.workflow_state
+    _add_peak(dispatcher)
+    peak = controller.document.peak_by_id("spec-1", "peak-1")
+    assert peak is not None
+    assert selection.state.peak_id == "peak-1"
+    assert (
+        controller.document.workflow_state["analysis_invalidation"][
+            "requires_reanalysis"
+        ]
+        is True
+    )
+    assert controller.state.activity_results == ()
+    stack.undo()
+    assert controller.document.workflow_state == original_workflow
+    assert len(controller.state.activity_results) == 1
+    stack.redo()
+
+    peak = controller.document.peak_by_id("spec-1", "peak-1")
+    fitted_peak = replace(
+        peak,
+        status="accepted",
+        fit_quality=0.99,
+        normalized_residuals=(0.25,),
+        residual_channels=(1.0,),
+    )
+    unrelated_peak = replace(
+        peak,
+        peak_id="peak-unrelated",
+        centroid_channel=2.0,
+        centroid_energy_keV=102.0,
+        fit_quality=0.88,
+        normalized_residuals=(0.5,),
+        residual_channels=(2.0,),
+    )
+    controller.upsert_peak_model(fitted_peak)
+    controller.upsert_peak_model(unrelated_peak)
+    fitted_diagnostic = FitDiagnostics(
+        diagnostic_id="diag-peak-1",
+        spectrum_id="spec-1",
+        peak_id="peak-1",
+        fit_revision=1,
+        status="valid",
+        x=(1.0,),
+        observed=(8.0,),
+        model=(7.8,),
+        uncertainty=(2.0,),
+        normalized_residuals=(0.1,),
+        goodness_of_fit={"chi_squared": 0.01},
+        method="fixture",
+    )
+    unrelated_diagnostic = replace(
+        fitted_diagnostic,
+        diagnostic_id="diag-unrelated",
+        peak_id="peak-unrelated",
+        x=(2.0,),
+    )
+    controller.upsert_fit_diagnostic(fitted_diagnostic)
+    controller.upsert_fit_diagnostic(unrelated_diagnostic)
+    peak = fitted_peak
+
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.MOVE_PEAK,
+            spectrum_id="spec-1",
+            peak_id="peak-1",
+            position=102.4,
+            drag_token="peak-drag",
+        )
+    )
+    assert controller.document.peak_by_id(
+        "spec-1", "peak-1"
+    ).centroid_energy_keV == pytest.approx(102.4)
+    moved_peak = controller.document.peak_by_id("spec-1", "peak-1")
+    assert moved_peak.fit_quality == 0.0
+    assert moved_peak.normalized_residuals == ()
+    assert _diagnostic(controller, "diag-peak-1").status == "invalid"
+    assert _diagnostic(controller, "diag-unrelated").status == "valid"
+    assert controller.document.peak_by_id(
+        "spec-1", "peak-unrelated"
+    ).fit_quality == pytest.approx(0.88)
+    stack.undo()
+    assert controller.document.peak_by_id("spec-1", "peak-1") == peak
+    assert _diagnostic(controller, "diag-peak-1") == fitted_diagnostic
+    assert _diagnostic(controller, "diag-unrelated") == unrelated_diagnostic
+    stack.redo()
+
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.DELETE_PEAK,
+            spectrum_id="spec-1",
+            peak_id="peak-1",
+        )
+    )
+    assert controller.document.peak_by_id("spec-1", "peak-1") is None
+    stack.undo()
+    assert controller.document.peak_by_id("spec-1", "peak-1") is not None
+
+
+def test_roi_association_and_shared_fit_invalidation_are_reciprocal_and_undoable() -> (
+    None
+):
+    dispatcher, controller, _selection, stack = _dispatcher()
+    _add_peak(dispatcher)
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.ADD_PEAK,
+            spectrum_id="spec-1",
+            position=101.8,
+        )
+    )
+    for peak_id, residual in (("peak-1", 0.2), ("peak-2", -0.4)):
+        peak = controller.document.peak_by_id("spec-1", peak_id)
+        controller.upsert_peak_model(
+            replace(
+                peak,
+                status="accepted",
+                fit_quality=0.95,
+                normalized_residuals=(residual,),
+                residual_channels=(peak.centroid_channel,),
+            )
+        )
+        controller.upsert_fit_diagnostic(
+            FitDiagnostics(
+                diagnostic_id=f"diag-{peak_id}",
+                spectrum_id="spec-1",
+                peak_id=peak_id,
+                fit_revision=1,
+                status="valid",
+                x=(peak.centroid_channel,),
+                observed=(8.0,),
+                model=(7.5,),
+                uncertainty=(2.0,),
+                normalized_residuals=(residual,),
+                method="fixture",
+            )
+        )
+
+    _create_roi(dispatcher)
+    roi = controller.document.roi_by_id("roi-1")
+    assert roi.associated_peak_ids == ("peak-1", "peak-2")
+    assert {
+        controller.document.peak_by_id("spec-1", peak_id).roi_id
+        for peak_id in roi.associated_peak_ids
+    } == {"roi-1"}
+    assert all(
+        controller.document.peak_by_id("spec-1", peak_id).normalized_residuals == ()
+        for peak_id in roi.associated_peak_ids
+    )
+    assert all(
+        _diagnostic(controller, f"diag-{peak_id}").status == "invalid"
+        for peak_id in roi.associated_peak_ids
+    )
+
+    stack.undo()
+    assert controller.document.roi_by_id("roi-1") is None
+    assert all(
+        controller.document.peak_by_id("spec-1", peak_id).roi_id is None
+        for peak_id in ("peak-1", "peak-2")
+    )
+    assert all(
+        _diagnostic(controller, f"diag-{peak_id}").status == "valid"
+        for peak_id in ("peak-1", "peak-2")
+    )
+    stack.redo()
+
+    for peak_id, residual in (("peak-1", 0.2), ("peak-2", -0.4)):
+        peak = controller.document.peak_by_id("spec-1", peak_id)
+        controller.upsert_peak_model(
+            replace(
+                peak,
+                status="accepted",
+                fit_quality=0.97,
+                normalized_residuals=(residual,),
+                residual_channels=(peak.centroid_channel,),
+            )
+        )
+        diagnostic = _diagnostic(controller, f"diag-{peak_id}")
+        controller.upsert_fit_diagnostic(
+            replace(
+                diagnostic,
+                roi_id="roi-1",
+                status="valid",
+                x=(peak.centroid_channel,),
+                observed=(8.0,),
+                model=(7.5,),
+                uncertainty=(2.0,),
+                normalized_residuals=(residual,),
+                goodness_of_fit={"chi_squared": 0.02},
+                warning_flags=(),
+            )
+        )
+
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.MOVE_ROI,
+            spectrum_id="spec-1",
+            roi_id="roi-1",
+            bounds=(100.9, 102.4),
+            drag_token="shared-roi",
+        )
+    )
+    assert all(
+        controller.document.peak_by_id("spec-1", peak_id).status == "invalidated"
+        for peak_id in ("peak-1", "peak-2")
+    )
+    assert all(
+        _diagnostic(controller, f"diag-{peak_id}").status == "invalid"
+        for peak_id in ("peak-1", "peak-2")
+    )
+    stack.undo()
+    assert all(
+        controller.document.peak_by_id("spec-1", peak_id).status == "accepted"
+        for peak_id in ("peak-1", "peak-2")
+    )
+
+
+def test_completed_reanalysis_clears_the_stale_result_marker() -> None:
+    dispatcher, controller, _selection, _stack = _dispatcher()
+    _add_peak(dispatcher)
+    assert "analysis_invalidation" in controller.document.workflow_state
+
+    controller.set_activity_results((_activity_result(),))
+
+    assert "analysis_invalidation" not in controller.document.workflow_state
+    assert len(controller.state.activity_results) == 1
+
+
+def test_peak_context_edits_preserve_assignments_tags_components_and_pins() -> None:
+    dispatcher, controller, _selection, stack = _dispatcher()
+    _add_peak(dispatcher)
+
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.ASSIGN_NUCLIDE,
+            spectrum_id="spec-1",
+            peak_id="peak-1",
+            nuclide="Cs-137",
+        )
+    )
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.TAG_PEAK,
+            spectrum_id="spec-1",
+            peak_id="peak-1",
+            tag="reviewed",
+        )
+    )
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.TAG_NUCLIDE,
+            nuclide="Cs-137",
+            tag="benchmark",
+        )
+    )
+    assert controller.document.nuclide_tags["Cs-137"] == ("benchmark",)
+    stack.undo()
+    assert "Cs-137" not in controller.document.nuclide_tags
+    stack.redo()
+    assert controller.document.nuclide_tags["Cs-137"] == ("benchmark",)
+
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.ADD_COMPONENT,
+            spectrum_id="spec-1",
+            peak_id="peak-1",
+            position=101.0,
+        )
+    )
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.SPLIT_PEAK,
+            spectrum_id="spec-1",
+            peak_id="peak-1",
+            component_ids=("component-1",),
+        )
+    )
+    peak = controller.document.peak_by_id("spec-1", "peak-1")
+    assert peak.assignments[0].nuclide == "Cs-137"
+    assert peak.assignments[0].provenance["source"] == "canvas_context_menu"
+    assert peak.tags == ("reviewed",)
+    assert controller.document.nuclide_tags["Cs-137"] == ("benchmark",)
+    assert len(peak.components) == 2
+
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.MERGE_PEAKS,
+            spectrum_id="spec-1",
+            peak_id="peak-1",
+            component_ids=tuple(item.component_id for item in peak.components),
+        )
+    )
+    assert len(controller.document.peak_by_id("spec-1", "peak-1").components) == 1
+
+    dispatcher.handle(CanvasIntent(CanvasIntentKind.PIN_NUCLIDE, nuclide="Co60"))
+    assert controller.document.pinned_nuclides == ("Co60",)
+    pinned_cascade = controller.state.cascade_sum_lines_keV
+    assert pinned_cascade
+    dispatcher.handle(CanvasIntent(CanvasIntentKind.UNPIN_NUCLIDE, nuclide="Co60"))
+    assert controller.document.pinned_nuclides == ()
+    assert controller.state.cascade_sum_lines_keV == ()
+    stack.undo()
+    assert controller.document.pinned_nuclides == ("Co60",)
+    assert controller.state.cascade_sum_lines_keV == pinned_cascade
+
+
+def test_role_and_viewport_intents_are_focused_and_undoable() -> None:
+    dispatcher, controller, _selection, stack = _dispatcher()
+
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.ASSIGN_SPECTRUM_ROLE,
+            spectrum_id="spec-1",
+            role="foreground",
+        )
+    )
+    assert stack.count() == 0
+    assert "analysis_invalidation" not in controller.document.workflow_state
+
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.ASSIGN_SPECTRUM_ROLE,
+            spectrum_id="spec-1",
+            role="background",
+        )
+    )
+    assert next(
+        item for item in controller.document.spectrum_roles if item.role == "background"
+    ).spectrum_ids == ("spec-1",)
+    stack.undo()
+    assert all(item.role != "background" for item in controller.document.spectrum_roles)
+
+    dispatcher.handle(
+        CanvasIntent(
+            CanvasIntentKind.TOGGLE_CROSSHAIR,
+            spectrum_id="spec-1",
+            viewport_id="primary-spectrum",
+            enabled=True,
+        )
+    )
+    assert controller.document.viewport_by_id("primary-spectrum").crosshair_enabled
+    stack.undo()
+    assert controller.document.viewport_by_id("primary-spectrum") is None

--- a/tests/test_production_gui_mode.py
+++ b/tests/test_production_gui_mode.py
@@ -97,6 +97,9 @@ def test_production_startup_is_empty_and_examples_are_explicit(tmp_path):
     assert window.analysis_workspace.spectrum() is None
     assert window.file_label.text() == "File: none"
     assert window.qa_monitor.history() == ()
+    assert window.selection_bus.state == window.selection_bus.state.__class__()
+    assert window.left_dock.widget().nuclides.count() == 0
+    assert window.central_tabs.canvas.header_label.text() == "Live spectrum canvas"
     assert (
         "No QA or standards result" in window.left_dock.widget().qa_note.toPlainText()
     )

--- a/tests/test_pyqtgraph_direct_interactions.py
+++ b/tests/test_pyqtgraph_direct_interactions.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+
+import pytest
+
+from fluxforge.gui import QT_AVAILABLE, SelectionBus
+from fluxforge.gui.backends import PYQTGRAPH_AVAILABLE, PyQtGraphSpectrumCanvas
+from fluxforge.gui.backends import pyqtgraph_backend as backend_module
+from fluxforge.gui.canvas_intents import CanvasIntentKind
+from fluxforge.gui.qt_compat import QApplication, Qt
+from fluxforge.gui.spectrum_canvas import (
+    CanvasPeakOverlay,
+    CanvasROIOverlay,
+    SpectrumTrace,
+)
+
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+pytestmark = pytest.mark.skipif(
+    not (QT_AVAILABLE and PYQTGRAPH_AVAILABLE),
+    reason="Qt spectrum renderer dependencies are unavailable.",
+)
+
+
+if QT_AVAILABLE:
+    from PySide6.QtCore import QPointF
+    from PySide6.QtGui import QAction
+    from PySide6.QtTest import QTest
+
+
+def _qapp() -> QApplication:
+    return QApplication.instance() or QApplication([])
+
+
+def _canvas() -> PyQtGraphSpectrumCanvas:
+    app = _qapp()
+    canvas = PyQtGraphSpectrumCanvas(selection_bus=SelectionBus())
+    canvas.resize(1000, 640)
+    canvas.show()
+    canvas.set_interaction_context("spectrum-1")
+    canvas.set_traces(
+        (
+            SpectrumTrace(
+                label="Foreground",
+                counts=tuple(float((index % 19) + 1) for index in range(101)),
+                channels=tuple(float(index) for index in range(101)),
+                x_axis_label="Energy (keV)",
+            ),
+        )
+    )
+    canvas.plot_item.setXRange(0.0, 100.0, padding=0.0)
+    canvas.plot_item.setYRange(0.0, 25.0, padding=0.0)
+    app.processEvents()
+    return canvas
+
+
+def _viewport_point(canvas: PyQtGraphSpectrumCanvas, x: float, y: float = 12.0):
+    scene_position = canvas.plot_item.getViewBox().mapViewToScene(QPointF(x, y))
+    return canvas.plot.mapFromScene(scene_position)
+
+
+def _overlays():
+    return (
+        CanvasROIOverlay(
+            roi_id="roi-1",
+            spectrum_id="spectrum-1",
+            signal_range=(40.0, 50.0),
+            left_background_range=(30.0, 38.0),
+            right_background_range=(52.0, 60.0),
+            selected=True,
+        ),
+    ), (
+        CanvasPeakOverlay(
+            peak_id="peak-1",
+            spectrum_id="spectrum-1",
+            position=45.0,
+            y_value=18.0,
+            component_ids=("component-a", "component-b"),
+            nuclide="Co60",
+            tags=("reviewed",),
+            pinned=False,
+            selected=True,
+        ),
+    )
+
+
+def test_shift_drag_previews_and_emits_one_complete_create_roi_intent() -> None:
+    app = _qapp()
+    canvas = _canvas()
+    intents = []
+    canvas.set_intent_sink(intents.append)
+    viewport = canvas.plot.viewport()
+
+    start = _viewport_point(canvas, 25.0)
+    middle = _viewport_point(canvas, 30.0)
+    finish = _viewport_point(canvas, 35.0)
+    QTest.mousePress(viewport, Qt.LeftButton, Qt.ShiftModifier, start)
+    QTest.mouseMove(viewport, middle, delay=20)
+    app.processEvents()
+    assert canvas._shift_drag_preview is not None
+    assert canvas._shift_drag_preview.isVisible()
+    QTest.mouseMove(viewport, finish, delay=20)
+    QTest.mouseRelease(viewport, Qt.LeftButton, Qt.ShiftModifier, finish)
+    app.processEvents()
+
+    assert canvas._shift_drag_preview is None
+    assert len(intents) == 1
+    intent = intents[0]
+    assert intent.kind is CanvasIntentKind.CREATE_ROI
+    assert intent.spectrum_id == "spectrum-1"
+    # Integer viewport coordinates map back to slightly different values across
+    # Windows and Linux Qt platform plugins.
+    assert intent.bounds == pytest.approx((25.0, 35.0), abs=2.0)
+    assert intent.left_background is not None
+    assert intent.right_background is not None
+    assert intent.left_background[1] == pytest.approx(intent.bounds[0])
+    assert intent.right_background[0] == pytest.approx(intent.bounds[1])
+    assert intent.drag_token.startswith("roi-create-")
+    canvas.close()
+
+
+def test_canonical_roi_regions_emit_one_finished_signal_or_background_move() -> None:
+    canvas = _canvas()
+    intents = []
+    canvas.subscribe_intents(intents.append)
+    rois, peaks = _overlays()
+    canvas.set_analysis_overlays(
+        rois,
+        peaks,
+        selected_roi_id="roi-1",
+        selected_peak_id="peak-1",
+    )
+
+    bundle = canvas._roi_items_by_id["roi-1"]
+    bundle.signal.setRegion((41.0, 51.0))
+    assert len(intents) == 1
+    assert intents[0].kind is CanvasIntentKind.MOVE_ROI
+    assert intents[0].roi_id == "roi-1"
+    assert intents[0].bounds == pytest.approx((41.0, 51.0))
+    assert intents[0].left_background == pytest.approx((30.0, 38.0))
+    assert intents[0].right_background == pytest.approx((52.0, 60.0))
+
+    bundle.left_background.setRegion((29.0, 37.0))
+    assert len(intents) == 2
+    assert intents[1].kind is CanvasIntentKind.MOVE_BACKGROUND
+    assert intents[1].roi_id == "roi-1"
+    assert intents[1].left_background == pytest.approx((29.0, 37.0))
+    assert intents[1].right_background == pytest.approx((52.0, 60.0))
+    canvas.close()
+
+
+def test_exact_peak_selection_and_finished_centroid_move_emit_exact_ids() -> None:
+    canvas = _canvas()
+    intents = []
+    canvas.set_intent_sink(intents.append)
+    rois, peaks = _overlays()
+    duplicate = CanvasPeakOverlay(
+        peak_id="peak-duplicate",
+        spectrum_id="spectrum-1",
+        position=45.0,
+        y_value=10.0,
+    )
+    canvas.set_analysis_overlays(
+        rois,
+        peaks + (duplicate,),
+        selected_roi_id="roi-1",
+        selected_peak_id="peak-1",
+    )
+
+    point = next(
+        point
+        for point in canvas._peak_scatter.points()
+        if point.data() == "peak-duplicate"
+    )
+    canvas._peak_scatter_clicked(canvas._peak_scatter, [point])
+    assert len(intents) == 1
+    assert intents[0].kind is CanvasIntentKind.SELECT_PEAK
+    assert intents[0].peak_id == "peak-duplicate"
+
+    duplicate_roi = replace(rois[0], roi_id="roi-duplicate", selected=True)
+    canvas.set_analysis_overlays(
+        rois + (duplicate_roi,),
+        peaks + (duplicate,),
+        selected_roi_id="roi-duplicate",
+        selected_peak_id="peak-duplicate",
+    )
+    intents.clear()
+    canvas._prepare_context_menu(45.0)
+    assert canvas._context_peak_id == "peak-duplicate"
+    assert canvas._context_roi_id == "roi-duplicate"
+    canvas.move_peak_action.trigger()
+    canvas.delete_roi_action.trigger()
+    assert intents[0].peak_id == "peak-duplicate"
+    assert intents[1].roi_id == "roi-duplicate"
+
+    canvas.set_analysis_overlays(
+        rois,
+        peaks,
+        selected_roi_id="roi-1",
+        selected_peak_id="peak-1",
+    )
+    intents.clear()
+    canvas._selected_peak_line.setPos(47.25)
+    canvas._selected_peak_line.sigPositionChangeFinished.emit(
+        canvas._selected_peak_line
+    )
+    assert len(intents) == 1
+    assert intents[0].kind is CanvasIntentKind.MOVE_PEAK
+    assert intents[0].spectrum_id == "spectrum-1"
+    assert intents[0].peak_id == "peak-1"
+    assert intents[0].position == pytest.approx(47.25)
+    assert intents[0].drag_token.startswith("peak-")
+    canvas.close()
+
+
+def test_real_mouse_drag_of_selected_centroid_emits_once_on_release() -> None:
+    app = _qapp()
+    canvas = _canvas()
+    intents = []
+    canvas.set_intent_sink(intents.append)
+    rois, peaks = _overlays()
+    canvas.set_analysis_overlays(
+        rois,
+        peaks,
+        selected_roi_id="roi-1",
+        selected_peak_id="peak-1",
+    )
+    viewport = canvas.plot.viewport()
+    start = _viewport_point(canvas, 45.0, 12.0)
+    finish = _viewport_point(canvas, 48.0, 12.0)
+
+    QTest.mousePress(viewport, Qt.LeftButton, pos=start)
+    QTest.mouseMove(viewport, finish, delay=30)
+    app.processEvents()
+    assert intents == []
+    QTest.mouseRelease(viewport, Qt.LeftButton, pos=finish)
+    app.processEvents()
+
+    assert len(intents) == 1
+    assert intents[0].kind is CanvasIntentKind.MOVE_PEAK
+    assert intents[0].peak_id == "peak-1"
+    assert intents[0].position == pytest.approx(48.0, abs=1.2)
+    canvas.close()
+
+
+def test_real_mouse_drag_of_roi_signal_handle_emits_once_on_release() -> None:
+    app = _qapp()
+    canvas = _canvas()
+    intents = []
+    canvas.set_intent_sink(intents.append)
+    rois, peaks = _overlays()
+    canvas.set_analysis_overlays(
+        rois,
+        peaks,
+        selected_roi_id="roi-1",
+        selected_peak_id="peak-1",
+    )
+    viewport = canvas.plot.viewport()
+    start = _viewport_point(canvas, 40.0, 12.0)
+    finish = _viewport_point(canvas, 42.0, 12.0)
+
+    QTest.mousePress(viewport, Qt.LeftButton, pos=start)
+    QTest.mouseMove(viewport, finish, delay=30)
+    app.processEvents()
+    assert intents == []
+    QTest.mouseRelease(viewport, Qt.LeftButton, pos=finish)
+    app.processEvents()
+
+    assert len(intents) == 1
+    assert intents[0].kind is CanvasIntentKind.MOVE_ROI
+    assert intents[0].roi_id == "roi-1"
+    assert intents[0].bounds == pytest.approx((42.0, 50.0), abs=1.2)
+    canvas.close()
+
+
+@pytest.mark.parametrize(
+    ("part", "start_x", "finish_x", "expected"),
+    (
+        ("left_background", 30.0, 28.0, (28.0, 38.0)),
+        ("right_background", 60.0, 62.0, (52.0, 62.0)),
+    ),
+)
+def test_real_mouse_drag_of_each_background_handle_emits_once_on_release(
+    part: str,
+    start_x: float,
+    finish_x: float,
+    expected: tuple[float, float],
+) -> None:
+    app = _qapp()
+    canvas = _canvas()
+    intents = []
+    canvas.set_intent_sink(intents.append)
+    rois, peaks = _overlays()
+    canvas.set_analysis_overlays(
+        rois,
+        peaks,
+        selected_roi_id="roi-1",
+        selected_peak_id="peak-1",
+    )
+    viewport = canvas.plot.viewport()
+    start = _viewport_point(canvas, start_x, 12.0)
+    finish = _viewport_point(canvas, finish_x, 12.0)
+
+    QTest.mousePress(viewport, Qt.LeftButton, pos=start)
+    QTest.mouseMove(viewport, finish, delay=30)
+    app.processEvents()
+    assert intents == []
+    QTest.mouseRelease(viewport, Qt.LeftButton, pos=finish)
+    app.processEvents()
+
+    assert len(intents) == 1
+    assert intents[0].kind is CanvasIntentKind.MOVE_BACKGROUND
+    assert intents[0].roi_id == "roi-1"
+    moved = getattr(intents[0], part)
+    if part == "left_background":
+        assert moved[0] < start_x
+        assert moved[1] == pytest.approx(expected[1], abs=0.25)
+    else:
+        assert moved[0] == pytest.approx(expected[0], abs=0.25)
+        assert moved[1] > start_x
+    canvas.close()
+
+
+def test_context_menu_actions_are_persistent_and_emit_scientific_intents(
+    monkeypatch,
+) -> None:
+    app = _qapp()
+    canvas = _canvas()
+    intents = []
+    canvas.set_intent_sink(intents.append)
+    rois, peaks = _overlays()
+    canvas.set_analysis_overlays(
+        rois,
+        peaks,
+        selected_roi_id="roi-1",
+        selected_peak_id="peak-1",
+    )
+    QTest.mouseClick(
+        canvas.plot.viewport(),
+        Qt.RightButton,
+        pos=_viewport_point(canvas, 45.0),
+    )
+    app.processEvents()
+    assert canvas.context_menu.isVisible()
+    canvas.context_menu.hide()
+    canvas._prepare_context_menu(45.0)
+    responses = iter((("Cs-137", True), ("reviewed-again", True), ("benchmark", True)))
+    monkeypatch.setattr(
+        backend_module.QInputDialog,
+        "getText",
+        staticmethod(lambda *_args, **_kwargs: next(responses)),
+    )
+
+    object_names = {
+        action.objectName()
+        for action in canvas.context_menu.actions()
+        if action.objectName()
+    }
+    assert {
+        "CanvasContextAddPeakAction",
+        "CanvasContextSelectPeakAction",
+        "CanvasContextMovePeakAction",
+        "CanvasContextDeletePeakAction",
+        "CanvasContextAssignNuclideAction",
+        "CanvasContextClearNuclideAction",
+        "CanvasContextPinNuclideAction",
+        "CanvasContextUnpinNuclideAction",
+        "CanvasContextTagPeakAction",
+        "CanvasContextTagNuclideAction",
+        "CanvasContextAddComponentAction",
+        "CanvasContextSplitPeakAction",
+        "CanvasContextMergePeaksAction",
+        "CanvasContextSelectRoiAction",
+        "CanvasContextDeleteRoiAction",
+        "CanvasContextCreateRoiAction",
+        "CanvasContextResetViewAction",
+        "CanvasContextCrosshairAction",
+        "ExportSpectrumPlotAction",
+    }.issubset(object_names)
+
+    export_action = next(
+        (
+            action
+            for action in canvas.context_menu.actions()
+            if action.objectName() == "ExportSpectrumPlotAction"
+        ),
+        None,
+    )
+    assert export_action is not None
+    export_action.trigger()
+    app.processEvents()
+    assert canvas.plot.scene().exportDialog is not None
+    assert canvas.plot.scene().exportDialog.isVisible()
+    canvas.plot.scene().exportDialog.close()
+
+    for action in (
+        canvas.add_peak_action,
+        canvas.select_peak_action,
+        canvas.move_peak_action,
+        canvas.delete_peak_action,
+        canvas.assign_nuclide_action,
+        canvas.clear_nuclide_action,
+    ):
+        action.trigger()
+    assert canvas.pin_nuclide_action.isEnabled()
+    assert not canvas.unpin_nuclide_action.isEnabled()
+    canvas.pin_nuclide_action.trigger()
+    canvas.set_analysis_overlays(
+        rois,
+        (replace(peaks[0], pinned=True),),
+        selected_roi_id="roi-1",
+        selected_peak_id="peak-1",
+    )
+    canvas._prepare_context_menu(45.0)
+    assert not canvas.pin_nuclide_action.isEnabled()
+    assert canvas.unpin_nuclide_action.isEnabled()
+    canvas.unpin_nuclide_action.trigger()
+    for action in (
+        canvas.tag_peak_action,
+        canvas.tag_nuclide_action,
+        canvas.add_component_action,
+        canvas.split_peak_action,
+        canvas.merge_peaks_action,
+        canvas.select_roi_action,
+        canvas.delete_roi_action,
+        canvas.create_roi_action,
+    ):
+        action.trigger()
+    for object_name in (
+        "CanvasContextForegroundRoleAction",
+        "CanvasContextBackgroundRoleAction",
+        "CanvasContextSecondaryRoleAction",
+    ):
+        action = canvas.context_menu.findChild(QAction, object_name)
+        assert action is not None
+        action.trigger()
+    emitted_kinds = [intent.kind for intent in intents]
+    assert emitted_kinds == [
+        CanvasIntentKind.ADD_PEAK,
+        CanvasIntentKind.SELECT_PEAK,
+        CanvasIntentKind.MOVE_PEAK,
+        CanvasIntentKind.DELETE_PEAK,
+        CanvasIntentKind.ASSIGN_NUCLIDE,
+        CanvasIntentKind.CLEAR_NUCLIDE,
+        CanvasIntentKind.PIN_NUCLIDE,
+        CanvasIntentKind.UNPIN_NUCLIDE,
+        CanvasIntentKind.TAG_PEAK,
+        CanvasIntentKind.TAG_NUCLIDE,
+        CanvasIntentKind.ADD_COMPONENT,
+        CanvasIntentKind.SPLIT_PEAK,
+        CanvasIntentKind.MERGE_PEAKS,
+        CanvasIntentKind.SELECT_ROI,
+        CanvasIntentKind.DELETE_ROI,
+        CanvasIntentKind.CREATE_ROI,
+        CanvasIntentKind.ASSIGN_SPECTRUM_ROLE,
+        CanvasIntentKind.ASSIGN_SPECTRUM_ROLE,
+        CanvasIntentKind.ASSIGN_SPECTRUM_ROLE,
+    ]
+    assert [intent.role for intent in intents[-3:]] == [
+        "foreground",
+        "background",
+        "secondary",
+    ]
+    canvas.close()
+
+
+def test_crosshair_button_emits_toggle_intent_updates_readout_and_zoom_api() -> None:
+    app = _qapp()
+    canvas = _canvas()
+    intents = []
+    canvas.set_intent_sink(intents.append)
+
+    QTest.mouseClick(canvas.crosshair_button, Qt.LeftButton)
+    app.processEvents()
+    assert canvas._crosshair_enabled
+    assert canvas.crosshair_readout.isVisible()
+    assert intents[-1].kind is CanvasIntentKind.TOGGLE_CROSSHAIR
+    assert intents[-1].enabled is True
+
+    QTest.mouseMove(canvas.plot.viewport(), _viewport_point(canvas, 55.0, 10.0))
+    app.processEvents()
+    if "--" in canvas.crosshair_readout.text():
+        # Linux's offscreen platform does not always synthesize hover delivery;
+        # exercise the same scene-coordinate callback deterministically.
+        canvas._move_crosshair(
+            canvas.plot.mapToScene(_viewport_point(canvas, 55.0, 10.0))
+        )
+    assert "--" not in canvas.crosshair_readout.text()
+
+    canvas.zoom_to_range(40.0, 50.0, padding_fraction=0.1)
+    x_range = canvas.plot_item.viewRange()[0]
+    assert x_range == pytest.approx((39.0, 51.0), abs=0.05)
+
+    intents.clear()
+    QTest.mouseClick(canvas.zoom_in_button, Qt.LeftButton)
+    QTest.qWait(180)
+    app.processEvents()
+    assert [intent.kind for intent in intents] == [CanvasIntentKind.CHANGE_VIEWPORT]
+    assert intents[0].viewport_id == "primary-spectrum"
+    assert intents[0].x_range is not None
+    assert intents[0].y_range is not None
+    canvas.close()

--- a/tests/test_workspace_undo.py
+++ b/tests/test_workspace_undo.py
@@ -36,6 +36,7 @@ from fluxforge.gui.workspace_undo import (
     UpdateDetectorProfileCommand,
     UpdatePeakAssignmentCommand,
     UpdatePeakCommand,
+    UpdateWorkflowStateCommand,
     UpsertROICommand,
 )
 from fluxforge.io.spe import GammaSpectrum
@@ -50,6 +51,7 @@ class FakeLeafController:
         self.viewports: dict[str, CanvasViewport] = {}
         self.diagnostics: dict[str, FitDiagnostics] = {}
         self.pinned: tuple[str, ...] = ()
+        self.workflow_state: dict = {}
         self.calibrations: dict[str, CalibrationModel | DetectorProfile | None] = {}
 
     def replace_peak_models(self, peaks, *, spectrum_id=None):
@@ -115,6 +117,9 @@ class FakeLeafController:
 
     def set_pinned_nuclides(self, pinned_nuclides):
         self.pinned = tuple(pinned_nuclides)
+
+    def set_workflow_state(self, workflow_state):
+        self.workflow_state = dict(workflow_state)
 
     def apply_calibration(self, spectrum_id, calibration_state):
         self.calibrations[spectrum_id] = calibration_state
@@ -343,6 +348,16 @@ def test_assignment_pin_roi_role_profile_viewport_and_calibration_commands():
     pin.undo()
     assert controller.pinned == ("Co-60",)
 
+    workflow = UpdateWorkflowStateCommand(
+        controller,
+        before={"analysis": {"status": "valid"}},
+        after={"analysis": {"status": "invalid"}},
+    )
+    workflow.redo()
+    assert controller.workflow_state == {"analysis": {"status": "invalid"}}
+    workflow.undo()
+    assert controller.workflow_state == {"analysis": {"status": "valid"}}
+
     roi = _roi()
     upsert_roi = UpsertROICommand(controller, before=None, after=roi)
     upsert_roi.redo()
@@ -455,6 +470,7 @@ def test_commands_never_retain_documents_legacy_states_or_spectrum_arrays():
         DeletePeakCommand(controller, peak=peak),
         UpdatePeakAssignmentCommand(controller, before=peak, after=peak),
         TogglePinnedNuclideCommand(controller, before=(), after=("Cs-137",)),
+        UpdateWorkflowStateCommand(controller, before={}, after={"invalid": True}),
         UpsertROICommand(controller, before=None, after=roi),
         DeleteROICommand(controller, roi=roi),
         MoveROIBoundsCommand(controller, before=roi, after=roi, drag_token="drag-1"),


### PR DESCRIPTION
## Summary
- add renderer-independent canvas intents and focused undo for ROI, sideband, peak, assignment, tagging, overlap, role, and viewport edits
- synchronize stable spectrum/ROI/peak IDs between the modern table and PyQtGraph canvas
- invalidate stale diagnostics after scientific edits and persist canonical WorkspaceDocument v2 state
- add native Qt interaction tests, action-catalog coverage, user documentation, and evidence-ledger updates

## Validation
- Windows offscreen focused interaction/state/session slice: 68 passed
- Windows native Qt direct/integration slice: 15 passed
- Windows production shell: 9 passed; modern shell: 23 passed
- Linux X11 native direct/integration slice: 15 passed
- Linux offscreen focused interaction/state/session slice: 68 passed
- project tracker + production copy/action gates: 15 passed
- independent audit: 42 focused tests, no branch-level blockers

Wayland initialization was unavailable in the WSLg environment and remains explicitly tracked as a release-level qualification gate.